### PR TITLE
Refactor - Immutable sfConfigHandler

### DIFF
--- a/lib/config/sfConfigHandler.class.php
+++ b/lib/config/sfConfigHandler.class.php
@@ -28,24 +28,9 @@ abstract class sfConfigHandler
   /**
    * Class constructor.
    *
-   * @see initialize()
    * @param array|null $parameters
    */
   public function __construct(array $parameters = null)
-  {
-    $this->initialize($parameters);
-  }
-
-  /**
-   * Initializes this configuration handler.
-   *
-   * @param array $parameters An associative array of initialization parameters
-   *
-   * @return void
-   *
-   * @throws <b>sfInitializationException</b> If an error occurs while initializing this ConfigHandler
-   */
-  public function initialize(array $parameters = null): void
   {
     $this->parameterHolder = new sfParameterHolder();
     $this->parameterHolder->add($parameters);

--- a/lib/config/sfRootConfigHandler.class.php
+++ b/lib/config/sfRootConfigHandler.class.php
@@ -26,6 +26,8 @@ class sfRootConfigHandler extends sfYamlConfigHandler
    *
    * @return string Data to be written to a cache file
    *
+   * @see sfConfigCache::loadConfigHandlers()
+   *
    * @throws sfConfigurationException If a requested configuration file does not exist or is not readable
    * @throws sfParseException If a requested configuration file is improperly formatted
    */

--- a/test/unit/config/sfCompileConfigHandlerTest.php
+++ b/test/unit/config/sfCompileConfigHandlerTest.php
@@ -13,7 +13,6 @@ require_once(__DIR__.'/../../bootstrap/unit.php');
 $t = new lime_test(2);
 
 $handler = new sfCompileConfigHandler();
-$handler->initialize();
 
 $dir = __DIR__.DIRECTORY_SEPARATOR.'fixtures'.DIRECTORY_SEPARATOR.'sfCompileConfigHandler'.DIRECTORY_SEPARATOR;
 

--- a/test/unit/config/sfConfigHandlerTest.php
+++ b/test/unit/config/sfConfigHandlerTest.php
@@ -14,14 +14,16 @@ $t = new lime_test(8);
 
 class myConfigHandler extends sfConfigHandler
 {
-  public function execute(array $configFiles): string {}
+  public function execute(array $configFiles): string {
+    return '';
+  }
 }
 
-$config = new myConfigHandler();
+$config = new myConfigHandler(['foo' => 'bar']);
 
-// ->initialize()
-$t->diag('->initialize()');
-$t->is($config->getParameterHolder()->get('foo'), 'bar', '->initialize() takes an array of parameters as its first argument');
+// ->__construct()
+$t->diag('->__construct()');
+$t->is($config->getParameterHolder()->get('foo'), 'bar', '->__construct() takes an array of parameters as its first argument');
 
 // ::replaceConstants()
 $t->diag('::replaceConstants()');

--- a/test/unit/config/sfConfigHandlerTest.php
+++ b/test/unit/config/sfConfigHandlerTest.php
@@ -18,11 +18,9 @@ class myConfigHandler extends sfConfigHandler
 }
 
 $config = new myConfigHandler();
-$config->initialize();
 
 // ->initialize()
 $t->diag('->initialize()');
-$config->initialize(array('foo' => 'bar'));
 $t->is($config->getParameterHolder()->get('foo'), 'bar', '->initialize() takes an array of parameters as its first argument');
 
 // ::replaceConstants()

--- a/test/unit/config/sfDefineEnvironmentConfigHandlerTest.php
+++ b/test/unit/config/sfDefineEnvironmentConfigHandlerTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -15,8 +15,7 @@ sfConfig::set('sf_symfony_lib_dir', realpath(__DIR__.'/../../../lib'));
 $t = new lime_test(1);
 
 // prefix
-$handler = new sfDefineEnvironmentConfigHandler();
-$handler->initialize(array('prefix' => 'sf_'));
+$handler = new sfDefineEnvironmentConfigHandler(['prefix' => 'sf_']);
 
 $dir = __DIR__.DIRECTORY_SEPARATOR.'fixtures'.DIRECTORY_SEPARATOR.'sfDefineEnvironmentConfigHandler'.DIRECTORY_SEPARATOR;
 

--- a/test/unit/config/sfFilterConfigHandlerTest.php
+++ b/test/unit/config/sfFilterConfigHandlerTest.php
@@ -13,7 +13,6 @@ require_once(__DIR__.'/../../bootstrap/unit.php');
 $t = new lime_test(8);
 
 $handler = new sfFilterConfigHandler();
-$handler->initialize();
 
 $dir = __DIR__.DIRECTORY_SEPARATOR.'fixtures'.DIRECTORY_SEPARATOR.'sfFilterConfigHandler'.DIRECTORY_SEPARATOR;
 

--- a/test/unit/config/sfSimpleYamlConfigHandlerTest.php
+++ b/test/unit/config/sfSimpleYamlConfigHandlerTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -13,7 +13,6 @@ require_once(__DIR__.'/../../bootstrap/unit.php');
 $t = new lime_test(2);
 
 $config = new sfSimpleYamlConfigHandler();
-$config->initialize();
 
 $dir = __DIR__.DIRECTORY_SEPARATOR.'fixtures'.DIRECTORY_SEPARATOR.'sfSimpleYamlConfigHandler'.DIRECTORY_SEPARATOR;
 

--- a/test/unit/config/sfYamlConfigHandlerTest.php
+++ b/test/unit/config/sfYamlConfigHandlerTest.php
@@ -40,7 +40,6 @@ class myConfigHandler extends sfYamlConfigHandler
 }
 
 $config = new myConfigHandler();
-$config->initialize();
 
 // ->parseYamls()
 $t->diag('->parseYamls()');


### PR DESCRIPTION
- `sfConfigHandler` implementations are now immutable
- Drop `sfConfigHandler::initialize()` method - config handlers are now initialized in their constructors (BC break)
- Drop support for module-level config handlers. They are now only run on app-level or higher. (BC break)