### PR TITLE
Add support for "alias" option @ service definition

### DIFF
--- a/test/unit/service/fixtures/yaml/nonvalid5-1.yml
+++ b/test/unit/service/fixtures/yaml/nonvalid5-1.yml
@@ -1,0 +1,8 @@
+services:
+  hello:
+    class: HelloWorld
+    alias: greeting
+
+  hi:
+    class: SayHi
+    alias: hello # should fail because of "hello" already existing

--- a/test/unit/service/fixtures/yaml/nonvalid5-2.yml
+++ b/test/unit/service/fixtures/yaml/nonvalid5-2.yml
@@ -1,0 +1,8 @@
+services:
+  hello:
+    class: HelloWorld
+    alias: greeting
+
+  hi:
+    class: SayHi
+    alias: greeting # should fail because of duplicated alias

--- a/test/unit/service/fixtures/yaml/services2.yml
+++ b/test/unit/service/fixtures/yaml/services2.yml
@@ -1,6 +1,6 @@
 services:
-  foo: { class: FooClass }
-  baz: { class: BazClass }
+  foo: { class: FooClass, alias: foo__alias } # string alias
+  baz: { class: BazClass, alias: [ baz__alias1, baz__alias2 ] } # array of aliases
   shared: { class: FooClass, shared: true }
   non_shared: { class: FooClass, shared: false }
   constructor: { class: FooClass, constructor: getInstance }

--- a/test/unit/service/sfServiceContainerConfigParserTest.php
+++ b/test/unit/service/sfServiceContainerConfigParserTest.php
@@ -10,7 +10,7 @@
 
 require_once(__DIR__.'/../../bootstrap/unit.php');
 
-$t = new lime_test(21);
+$t = new lime_test(26);
 
 $parser = new sfServiceContainerConfigParser();
 
@@ -73,11 +73,17 @@ $t->is($builder->getServiceDefinition('method_call2')->getMethodCalls(), array(a
 $t->ok($builder->hasAlias('alias_for_foo'), '->parse parses aliases');
 $t->is($builder->getAlias('alias_for_foo'), 'foo', '->parse parses aliases');
 
+$t->is($builder->getAlias('foo__alias'), 'foo', '->parse parses "alias" option (string)');
+$t->is($builder->getAlias('baz__alias1'), 'baz', '->parse parses "alias" option (array)');
+$t->is($builder->getAlias('baz__alias2'), 'baz', '->parse parses "alias" option (array)');
+
 $t->diag('->parse # validation');
 foreach ([
            __DIR__ . '/fixtures/yaml/nonvalid4-1.yml',
            __DIR__ . '/fixtures/yaml/nonvalid4-2.yml',
            __DIR__ . '/fixtures/yaml/nonvalid4-3.yml',
+           __DIR__ . '/fixtures/yaml/nonvalid5-1.yml',
+           __DIR__ . '/fixtures/yaml/nonvalid5-2.yml',
          ] as $file) {
   try {
     $builder = $parser->parse(sfYaml::load($file));


### PR DESCRIPTION
- Allow to define service aliases using `alias` option.
  No more than just syntax sugar for `alias: @service` to keep a service definition together with its aliases.

  ```yml
  my_service:
     class: MyService
     alias: [my, MyService]
  ```
  
  ```php
  $container->get('my_service')
  // same as
  $container->get('my')
  // same as 
  $container->get('MyService')
  // same as
  $container->get(MyService::class) // PHP 5.5 and higher
  ```

- Tests