### PR TITLE
Refactor - Immutable sfCache

### DIFF
--- a/lib/cache/sfAPCuCache.class.php
+++ b/lib/cache/sfAPCuCache.class.php
@@ -20,8 +20,6 @@ class sfAPCuCache extends sfCache
   protected $enabled;
 
   /**
-   * Initializes this sfCache instance.
-   *
    * Available options:
    *
    * * see sfCache for options available for all drivers
@@ -29,9 +27,9 @@ class sfAPCuCache extends sfCache
    * @see sfCache
    * @inheritdoc
    */
-  public function initialize(array $options = array()): void
+  public function __construct(array $options = [])
   {
-    parent::initialize($options);
+    parent::__construct($options);
 
     $this->enabled = function_exists('apcu_store') && ini_get('apc.enabled');
   }

--- a/lib/cache/sfCache.class.php
+++ b/lib/cache/sfCache.class.php
@@ -28,18 +28,6 @@ abstract class sfCache
   /**
    * Class constructor.
    *
-   * @see initialize()
-   *
-   * @param array $options
-   */
-  public function __construct(array $options = [])
-  {
-    $this->initialize($options);
-  }
-
-  /**
-   * Initializes this sfCache instance.
-   *
    * @param array $options An array of options.
    *
    * Available options:
@@ -52,9 +40,9 @@ abstract class sfCache
    *
    * * lifetime (optional): The default life time (default value: 86400)
    *
-   * @throws <b>sfInitializationException</b> If an error occurs while initializing this sfCache instance.
+   * @throws sfInitializationException If an error occurs while initializing this sfCache instance.
    */
-  public function initialize(array $options = []): void
+  public function __construct(array $options = [])
   {
     $this->options = array_merge(array(
       'automatic_cleaning_factor' => 1000,

--- a/lib/cache/sfCache.class.php
+++ b/lib/cache/sfCache.class.php
@@ -187,6 +187,19 @@ abstract class sfCache
   }
 
   /**
+   * Sets an option value.
+   *
+   * @param string $name  The option name
+   * @param mixed  $value The option value
+   *
+   * @return mixed
+   */
+  public function setOption(string $name, $value): void
+  {
+    $this->options[$name] = $value;
+  }
+
+  /**
    * Converts a pattern to a regular expression.
    *
    * A pattern can use some special characters:

--- a/lib/cache/sfCache.class.php
+++ b/lib/cache/sfCache.class.php
@@ -187,19 +187,6 @@ abstract class sfCache
   }
 
   /**
-   * Sets an option value.
-   *
-   * @param string $name  The option name
-   * @param mixed  $value The option value
-   *
-   * @return mixed
-   */
-  public function setOption(string $name, $value): void
-  {
-    $this->options[$name] = $value;
-  }
-
-  /**
    * Converts a pattern to a regular expression.
    *
    * A pattern can use some special characters:

--- a/lib/cache/sfFileCache.class.php
+++ b/lib/cache/sfFileCache.class.php
@@ -25,8 +25,6 @@ class sfFileCache extends sfCache
   const EXTENSION = '.cache';
 
   /**
-   * Initializes this sfCache instance.
-   *
    * Available options:
    *
    * * cache_dir: The directory where to put cache files
@@ -36,9 +34,9 @@ class sfFileCache extends sfCache
    * @see sfCache
    * @inheritdoc
    */
-  public function initialize(array $options = array()): void
+  public function __construct(array $options = [])
   {
-    parent::initialize($options);
+    parent::__construct($options);
 
     if (!$this->getOption('cache_dir'))
     {

--- a/lib/cache/sfMemcacheCache.class.php
+++ b/lib/cache/sfMemcacheCache.class.php
@@ -39,14 +39,14 @@ class sfMemcacheCache extends sfCache
    * @see sfCache
    * @inheritdoc
    */
-  public function initialize(array $options = array()): void
+  public function __construct(array $options = [])
   {
-    parent::initialize($options);
-
     if (!class_exists('Memcache'))
     {
       throw new sfInitializationException('You must have memcache installed and enabled to use sfMemcacheCache class.');
     }
+
+    parent::__construct($options);
 
     if ($this->getOption('memcache'))
     {

--- a/lib/cache/sfSQLiteCache.class.php
+++ b/lib/cache/sfSQLiteCache.class.php
@@ -28,8 +28,6 @@ class sfSQLiteCache extends sfCache
   protected $database = '';
 
   /**
-   * Initializes this sfCache instance.
-   *
    * Available options:
    *
    * * database: File where to put the cache database (or :memory: to store cache in memory)
@@ -39,14 +37,14 @@ class sfSQLiteCache extends sfCache
    * @see sfCache
    * @inheritdoc
    */
-  public function initialize(array $options = array()): void
+  public function __construct(array $options = [])
   {
     if (!extension_loaded('SQLite') && !extension_loaded('pdo_SQLite'))
     {
       throw new sfConfigurationException('sfSQLiteCache class needs "sqlite" or "pdo_sqlite" extension to be loaded.');
     }
 
-    parent::initialize($options);
+    parent::__construct($options);
 
     if (!$this->getOption('database'))
     {

--- a/lib/cache/sfXCacheCache.class.php
+++ b/lib/cache/sfXCacheCache.class.php
@@ -19,8 +19,6 @@
 class sfXCacheCache extends sfCache
 {
   /**
-   * Initializes this sfCache instance.
-   *
    * Available options:
    *
    * * see sfCache for options available for all drivers
@@ -28,10 +26,8 @@ class sfXCacheCache extends sfCache
    * @see sfCache
    * @inheritdoc
    */
-  public function initialize(array $options = array()): void
+  public function __construct(array $options = [])
   {
-    parent::initialize($options);
-
     if (!function_exists('xcache_set'))
     {
       throw new sfInitializationException('You must have XCache installed and enabled to use sfXCacheCache class.');
@@ -41,6 +37,7 @@ class sfXCacheCache extends sfCache
     {
       throw new sfInitializationException('You must set the "xcache.var_size" variable to a value greater than 0 to use sfXCacheCache class.');
     }
+    parent::__construct($options);
   }
 
  /**

--- a/test/unit/cache/sfAPCuCacheTest.php
+++ b/test/unit/cache/sfAPCuCacheTest.php
@@ -34,9 +34,6 @@ require_once(__DIR__.'/sfCacheDriverTests.class.php');
 // setup
 sfConfig::set('sf_logging_enabled', false);
 
-// ->initialize()
-$t->diag('->initialize()');
-
 $test = new class extends sfCacheDriverTests
 {
   public function createCache(array $options = []): sfCache

--- a/test/unit/cache/sfAPCuCacheTest.php
+++ b/test/unit/cache/sfAPCuCacheTest.php
@@ -37,6 +37,5 @@ sfConfig::set('sf_logging_enabled', false);
 // ->initialize()
 $t->diag('->initialize()');
 $cache = new sfAPCuCache();
-$cache->initialize();
 
 sfCacheDriverTests::launch($t, $cache);

--- a/test/unit/cache/sfAPCuCacheTest.php
+++ b/test/unit/cache/sfAPCuCacheTest.php
@@ -36,6 +36,13 @@ sfConfig::set('sf_logging_enabled', false);
 
 // ->initialize()
 $t->diag('->initialize()');
-$cache = new sfAPCuCache();
 
-sfCacheDriverTests::launch($t, $cache);
+$test = new class extends sfCacheDriverTests
+{
+  public function createCache(array $options = []): sfCache
+  {
+    return new sfAPCuCache($options);
+  }
+};
+
+$test->launch($t);

--- a/test/unit/cache/sfCacheDriverTests.class.php
+++ b/test/unit/cache/sfCacheDriverTests.class.php
@@ -7,10 +7,14 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-class sfCacheDriverTests
+abstract class sfCacheDriverTests
 {
-  static public function launch(lime_test $t, sfCache $cache)
+  public abstract function createCache(array $options = []): sfCache;
+
+  public function launch(lime_test $t)
   {
+    $cache = $this->createCache();
+
     // ->set() ->get() ->has()
     $t->diag('->set() ->get() ->has()');
     $data = 'some random data to store in the cache system... (\'"!#/é$£)';
@@ -68,12 +72,11 @@ class sfCacheDriverTests
     $t->is($cache->has('foo'), false, '->clean() cleans all cache key if given no argument');
     $t->is($cache->has('bar'), false, '->clean() cleans all cache key if given no argument');
 
-    $cache->clean();
-    $cache->setOption('automatic_cleaning_factor', 1);
+    $cache = $this->createCache(['automatic_cleaning_factor' => 1]);
     $cache->set('foo', $data);
     $cache->set('foo', $data);
     $cache->set('foo', $data);
-    $cache->setOption('automatic_cleaning_factor', 1000);
+    $cache = $this->createCache(['automatic_cleaning_factor' => 1000]);
 
     // ->remove()
     $t->diag('->remove()');

--- a/test/unit/cache/sfFileCacheTest.php
+++ b/test/unit/cache/sfFileCacheTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -31,9 +31,16 @@ catch (sfInitializationException $e)
   $t->pass('->initialize() throws an sfInitializationException exception if you don\'t pass a "cache_dir" parameter');
 }
 
-$cache = new sfFileCache(array('cache_dir' => $temp));
+$test = new class extends sfCacheDriverTests
+{
+  public function createCache(array $options = []): sfCache
+  {
+    global $temp;
+    return new sfFileCache(array_merge(['cache_dir' => $temp], $options));
+  }
+};
 
-sfCacheDriverTests::launch($t, $cache);
+$test->launch($t);
 
 // teardown
 sfToolkit::clearDirectory($temp);

--- a/test/unit/cache/sfFileCacheTest.php
+++ b/test/unit/cache/sfFileCacheTest.php
@@ -19,16 +19,14 @@ $temp = tempnam('/tmp/cache_dir', 'tmp');
 unlink($temp);
 mkdir($temp);
 
-// ->initialize()
-$t->diag('->initialize()');
 try
 {
   $cache = new sfFileCache();
-  $t->fail('->initialize() throws an sfInitializationException exception if you don\'t pass a "cache_dir" parameter');
+  $t->fail('->__construct() throws an sfInitializationException exception if you don\'t pass a "cache_dir" parameter');
 }
 catch (sfInitializationException $e)
 {
-  $t->pass('->initialize() throws an sfInitializationException exception if you don\'t pass a "cache_dir" parameter');
+  $t->pass('->__construct() throws an sfInitializationException exception if you don\'t pass a "cache_dir" parameter');
 }
 
 $test = new class extends sfCacheDriverTests

--- a/test/unit/cache/sfMemcacheCacheTest.php
+++ b/test/unit/cache/sfMemcacheCacheTest.php
@@ -36,7 +36,14 @@ catch (sfInitializationException $e)
   return;
 }
 
-sfCacheDriverTests::launch($t, $cache);
+$test = new class extends sfCacheDriverTests
+{
+  public function createCache(array $options = []): sfCache
+  {
+    return new sfMemcacheCache(array_merge(['storeCacheInfo' => true], $options));
+  }
+};
+$test->launch($t);
 
 // ->remove() test for ticket #6220
 $t->diag('->remove() test for ticket #6220');

--- a/test/unit/cache/sfMemcacheCacheTest.php
+++ b/test/unit/cache/sfMemcacheCacheTest.php
@@ -24,8 +24,6 @@ require_once(__DIR__.'/sfCacheDriverTests.class.php');
 // setup
 sfConfig::set('sf_logging_enabled', false);
 
-// ->initialize()
-$t->diag('->initialize()');
 try
 {
   $cache = new sfMemcacheCache(array('storeCacheInfo' => true));

--- a/test/unit/cache/sfNoCacheTest.php
+++ b/test/unit/cache/sfNoCacheTest.php
@@ -12,8 +12,6 @@ require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(8);
 
-// ->initialize()
-$t->diag('->initialize()');
 $cache = new sfNoCache();
 
 // ->get() ->set() ->has() ->remove() ->removePattern() ->clean() ->getLastModified() ->getTimeout()

--- a/test/unit/cache/sfSQLiteCacheTest.php
+++ b/test/unit/cache/sfSQLiteCacheTest.php
@@ -30,16 +30,14 @@ catch (sfInitializationException $e)
   return;
 }
 
-// ->initialize()
-$t->diag('->initialize()');
 try
 {
   $cache = new sfSQLiteCache();
-  $t->fail('->initialize() throws an sfInitializationException exception if you don\'t pass a "database" parameter');
+  $t->fail('->__construct() throws an sfInitializationException exception if you don\'t pass a "database" parameter');
 }
 catch (sfInitializationException $e)
 {
-  $t->pass('->initialize() throws an sfInitializationException exception if you don\'t pass a "database" parameter');
+  $t->pass('->__construct() throws an sfInitializationException exception if you don\'t pass a "database" parameter');
 }
 
 $test = new class extends sfCacheDriverTests

--- a/test/unit/cache/sfSQLiteCacheTest.php
+++ b/test/unit/cache/sfSQLiteCacheTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -14,7 +14,7 @@ require_once(__DIR__.'/sfCacheDriverTests.class.php');
 $plan = 129;
 $t = new lime_test($plan);
 
-if (!extension_loaded('SQLite') && !extension_loaded('pdo_SQLite')) 
+if (!extension_loaded('SQLite') && !extension_loaded('pdo_SQLite'))
 {
   $t->skip('SQLite extension not loaded, skipping tests', $plan);
   return;
@@ -42,14 +42,28 @@ catch (sfInitializationException $e)
   $t->pass('->initialize() throws an sfInitializationException exception if you don\'t pass a "database" parameter');
 }
 
-// database in memory
-$cache = new sfSQLiteCache(array('database' => ':memory:'));
+$test = new class extends sfCacheDriverTests
+{
+  public function createCache(array $options = []): sfCache
+  {
+    return new sfSQLiteCache(array_merge(['database' => ':memory:'], $options));
+  }
+};
+$test->launch($t);
 
-sfCacheDriverTests::launch($t, $cache);
 
 // database on disk
 $database = tempnam('/tmp/cachedir', 'tmp');
 unlink($database);
-$cache = new sfSQLiteCache(array('database' => $database));
-sfCacheDriverTests::launch($t, $cache);
+
+$test = new class extends sfCacheDriverTests
+{
+  public function createCache(array $options = []): sfCache
+  {
+    global $database;
+    return new sfSQLiteCache(array_merge(['database' => $database], $options));
+  }
+};
+$test->launch($t);
+
 unlink($database);

--- a/test/unit/cache/sfXCacheCacheTest.php
+++ b/test/unit/cache/sfXCacheCacheTest.php
@@ -30,6 +30,12 @@ sfConfig::set('sf_logging_enabled', false);
 
 // ->initialize()
 $t->diag('->initialize()');
-$cache = new sfXCacheCache();
 
-sfCacheDriverTests::launch($t, $cache);
+$test = new class extends sfCacheDriverTests
+{
+  public function createCache(array $options = []): sfCache
+  {
+    return new sfXCacheCache();
+  }
+};
+$test->launch($t);

--- a/test/unit/cache/sfXCacheCacheTest.php
+++ b/test/unit/cache/sfXCacheCacheTest.php
@@ -28,14 +28,11 @@ require_once(__DIR__.'/sfCacheDriverTests.class.php');
 // setup
 sfConfig::set('sf_logging_enabled', false);
 
-// ->initialize()
-$t->diag('->initialize()');
-
 $test = new class extends sfCacheDriverTests
 {
   public function createCache(array $options = []): sfCache
   {
-    return new sfXCacheCache();
+    return new sfXCacheCache($options);
   }
 };
 $test->launch($t);

--- a/test/unit/cache/sfXCacheCacheTest.php
+++ b/test/unit/cache/sfXCacheCacheTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -31,6 +31,5 @@ sfConfig::set('sf_logging_enabled', false);
 // ->initialize()
 $t->diag('->initialize()');
 $cache = new sfXCacheCache();
-$cache->initialize();
 
 sfCacheDriverTests::launch($t, $cache);


### PR DESCRIPTION
- `sfCache` implementations are now immutable. Once it's created -- it cannot be mutated.
   - drop `initialize()` method, merge their code into constructors
   - drop `setOption()` method, options are now immutable
- Update tests