### PR TITLE
Refactor - Disconnect plugins tests

### DIFF
--- a/docs/upgrade/Upgrade_4.0_to_5.0.md
+++ b/docs/upgrade/Upgrade_4.0_to_5.0.md
@@ -8,3 +8,7 @@ Upgrade guide 3.0 to 4.0
    See the complete list in the Pull Request description: 
    [#17](https://github.com/rock-symphony/rock-symphony/pull/17).
    
+2. Make sure your project plugins don't rely on symfony's testing commands.
+   See the complete list of dropped stuff in 
+   [#17](https://github.com/rock-symphony/rock-symphony/pull/18).
+

--- a/lib/config/sfPluginConfiguration.class.php
+++ b/lib/config/sfPluginConfiguration.class.php
@@ -160,56 +160,6 @@ abstract class sfPluginConfiguration
   }
 
   /**
-   * Connects the current plugin's tests to the "test:*" tasks.
-   */
-  public function connectTests()
-  {
-    $this->dispatcher->connect('task.test.filter_test_files', array($this, 'filterTestFiles'));
-  }
-
-  /**
-   * Listens for the "task.test.filter_test_files" event and adds tests from the current plugin.
-   *
-   * @param  sfEvent $event
-   * @param  array   $files
-   *
-   * @return array An array of files with the appropriate tests from the current plugin merged in
-   */
-  public function filterTestFiles(sfEvent $event, $files)
-  {
-    $task = $event->getSubject();
-
-    if ($task instanceof sfTestAllTask)
-    {
-      $directory = $this->rootDir.'/test';
-      $names = array();
-    }
-    else if ($task instanceof sfTestFunctionalTask)
-    {
-      $directory = $this->rootDir.'/test/functional';
-      $names = $event['arguments']['controller'];
-    }
-    else if ($task instanceof sfTestUnitTask)
-    {
-      $directory = $this->rootDir.'/test/unit';
-      $names = $event['arguments']['name'];
-    }
-
-    if (!count($names))
-    {
-      $names = array('*');
-    }
-
-    foreach ($names as $name)
-    {
-      $finder = sfFinder::type('file')->follow_link()->name(basename($name).'Test.php');
-      $files = array_merge($files, $finder->in($directory.'/'.dirname($name)));
-    }
-
-    return array_unique($files);
-  }
-
-  /**
    * Guesses the plugin root directory.
    *
    * @return string

--- a/lib/task/test/sfTestAllTask.class.php
+++ b/lib/task/test/sfTestAllTask.class.php
@@ -107,7 +107,7 @@ EOF;
     {
       // filter and register all tests
       $finder = sfFinder::type('file')->follow_link()->name('*Test.php');
-      $h->register($this->filterTestFiles($finder->in($h->base_dir), $arguments, $options));
+      $h->register($finder->in($h->base_dir));
     }
 
     $ret = $h->run() ? 0 : 1;

--- a/lib/task/test/sfTestBaseTask.class.php
+++ b/lib/task/test/sfTestBaseTask.class.php
@@ -19,24 +19,6 @@
 abstract class sfTestBaseTask extends sfBaseTask
 {
   /**
-   * Filters tests through the "task.test.filter_test_files" event.
-   *
-   * @param  array $tests     An array of absolute test file paths
-   * @param  array $arguments Current task arguments
-   * @param  array $options   Current task options
-   *
-   * @return array The filtered array of test files
-   */
-  protected function filterTestFiles($tests, $arguments, $options)
-  {
-    $event = new sfEvent($this, 'task.test.filter_test_files', array('arguments' => $arguments, 'options' => $options));
-
-    $this->dispatcher->filter($event, $tests);
-
-    return $event->getReturnValue();
-  }
-
-  /**
    * Checks if a plugin exists.
    *
    * The plugin directory must exist and have at least one file or folder

--- a/lib/task/test/sfTestFunctionalTask.class.php
+++ b/lib/task/test/sfTestFunctionalTask.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -82,7 +82,7 @@ EOF;
         $files = array_merge($files, $finder->in(sfConfig::get('sf_test_dir').'/functional/'.$app.'/'.dirname($controller)));
       }
 
-      if($allFiles = $this->filterTestFiles($files, $arguments, $options))
+      if($allFiles = $files)
       {
         foreach ($allFiles as $file)
         {
@@ -107,7 +107,7 @@ EOF;
 
       // filter and register functional tests
       $finder = sfFinder::type('file')->follow_link()->name('*Test.php');
-      $h->register($this->filterTestFiles($finder->in($h->base_dir), $arguments, $options));
+      $h->register($finder->in($h->base_dir));
 
       $ret = $h->run() ? 0 : 1;
 

--- a/lib/task/test/sfTestFunctionalTask.class.php
+++ b/lib/task/test/sfTestFunctionalTask.class.php
@@ -82,9 +82,9 @@ EOF;
         $files = array_merge($files, $finder->in(sfConfig::get('sf_test_dir').'/functional/'.$app.'/'.dirname($controller)));
       }
 
-      if($allFiles = $files)
+      if(count($files) > 0)
       {
-        foreach ($allFiles as $file)
+        foreach ($files as $file)
         {
           include($file);
         }

--- a/lib/task/test/sfTestUnitTask.class.php
+++ b/lib/task/test/sfTestUnitTask.class.php
@@ -77,9 +77,9 @@ EOF;
         $files = array_merge($files, $finder->in(sfConfig::get('sf_test_dir').'/unit/'.dirname($name)));
       }
 
-      if($allFiles = $files)
+      if(count($files) > 0)
       {
-        foreach ($allFiles as $file)
+        foreach ($files as $file)
         {
           include($file);
         }

--- a/lib/task/test/sfTestUnitTask.class.php
+++ b/lib/task/test/sfTestUnitTask.class.php
@@ -77,7 +77,7 @@ EOF;
         $files = array_merge($files, $finder->in(sfConfig::get('sf_test_dir').'/unit/'.dirname($name)));
       }
 
-      if($allFiles = $this->filterTestFiles($files, $arguments, $options))
+      if($allFiles = $files)
       {
         foreach ($allFiles as $file)
         {
@@ -103,7 +103,7 @@ EOF;
 
       // filter and register unit tests
       $finder = sfFinder::type('file')->follow_link()->name('*Test.php');
-      $h->register($this->filterTestFiles($finder->in($h->base_dir), $arguments, $options));
+      $h->register($finder->in($h->base_dir));
 
       $ret = $h->run() ? 0 : 1;
 

--- a/test/unit/config/sfPluginConfigurationTest.php
+++ b/test/unit/config/sfPluginConfigurationTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -15,7 +15,7 @@ $pluginRoot = realpath($rootDir.'/plugins/sfAutoloadPlugin');
 
 require_once $pluginRoot.'/config/sfAutoloadPluginConfiguration.class.php';
 
-$t = new lime_test(9);
+$t = new lime_test(2);
 
 class ProjectConfiguration extends sfProjectConfiguration
 {
@@ -33,44 +33,3 @@ $pluginConfig = new sfAutoloadPluginConfiguration($configuration);
 
 $t->is($pluginConfig->getRootDir(), $pluginRoot, '->guessRootDir() guesses plugin root directory');
 $t->is($pluginConfig->getName(), 'sfAutoloadPlugin', '->guessName() guesses plugin name');
-
-// ->filterTestFiles()
-$t->diag('->filterTestFiles()');
-
-// test:all
-$task = new sfTestAllTask($configuration->getEventDispatcher(), new sfFormatter());
-$event = new sfEvent($task, 'task.test.filter_test_files', array('arguments' => array(), 'options' => array()));
-$files = $pluginConfig->filterTestFiles($event, array());
-$t->is(count($files), 6, '->filterTestFiles() adds all plugin tests');
-
-// test:functional
-$task = new sfTestFunctionalTask($configuration->getEventDispatcher(), new sfFormatter());
-$event = new sfEvent($task, 'task.test.filter_test_files', array('arguments' => array('controller' => array()), 'options' => array()));
-$files = $pluginConfig->filterTestFiles($event, array());
-$t->is(count($files), 3, '->filterTestFiles() adds functional plugin tests');
-
-$task = new sfTestFunctionalTask($configuration->getEventDispatcher(), new sfFormatter());
-$event = new sfEvent($task, 'task.test.filter_test_files', array('arguments' => array('controller' => array('BarFunctional')), 'options' => array()));
-$files = $pluginConfig->filterTestFiles($event, array());
-$t->is(count($files), 1, '->filterTestFiles() adds functional plugin tests when a controller is specified');
-
-$task = new sfTestFunctionalTask($configuration->getEventDispatcher(), new sfFormatter());
-$event = new sfEvent($task, 'task.test.filter_test_files', array('arguments' => array('controller' => array('nested/NestedFunctional')), 'options' => array()));
-$files = $pluginConfig->filterTestFiles($event, array());
-$t->is(count($files), 1, '->filterTestFiles() adds functional plugin tests when a nested controller is specified');
-
-// test:unit
-$task = new sfTestUnitTask($configuration->getEventDispatcher(), new sfFormatter());
-$event = new sfEvent($task, 'task.test.filter_test_files', array('arguments' => array('name' => array()), 'options' => array()));
-$files = $pluginConfig->filterTestFiles($event, array());
-$t->is(count($files), 3, '->filterTestFiles() adds unit plugin tests');
-
-$task = new sfTestUnitTask($configuration->getEventDispatcher(), new sfFormatter());
-$event = new sfEvent($task, 'task.test.filter_test_files', array('arguments' => array('name' => array('FooUnit')), 'options' => array()));
-$files = $pluginConfig->filterTestFiles($event, array());
-$t->is(count($files), 1, '->filterTestFiles() adds unit plugin tests when a name is specified');
-
-$task = new sfTestUnitTask($configuration->getEventDispatcher(), new sfFormatter());
-$event = new sfEvent($task, 'task.test.filter_test_files', array('arguments' => array('name' => array('nested/NestedUnit')), 'options' => array()));
-$files = $pluginConfig->filterTestFiles($event, array());
-$t->is(count($files), 1, '->filterTestFiles() adds unit plugin tests when a nested name is specified');


### PR DESCRIPTION
Disconnect plugins tests from project `test:*` CLI commands. 

Plugins packages should be responsible for their tests themselves (at development stage). 

- When a 3rd party plugin is linked to a project it should be tested already. So no tests linking needed.
- If you have your own in-project plugin you want to maintain tests for, please make sure the tests are executed. You can do that by manually listing the tests PHP files or migrate your plugin tests to [PHPUnit](https://github.com/sebastianbergmann/phpunit).

**BC Break**

- Dropped methods:
   - `sfPluginConfiguration::connectTests()`
   - `sfPluginConfiguration::filterTestFiles()`
   - `sfTestBaseTask::filterTestFiles()`
- Other:
   - Dropped `task.test.filter_test_files` event: it's never triggered now