### PR TITLE
Refactor - Immutable sfFilter

### DIFF
--- a/lib/filter/sfFilter.class.php
+++ b/lib/filter/sfFilter.class.php
@@ -21,9 +21,9 @@
 abstract class sfFilter
 {
   /** @var sfParameterHolder */
-  protected $parameterHolder = null;
+  protected $parameterHolder;
   /** @var sfContext */
-  protected $context = null;
+  protected $context;
 
   /** @var bool[] */
   public static $filterCalled = [];
@@ -31,33 +31,17 @@ abstract class sfFilter
   /**
    * Class constructor.
    *
-   * @see initialize()
-   *
    * @param sfContext $context
    * @param array     $parameters
    */
   public function __construct(sfContext $context, array $parameters = [])
   {
-    $this->initialize($context, $parameters);
-  }
-
-  abstract function execute(sfFilterChain $chain): void;
-
-  /**
-   * Initializes this Filter.
-   *
-   * @param sfContext $context    The current application context
-   * @param array     $parameters An associative array of initialization parameters
-   *
-   * @return void
-   */
-  public function initialize(sfContext $context, array $parameters = []): void
-  {
     $this->context = $context;
-
     $this->parameterHolder = new sfParameterHolder();
     $this->parameterHolder->add($parameters);
   }
+
+  abstract function execute(sfFilterChain $chain): void;
 
   /**
    * Returns true if this is the first call to the sfFilter instance.

--- a/lib/filter/sfFilter.class.php
+++ b/lib/filter/sfFilter.class.php
@@ -74,16 +74,6 @@ abstract class sfFilter
   }
 
   /**
-   * Gets the parameter holder for this object.
-   *
-   * @return sfParameterHolder A sfParameterHolder instance
-   */
-  public function getParameterHolder(): sfParameterHolder
-  {
-    return $this->parameterHolder;
-  }
-
-  /**
    * Gets the parameter associated with the given key.
    *
    * This is a shortcut for:
@@ -118,22 +108,5 @@ abstract class sfFilter
   public function hasParameter(string $name): bool
   {
     return $this->parameterHolder->has($name);
-  }
-
-  /**
-   * Sets the value for the given key.
-   *
-   * This is a shortcut for:
-   *
-   * <code>$this->getParameterHolder()->set()</code>
-   *
-   * @param string $name  The key name
-   * @param mixed  $value The value
-   *
-   * @see sfParameterHolder
-   */
-  public function setParameter(string $name, $value): void
-  {
-    $this->parameterHolder->set($name, $value);
   }
 }

--- a/test/unit/filter/sfFilterTest.php
+++ b/test/unit/filter/sfFilterTest.php
@@ -11,7 +11,7 @@
 require_once(__DIR__ . '/../../bootstrap/unit.php');
 require_once(__DIR__ . '/../../unit/sfContextMock.class.php');
 
-$t = new lime_test(16);
+$t = new lime_test(6);
 
 class myFilter extends sfFilter
 {
@@ -42,8 +42,3 @@ $t->is($filter->isFirstCall('beforeExecution'), false, '->isFirstCall() returns 
 
 $filter = new myFilter($context);
 $t->is($filter->isFirstCall('beforeExecution'), false, '->isFirstCall() returns false if this is not the first call with this argument');
-
-// parameter holder proxy
-require_once($_test_dir.'/unit/sfParameterHolderTest.class.php');
-$pht = new sfParameterHolderProxyTest($t);
-$pht->launchTests($filter, 'parameter');

--- a/test/unit/filter/sfFilterTest.php
+++ b/test/unit/filter/sfFilterTest.php
@@ -11,7 +11,7 @@
 require_once(__DIR__ . '/../../bootstrap/unit.php');
 require_once(__DIR__ . '/../../unit/sfContextMock.class.php');
 
-$t = new lime_test(17);
+$t = new lime_test(16);
 
 class myFilter extends sfFilter
 {
@@ -27,19 +27,12 @@ class myFilter extends sfFilter
 }
 
 $context = sfContextMock::mockInstance();
-$filter = new myFilter($context);
+$filter = new myFilter($context, ['foo' => 'bar']);
 
 // ->initialize()
-$t->diag('->initialize()');
-$filter = new myFilter($context);
-$t->is($filter->getContext(), $context, '->initialize() takes a sfContext object as its first argument');
-$filter->initialize($context, array('foo' => 'bar'));
-$t->is($filter->getParameter('foo'), 'bar', '->initialize() takes an array of parameters as its second argument');
-
-// ->getContext()
-$t->diag('->getContext()');
-$filter->initialize($context);
-$t->is($filter->getContext(), $context, '->getContext() returns the current context');
+$t->diag('->__construct()');
+$t->is($filter->getContext(), $context, '->__construct() takes a sfContext object as its first argument');
+$t->is($filter->getParameter('foo'), 'bar', '->__construct() takes an array of parameters as its second argument');
 
 // ->isFirstCall()
 $t->diag('->isFirstCall()');
@@ -48,7 +41,6 @@ $t->is($filter->isFirstCall('beforeExecution'), false, '->isFirstCall() returns 
 $t->is($filter->isFirstCall('beforeExecution'), false, '->isFirstCall() returns false if this is not the first call with this argument');
 
 $filter = new myFilter($context);
-$filter->initialize($context);
 $t->is($filter->isFirstCall('beforeExecution'), false, '->isFirstCall() returns false if this is not the first call with this argument');
 
 // parameter holder proxy


### PR DESCRIPTION
- Drop `sfFilter::initialize()` method -- filters are now fully initialized with their constructors
- Drop `sfFilter::setParameter()` and `sfFilter::getParameterHolder()` methods -- constructor now is the only way to set parameters