### PR TITLE
Refactor - Drop compression support

### DIFF
--- a/lib/config/config/settings.yml
+++ b/lib/config/config/settings.yml
@@ -16,7 +16,6 @@ default:
     # Optional features. Deactivating unused features boots performance a bit.
     use_database:           true        # Enable database manager. Set to false if you don't use a database.
     i18n:                   false       # Enable interface translation. Set to false if your application should not be translated.
-    compressed:             false       # Enable PHP response compression. Set to true to compress the outgoing HTML via the PHP handler.
     check_lock:             false       # Enable the application lock system triggered by the clear-cache and disable tasks. Set to true to have all requests to disabled applications redirected to the sfConfig::get('sf_symfony_lib_dir')/exception/data/unavailable.php page.
 
     # Form security secret (CSRF protection)

--- a/lib/config/sfApplicationConfiguration.class.php
+++ b/lib/config/sfApplicationConfiguration.class.php
@@ -152,12 +152,6 @@ abstract class sfApplicationConfiguration extends ProjectConfiguration
     // initialize plugin configuration objects
     $this->initializePlugins();
 
-    // compress output
-    if (!self::$coreLoaded && sfConfig::get('sf_compressed'))
-    {
-      ob_start('ob_gzhandler');
-    }
-
     self::$coreLoaded = true;
   }
 

--- a/lib/debug/sfWebDebugPanelConfig.class.php
+++ b/lib/debug/sfWebDebugPanelConfig.class.php
@@ -37,7 +37,6 @@ class sfWebDebugPanelConfig extends sfWebDebugPanel
       'xdebug'       => extension_loaded('xdebug')          ? 'on' : 'off',
       'logging'      => sfConfig::get('sf_logging_enabled') ? 'on' : 'off',
       'cache'        => sfConfig::get('sf_cache')           ? 'on' : 'off',
-      'compression'  => sfConfig::get('sf_compressed')      ? 'on' : 'off',
       'tokenizer'    => function_exists('token_get_all')    ? 'on' : 'off',
       'eaccelerator' => extension_loaded('eaccelerator') && ini_get('eaccelerator.enable') ? 'on' : 'off',
       'apc'          => extension_loaded('apc') && ini_get('apc.enabled')                  ? 'on' : 'off',

--- a/lib/exception/sfException.class.php
+++ b/lib/exception/sfException.class.php
@@ -103,10 +103,6 @@ class sfException extends Exception
         }
       }
 
-      if (sfConfig::get('sf_compressed')) {
-        ob_start('ob_gzhandler');
-      }
-
       header('HTTP/1.0 500 Internal Server Error');
     }
 


### PR DESCRIPTION
Drop in-framework response compression.

Compression should be done on the web-server side instead.