### PR TITLE
Refactor - Immutable sfStorage

### DIFF
--- a/lib/controller/sfController.class.php
+++ b/lib/controller/sfController.class.php
@@ -38,12 +38,12 @@ abstract class sfController
   /**
    * Class constructor.
    *
-   * @see initialize()
    * @param sfContext $context A sfContext implementation instance
    */
   public function __construct(sfContext $context)
   {
-    $this->initialize($context);
+    $this->context    = $context;
+    $this->dispatcher = $context->getEventDispatcher();
   }
 
   /**
@@ -53,8 +53,7 @@ abstract class sfController
    */
   public function initialize(sfContext $context): void
   {
-    $this->context    = $context;
-    $this->dispatcher = $context->getEventDispatcher();
+
   }
 
   /**

--- a/lib/storage/sfDatabaseSessionStorage.class.php
+++ b/lib/storage/sfDatabaseSessionStorage.class.php
@@ -35,13 +35,12 @@ abstract class sfDatabaseSessionStorage extends sfSessionStorage
    *   * db_time_col: The database column in which the session timestamp will be stored (sess_time by default)
    *
    * @param  array $options An associative array of options
-   * @return bool|void
    *
    * @throws sfInitializationException
    *
    * @see sfSessionStorage
    */
-  public function initialize(array $options = array()): void
+  public function __construct(array $options = [])
   {
     $options = array_merge(array(
       'db_id_col'   => 'sess_id',
@@ -53,7 +52,7 @@ abstract class sfDatabaseSessionStorage extends sfSessionStorage
     $options['auto_start'] = false;
 
     // initialize the parent
-    parent::initialize($options);
+    parent::__construct($options);
 
     if (!isset($this->options['db_table']))
     {
@@ -66,12 +65,14 @@ abstract class sfDatabaseSessionStorage extends sfSessionStorage
     }
 
     // use this object as the session handler
-    session_set_save_handler(array($this, 'sessionOpen'),
-                             array($this, 'sessionClose'),
-                             array($this, 'sessionRead'),
-                             array($this, 'sessionWrite'),
-                             array($this, 'sessionDestroy'),
-                             array($this, 'sessionGC'));
+    session_set_save_handler(
+      [$this, 'sessionOpen'],
+      [$this, 'sessionClose'],
+      [$this, 'sessionRead'],
+      [$this, 'sessionWrite'],
+      [$this, 'sessionDestroy'],
+      [$this, 'sessionGC']
+    );
 
     // start our session
     session_start();

--- a/lib/storage/sfSessionStorage.class.php
+++ b/lib/storage/sfSessionStorage.class.php
@@ -45,14 +45,12 @@ class sfSessionStorage extends sfStorage
    * @param array $options An associative array of options
    *
    * @see sfStorage
-   *
-   * @return void
    */
-  public function initialize(array $options = []): void
+  public function __construct(array $options = [])
   {
     $cookieDefaults = session_get_cookie_params();
 
-    $options = array_merge(array(
+    $options = array_merge([
       'session_name'            => 'symfony',
       'session_id'              => null,
       'auto_start'              => true,
@@ -62,10 +60,10 @@ class sfSessionStorage extends sfStorage
       'session_cookie_secure'   => $cookieDefaults['secure'],
       'session_cookie_httponly' => isset($cookieDefaults['httponly']) ? $cookieDefaults['httponly'] : false,
       'session_cache_limiter'   => null,
-    ), $options);
+    ], $options);
 
     // initialize parent
-    parent::initialize($options);
+    parent::__construct($options);
 
     // set session name
     $sessionName = $this->options['session_name'];

--- a/lib/storage/sfSessionTestStorage.class.php
+++ b/lib/storage/sfSessionTestStorage.class.php
@@ -18,8 +18,10 @@
  */
 class sfSessionTestStorage extends sfStorage
 {
-  protected $sessionId   = null;
-  protected $sessionData = array();
+  /** @var string */
+  protected $sessionId;
+  /** @var array */
+  protected $sessionData = [];
 
   /**
    * Available options:
@@ -31,7 +33,7 @@ class sfSessionTestStorage extends sfStorage
    *
    * @see sfStorage
    */
-  public function initialize(array $options = []): void
+  public function __construct(array $options = [])
   {
     if (!isset($options['session_path']))
     {
@@ -43,7 +45,7 @@ class sfSessionTestStorage extends sfStorage
     ), $options);
 
     // initialize parent
-    parent::initialize($options);
+    parent::__construct($options);
 
     $this->sessionId = null !== $this->options['session_id'] ? $this->options['session_id'] : (array_key_exists('session_id', $_SERVER) ? $_SERVER['session_id'] : null);
 

--- a/lib/storage/sfStorage.class.php
+++ b/lib/storage/sfStorage.class.php
@@ -21,27 +21,10 @@
 abstract class sfStorage
 {
   /** @var array */
-  protected $options = array();
+  protected $options = [];
 
   /**
    * Class constructor.
-   *
-   * @see initialize()
-   *
-   * @param array $options
-   */
-  public function __construct($options = array())
-  {
-    $this->initialize($options);
-
-    if ($this->options['auto_shutdown'])
-    {
-      register_shutdown_function(array($this, 'shutdown'));
-    }
-  }
-
-  /**
-   * Initializes this Storage instance.
    *
    * Available options:
    *
@@ -49,15 +32,19 @@ abstract class sfStorage
    *
    * @param  array $options  An associative array of options
    *
-   * @return void
-   *
-   * @throws <b>sfInitializationException</b> If an error occurs while initializing this sfStorage
+   * @throws sfInitializationException If an error occurs while initializing this sfStorage
    */
-  public function initialize(array $options = array()): void
+  public function __construct($options = [])
   {
-    $this->options = array_merge(array(
-      'auto_shutdown' => true,
-    ), $options);
+    $this->options = array_merge(
+      ['auto_shutdown' => true],
+      $options
+    );
+
+    if ($this->options['auto_shutdown'])
+    {
+      register_shutdown_function(array($this, 'shutdown'));
+    }
   }
 
   /**

--- a/test/unit/user/sfBasicSecurityUserTest.php
+++ b/test/unit/user/sfBasicSecurityUserTest.php
@@ -10,7 +10,7 @@
 
 require_once(__DIR__.'/../../bootstrap/unit.php');
 
-$t = new lime_test(50);
+$t = new lime_test(49);
 
 class MySessionStorage extends sfSessionTestStorage
 {
@@ -25,10 +25,6 @@ $sessionPath = sys_get_temp_dir().'/sessions_'.rand(11111, 99999);
 $storage = new MySessionStorage(array('session_path' => $sessionPath));
 
 $user = new sfBasicSecurityUser($dispatcher, $storage);
-
-// ->initialize()
-$t->diag('->initialize()');
-$t->todo('->initialize() times out the user if no request made for a long time');
 
 // ->getCredentials()
 $t->diag('->getCredentials()');
@@ -159,10 +155,10 @@ $t->is($user->hasCredential('superadmin'), false);
 $user->setAuthenticated(true);
 $user->shutdown();
 $user = new sfBasicSecurityUser($dispatcher, $storage, array('timeout' => 0));
-$t->is($user->isTimedOut(), true, '->initialize() times out the user if no request made for a long time');
+$t->is($user->isTimedOut(), true, 'Session times out the user if no request made for a long time');
 
 $user = new sfBasicSecurityUser($dispatcher, $storage, array('timeout' => false));
-$t->is($user->isTimedOut(), false, '->initialize() takes a timeout parameter which can be false to disable session timeout');
+$t->is($user->isTimedOut(), false, '->__construct() takes a timeout parameter which can be false to disable session timeout');
 
 // session.gc_maxlifetime
 $user = new sfBasicSecurityUser($dispatcher, $storage, ['timeout' => ini_get('session.gc_maxlifetime') - 1]);


### PR DESCRIPTION
- Drop `initialize()` method from `sfStorage` implementations (BC break)
  Initialization is now done within the constructors.