### PR TITLE
Feature - Add `class` option support to container PHP dumper

### DIFF
--- a/docs/upgrade/Upgrade_1.7_to_2.0.md
+++ b/docs/upgrade/Upgrade_1.7_to_2.0.md
@@ -37,6 +37,11 @@ composer require rock-symphony/rock-symphony:2.0-alpha+1
    If your project is using/extending them, please make sure you adapt your code
    accordingly.
 
+5. *service.yml* stock config handler options have been changed:
+   instead of *class* and *base_class* it has:
+   
+   - `class` the service container class to be instantiated.
+
 ## sfCoreAutoload dropped
 
 *sfCoreAutoload* auto-loading functionality has been dropped. 

--- a/lib/config/config/config_handlers.yml
+++ b/lib/config/config/config_handlers.yml
@@ -29,7 +29,7 @@ config/routing.yml:
 config/services.yml:
   class:    sfServiceConfigHandler
   param:
-    base_class: sfServiceContainer
+    class: sfServiceContainer
 
 modules/*/config/generator.yml:
   class:    sfGeneratorConfigHandler

--- a/lib/config/sfServiceConfigHandler.class.php
+++ b/lib/config/sfServiceConfigHandler.class.php
@@ -27,13 +27,13 @@ class sfServiceConfigHandler extends sfYamlConfigHandler
    */
   public function execute($configFiles)
   {
-    $class = sfConfig::get('sf_app').'_'.sfConfig::get('sf_environment').'ServiceContainer';
-
     $parser = new sfServiceContainerConfigParser();
     $builder = $parser->parse(static::getConfiguration($configFiles));
 
     $dumper = new sfServiceContainerDumperPhp();
-    $code = $dumper->dump($builder);
+    $code = $dumper->dump($builder, [
+      'class' => $this->parameterHolder->get('class'),
+    ]);
 
     // compile data
     $retval = sprintf(

--- a/lib/service/config/sfServiceContainerDumperPhp.class.php
+++ b/lib/service/config/sfServiceContainerDumperPhp.class.php
@@ -196,7 +196,7 @@ class sfServiceContainerDumperPhp implements sfServiceContainerDumperInterface
 
     $template = <<<EOF
 /**
- * @return \sfServiceContainer
+ * @return \sfServiceContainerInterface
  */
 return function() {
   \$container = new %s();
@@ -219,7 +219,7 @@ EOF;
     $code = rtrim($code);
 
     $template = <<<EOL
-  \$container->bindResolver(%s, function(\sfServiceContainer \$container) {
+  \$container->bindResolver(%s, function(\sfServiceContainerInterface \$container) {
     %s
   });
 
@@ -238,7 +238,7 @@ EOL;
     $code = rtrim($code);
 
     $template = <<<EOL
-  \$container->bindSingletonResolver(%s, function(\sfServiceContainer \$container) {
+  \$container->bindSingletonResolver(%s, function(\sfServiceContainerInterface \$container) {
     %s
   });
 

--- a/lib/service/config/sfServiceContainerDumperPhp.class.php
+++ b/lib/service/config/sfServiceContainerDumperPhp.class.php
@@ -28,12 +28,17 @@ class sfServiceContainerDumperPhp implements sfServiceContainerDumperInterface
    */
   public function dump(sfServiceContainerBuilder $builder, array $options = array())
   {
-    if ($options !== []) {
-      throw new InvalidArgumentException('Unsupported options given: ' . implode(', ', array_keys($options)));
+    $unsupported_options = array_diff(array_keys($options), ['class']);
+
+    if (count($unsupported_options) > 0) {
+      throw new InvalidArgumentException('Unsupported options given: ' . implode(', ', $unsupported_options));
     }
+
+    $class = isset($options['class']) ? $options['class'] : '\sfServiceContainer';
 
     return
       $this->createClosureFunction(
+        $class,
         $this->addServices($builder)
       );
   }
@@ -181,10 +186,11 @@ class sfServiceContainerDumperPhp implements sfServiceContainerDumperInterface
   }
 
   /**
+   * @param string $class
    * @param string $body
    * @return string
    */
-  protected function createClosureFunction($body)
+  protected function createClosureFunction($class, $body)
   {
     $body = rtrim($body);
 
@@ -193,14 +199,14 @@ class sfServiceContainerDumperPhp implements sfServiceContainerDumperInterface
  * @return \sfServiceContainer
  */
 return function() {
-  \$container = new \sfServiceContainer();
+  \$container = new %s();
 %s
   return \$container;
 };
 
 EOF;
 
-    return sprintf($template, $body ? "{$body}\n" : '');
+    return sprintf($template, $class, $body ? "{$body}\n" : '');
   }
 
   /**

--- a/lib/util/sfContext.class.php
+++ b/lib/util/sfContext.class.php
@@ -463,11 +463,11 @@ class sfContext implements ArrayAccess
       /** @var \sfServiceContainerInterface $serviceContainer */
       $this->factories['serviceContainer'] = $serviceContainer = call_user_func($this->serviceContainerResolver);
 
-      if (! $serviceContainer instanceof sfServiceContainer) {
-        $given_type = is_object($serviceContainer) ? get_class($serviceContainer) : gettype($serviceContainer);
-        throw new RuntimeException(
-          "Service container resolver is expected to return an instance of sfServiceContainer. $given_type given."
-        );
+      if (! $serviceContainer instanceof sfServiceContainerInterface) {
+        throw new RuntimeException(sprintf(
+          "Service container resolver is expected to return an instance of sfServiceContainerInterface. %s given.",
+          is_object($serviceContainer) ? get_class($serviceContainer) : gettype($serviceContainer)
+        ));
       }
 
       $serviceContainer->set('sf_event_dispatcher', $this->configuration->getEventDispatcher());

--- a/test/unit/service/fixtures/php/services1-1.php
+++ b/test/unit/service/fixtures/php/services1-1.php
@@ -1,4 +1,8 @@
-class Container extends AbstractContainer
-{
+/**
+ * @return \sfServiceContainerInterface
+ */
+return function() {
+  $container = new CustomContainer();
 
-}
+  return $container;
+};

--- a/test/unit/service/fixtures/php/services1.php
+++ b/test/unit/service/fixtures/php/services1.php
@@ -1,5 +1,5 @@
 /**
- * @return \sfServiceContainer
+ * @return \sfServiceContainerInterface
  */
 return function() {
   $container = new \sfServiceContainer();

--- a/test/unit/service/fixtures/php/services9.php
+++ b/test/unit/service/fixtures/php/services9.php
@@ -1,11 +1,11 @@
 /**
- * @return \sfServiceContainer
+ * @return \sfServiceContainerInterface
  */
 return function() {
   $container = new \sfServiceContainer();
 
   // foo
-  $container->bindResolver('foo', function(\sfServiceContainer $container) {
+  $container->bindResolver('foo', function(\sfServiceContainerInterface $container) {
     require_once '%path%/foo.php';
 
     $instance = $container->call(array('FooClass', 'getInstance'), array(0 => 'foo', 1 => $this->get('foo.baz'), 2 => array('%foo%' => 'foo is %foo%'), 3 => true, 4 => $this));
@@ -16,21 +16,21 @@ return function() {
   });
 
   // bar
-  $container->bindSingletonResolver('bar', function(\sfServiceContainer $container) {
+  $container->bindSingletonResolver('bar', function(\sfServiceContainerInterface $container) {
     $instance = $container->construct('FooClass', array(0 => 'foo', 1 => $this->get('foo.baz'), 2 => sfConfig::get('foo_bar')));
     $this->get('@foo.baz')->configure($instance);
     return $instance;
   });
 
   // foo.baz
-  $container->bindSingletonResolver('foo.baz', function(\sfServiceContainer $container) {
+  $container->bindSingletonResolver('foo.baz', function(\sfServiceContainerInterface $container) {
     $instance = $container->call(array('%baz_class%', 'getInstance'), array());
     $container->call(array(0 => '%baz_class%', 1 => 'configureStatic1'), array($instance));
     return $instance;
   });
 
   // foo_bar
-  $container->bindSingletonResolver('foo_bar', function(\sfServiceContainer $container) {
+  $container->bindSingletonResolver('foo_bar', function(\sfServiceContainerInterface $container) {
     $instance = $container->construct('FooClass', array());
     return $instance;
   });

--- a/test/unit/service/sfServiceContainerDumperPhpTest.php
+++ b/test/unit/service/sfServiceContainerDumperPhpTest.php
@@ -10,7 +10,7 @@
 
 require_once(__DIR__.'/../../bootstrap/unit.php');
 
-$t = new lime_test(3);
+$t = new lime_test(4);
 
 // ->dump()
 $t->diag('->dump()');
@@ -18,6 +18,7 @@ $builder = new sfServiceContainerBuilder();
 $dumper = new sfServiceContainerDumperPhp();
 
 $t->is($dumper->dump($builder), file_get_contents(__DIR__.'/fixtures/php/services1.php'), '->dump() dumps an empty container as an empty closure function');
+$t->is($dumper->dump($builder, ['class' => 'CustomContainer']), file_get_contents(__DIR__ . '/fixtures/php/services1-1.php'), '->dump() takes a class option');
 
 // ->addService()
 $t->diag('->addService()');


### PR DESCRIPTION
You can now specify `class` option to override container class the dumper will instantiate.

```php
echo $dumper->dump($builder, ['class' => 'CustomContainer']);
```

```php
/**
 * @return \sfServiceContainerInterface
 */
return function() {
  $container = new CustomContainer();

  return $container;
};

```