### PR TITLE
Fix - PHP 7.3 setting `session.gc_maxlifetime` in runtime

### DIFF
--- a/lib/config/config/factories.yml
+++ b/lib/config/config/factories.yml
@@ -29,7 +29,7 @@ default:
   user:
     class: myUser
     param:
-      timeout:         1800
+      timeout:         false
       logging:         '%SF_LOGGING_ENABLED%'
       use_flash:       true
       default_culture: '%SF_DEFAULT_CULTURE%'

--- a/lib/user/sfBasicSecurityUser.class.php
+++ b/lib/user/sfBasicSecurityUser.class.php
@@ -248,7 +248,7 @@ class sfBasicSecurityUser extends sfUser implements sfSecurityUser
 
     if (!array_key_exists('timeout', $this->options))
     {
-      $this->options['timeout'] = 1800;
+      $this->options['timeout'] = false;
     }
 
     // force the max lifetime for session garbage collector to be greater than timeout

--- a/lib/user/sfBasicSecurityUser.class.php
+++ b/lib/user/sfBasicSecurityUser.class.php
@@ -4,7 +4,7 @@
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
  * (c) 2004-2006 Sean Kerr <sean@code-box.org>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -42,7 +42,7 @@ class sfBasicSecurityUser extends sfUser implements sfSecurityUser
 
   /**
    * Returns the current user's credentials.
-   * 
+   *
    * @return array
    */
   public function getCredentials()
@@ -254,7 +254,9 @@ class sfBasicSecurityUser extends sfUser implements sfSecurityUser
     // force the max lifetime for session garbage collector to be greater than timeout
     if (ini_get('session.gc_maxlifetime') < $this->options['timeout'])
     {
-      ini_set('session.gc_maxlifetime', $this->options['timeout']);
+      throw new LogicException(
+        '`timeout` option is greater than the configured `session.gc_maxlifetime` php.ini setting. This will not work. Please align them to resolve the conflict.'
+      );
     }
 
     // read data from storage


### PR DESCRIPTION
Setting `session.gc_maxlifetime` in runtime throws an error in PHP 7.3