### PR TITLE
Refactor - Test code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
     },
     "require-dev": {
         "ext-dom": "*",
+        "ext-libxml": "*",
         "psr/log": "*",
         "nette/robot-loader": "^3.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
         "symfony/yaml": "^3.4|^4.0|^5.0"
     },
     "require-dev": {
+        "ext-dom": "*",
         "psr/log": "*",
         "nette/robot-loader": "^3.1"
     },

--- a/lib/task/generator/skeleton/module/test/actionsTest.php
+++ b/lib/task/generator/skeleton/module/test/actionsTest.php
@@ -4,16 +4,13 @@ include(__DIR__.'/../../bootstrap/functional.php');
 
 $browser = new sfTestFunctional(new sfBrowser());
 
-$browser->
-  get('/##MODULE_NAME##/index')->
-
-  with('request')->begin()->
-    isParameter('module', '##MODULE_NAME##')->
-    isParameter('action', 'index')->
-  end()->
-
-  with('response')->begin()->
-    isStatusCode(200)->
-    checkElement('body', '!/This is a temporary page/')->
-  end()
+$browser->get('/##MODULE_NAME##/index')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->isParameter('module', '##MODULE_NAME##');
+    $request->isParameter('action', 'index');
+  })
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(200);
+    $response->checkElement('body', '!/This is a temporary page/');
+  })
 ;

--- a/lib/test/sfTestBrowser.class.php
+++ b/lib/test/sfTestBrowser.class.php
@@ -26,31 +26,23 @@ class sfTestBrowser extends sfTestFunctional
   /**
    * Initializes the browser tester instance.
    *
-   * @param string $hostname  Hostname to browse
-   * @param string $remote    Remote address to spook
-   * @param array  $options   Options for sfBrowser
+   * @param  string|null  $hostname  Hostname to browse
+   * @param  string|null  $remote    Remote address to spook
+   * @param  array        $options   Options for sfBrowser
    */
-  public function __construct($hostname = null, $remote = null, $options = array())
+  public function __construct(string $hostname = null, string $remote = null, array $options = [])
   {
-    if (is_object($hostname))
+    $browser = new sfBrowser($hostname, $remote, $options);
+
+    if (null === self::$test)
     {
-      // new signature
-      parent::__construct($hostname, $remote);
+      $lime = new lime_test(null, $options['output'] ?? null);
     }
     else
     {
-      $browser = new sfBrowser($hostname, $remote, $options);
-
-      if (null === self::$test)
-      {
-        $lime = new lime_test(null, isset($options['output']) ? $options['output'] : null);
-      }
-      else
-      {
-        $lime = null;
-      }
-
-      parent::__construct($browser, $lime);
+      $lime = null;
     }
+
+    parent::__construct($browser, $lime);
   }
 }

--- a/lib/test/sfTestFunctional.class.php
+++ b/lib/test/sfTestFunctional.class.php
@@ -21,13 +21,15 @@ class sfTestFunctional extends sfTestFunctionalBase
   /**
    * Initializes the browser tester instance.
    *
-   * @param  sfBrowserBase                  $browser  A sfBrowserBase instance
+   * @param  sfBrowser                  $browser  A sfBrowserBase instance
    * @param  \lime_test|null                $lime     A lime instance
    * @param  array<string,string|sfTester>  $testers  Testers to use
    */
-  public function __construct(sfBrowserBase $browser, lime_test $lime = null, array $testers = [])
+  public function __construct(sfBrowser $browser, lime_test $lime = null, array $testers = [])
   {
-    $testers = array_merge(['form' => sfTesterForm::class], $testers);
+    $testers = array_merge([
+      'form' => sfTesterForm::class,
+    ], $testers);
 
     parent::__construct($browser, $lime, $testers);
   }

--- a/lib/test/sfTestFunctional.class.php
+++ b/lib/test/sfTestFunctional.class.php
@@ -21,12 +21,13 @@ class sfTestFunctional extends sfTestFunctionalBase
   /**
    * Initializes the browser tester instance.
    *
-   * @param sfBrowserBase $browser A sfBrowserBase instance
-   * @param lime_test     $lime    A lime instance
+   * @param  sfBrowserBase                  $browser  A sfBrowserBase instance
+   * @param  \lime_test|null                $lime     A lime instance
+   * @param  array<string,string|sfTester>  $testers  Testers to use
    */
-  public function __construct(sfBrowserBase $browser, lime_test $lime = null, $testers = array())
+  public function __construct(sfBrowserBase $browser, lime_test $lime = null, array $testers = [])
   {
-    $testers = array_merge(['form' => 'sfTesterForm'], $testers);
+    $testers = array_merge(['form' => sfTesterForm::class], $testers);
 
     parent::__construct($browser, $lime, $testers);
   }
@@ -38,14 +39,13 @@ class sfTestFunctional extends sfTestFunctionalBase
    * @param  string $actionName  The action name
    * @param  mixed  $position    The position in the action stack (default to the last entry)
    *
-   * @return sfTestFunctional The current sfTestFunctional instance
+   * @return $this The current sfTestFunctional instance
    */
-  public function isForwardedTo($moduleName, $actionName, $position = 'last')
+  public function isForwardedTo(string $moduleName, string $actionName, $position = 'last'): self
   {
     $actionStack = $this->browser->getContext()->getActionStack();
 
-    switch ($position)
-    {
+    switch ($position) {
       case 'first':
         $entry = $actionStack->getFirstEntry();
         break;

--- a/lib/test/sfTestFunctionalBase.class.php
+++ b/lib/test/sfTestFunctionalBase.class.php
@@ -312,20 +312,14 @@ abstract class sfTestFunctionalBase
   /**
    * Checks that the current response contains a given text.
    *
-   * @param  string       $uri   Uniform resource identifier
-   * @param  string|null  $text  Text in the response
+   * @param  string  $uri  Uniform resource identifier
    *
    * @return $this The current sfTestFunctionalBase instance
    */
-  public function check(string $uri, string $text = null): self
+  public function check(string $uri): self
   {
-    $this->get($uri)->with('response', function (sfTesterResponse $response) use ($text) {
+    $this->get($uri)->with('response', function (sfTesterResponse $response) {
       $response->isStatusCode(200);
-
-      if ($text !== null) {
-        // FIXME: Apparently `contains` method was dropped
-        $response->contains($text);
-      }
     });
 
     return $this;

--- a/lib/test/sfTestFunctionalBase.class.php
+++ b/lib/test/sfTestFunctionalBase.class.php
@@ -205,11 +205,6 @@ abstract class sfTestFunctionalBase
 
     $this->test()->comment(sprintf('%s %s', strtolower($method), $uri));
 
-    foreach ($this->testers as $tester)
-    {
-      $tester->prepare();
-    }
-
     $this->browser->call($uri, $method, $parameters, $changeStack);
 
     return $this;

--- a/lib/test/sfTester.class.php
+++ b/lib/test/sfTester.class.php
@@ -36,11 +36,6 @@ abstract class sfTester
   }
 
   /**
-   * Prepares the tester.
-   */
-  abstract public function prepare();
-
-  /**
    * Initializes the tester.
    */
   abstract public function initialize();

--- a/lib/test/sfTester.class.php
+++ b/lib/test/sfTester.class.php
@@ -15,26 +15,24 @@
  * @subpackage test
  * @author     Fabien Potencier <fabien.potencier@symfony-project.com>
  * @version    SVN: $Id$
+ *
+ * @mixin \sfTestFunctional
  */
 abstract class sfTester
 {
-  /** @var bool */
-  protected $inABlock = false;
-  /** @var \sfTestFunctionalBase */
+  /** @var \sfTestFunctional */
   protected $browser;
   /** @var \lime_test */
   protected $tester;
 
   /**
-   * Constructor.
-   *
-   * @param sfTestFunctionalBase $browser A browser
-   * @param lime_test            $tester  A tester object
+   * @param  sfTestFunctional  $browser  A browser
+   * @param  lime_test         $tester   A tester object
    */
-  public function __construct(sfTestFunctionalBase $browser, lime_test $tester)
+  public function __construct(sfTestFunctional $browser, lime_test $tester)
   {
     $this->browser = $browser;
-    $this->tester  = $tester;
+    $this->tester = $tester;
   }
 
   /**
@@ -47,44 +45,10 @@ abstract class sfTester
    */
   abstract public function initialize();
 
-  /**
-   * Begins a block.
-   *
-   * @return sfTester This sfTester instance
-   */
-  public function begin()
-  {
-    $this->inABlock = true;
-
-    return $this->browser->begin();
-  }
-
-  /**
-   * Ends a block.
-   *
-   * @param sfTestFunctionalBase
-   */
-  public function end()
-  {
-    $this->inABlock = false;
-
-    return $this->browser->end();
-  }
-
-  /**
-   * Returns the object that each test method must return.
-   *
-   * @return sfTestFunctionalBase|sfTester
-   */
-  public function getObjectToReturn()
-  {
-    return $this->inABlock ? $this : $this->browser;
-  }
-
   public function __call($method, $arguments)
   {
     call_user_func_array([$this->browser, $method], $arguments);
 
-    return $this->getObjectToReturn();
+    return $this;
   }
 }

--- a/lib/test/sfTester.class.php
+++ b/lib/test/sfTester.class.php
@@ -18,10 +18,12 @@
  */
 abstract class sfTester
 {
-  protected
-    $inABlock = false,
-    $browser  = null,
-    $tester   = null;
+  /** @var bool */
+  protected $inABlock = false;
+  /** @var \sfTestFunctionalBase */
+  protected $browser;
+  /** @var \lime_test */
+  protected $tester;
 
   /**
    * Constructor.
@@ -29,7 +31,7 @@ abstract class sfTester
    * @param sfTestFunctionalBase $browser A browser
    * @param lime_test            $tester  A tester object
    */
-  public function __construct(sfTestFunctionalBase $browser, $tester)
+  public function __construct(sfTestFunctionalBase $browser, lime_test $tester)
   {
     $this->browser = $browser;
     $this->tester  = $tester;
@@ -81,7 +83,7 @@ abstract class sfTester
 
   public function __call($method, $arguments)
   {
-    call_user_func_array(array($this->browser, $method), $arguments);
+    call_user_func_array([$this->browser, $method], $arguments);
 
     return $this->getObjectToReturn();
   }

--- a/lib/test/sfTesterForm.class.php
+++ b/lib/test/sfTesterForm.class.php
@@ -18,20 +18,18 @@
  */
 class sfTesterForm extends sfTester
 {
-  protected
-    $form = null;
+  /** @var sfForm|null */
+  protected $form = null;
 
   /**
-   * Constructor.
-   *
    * @param sfTestFunctionalBase $browser A browser
    * @param lime_test            $tester  A tester object
    */
-  public function __construct(sfTestFunctionalBase $browser, $tester)
+  public function __construct(sfTestFunctionalBase $browser, lime_test $tester)
   {
     parent::__construct($browser, $tester);
 
-    $this->browser->addListener('template.filter_parameters', array($this, 'filterTemplateParameters'));
+    $this->browser->addListener('template.filter_parameters', [$this, 'filterTemplateParameters']);
   }
 
   /**
@@ -67,7 +65,7 @@ class sfTesterForm extends sfTester
    *
    * @return sfForm The current sfForm form instance
    */
-  public function getForm()
+  public function getForm(): ?sfForm
   {
     return $this->form;
   }
@@ -75,7 +73,7 @@ class sfTesterForm extends sfTester
   /**
    * Tests if the submitted form has some error.
    *
-   * @param  Boolean|integer $value Whether to check if the form has error or not, or the number of errors
+   * @param  bool|int $value Whether to check if the form has error or not, or the number of errors
    *
    * @return sfTestFunctionalBase|sfTester
    */

--- a/lib/test/sfTesterForm.class.php
+++ b/lib/test/sfTesterForm.class.php
@@ -22,22 +22,14 @@ class sfTesterForm extends sfTester
   protected $form = null;
 
   /**
-   * @param sfTestFunctionalBase $browser A browser
-   * @param lime_test            $tester  A tester object
+   * @param  sfTestFunctional  $browser  A browser
+   * @param  lime_test         $tester   A tester object
    */
-  public function __construct(sfTestFunctionalBase $browser, lime_test $tester)
+  public function __construct(sfTestFunctional $browser, lime_test $tester)
   {
     parent::__construct($browser, $tester);
 
     $this->browser->addListener('template.filter_parameters', [$this, 'filterTemplateParameters']);
-  }
-
-  /**
-   * Prepares the tester.
-   */
-  public function prepare()
-  {
-    $this->form = null;
   }
 
   /**

--- a/lib/test/sfTesterForm.class.php
+++ b/lib/test/sfTesterForm.class.php
@@ -195,7 +195,7 @@ class sfTesterForm extends sfTester
       throw new LogicException('no form has been submitted.');
     }
 
-    print $this->tester->error('Form debug');
+    $this->tester->error('Form debug');
 
     print sprintf("Submitted values: %s\n", str_replace("\n", '', var_export($this->form->getTaintedValues(), true)));
     print sprintf("Errors: %s\n", $this->form->getErrorSchema());

--- a/lib/test/sfTesterForm.class.php
+++ b/lib/test/sfTesterForm.class.php
@@ -75,9 +75,9 @@ class sfTesterForm extends sfTester
    *
    * @param  bool|int $value Whether to check if the form has error or not, or the number of errors
    *
-   * @return sfTestFunctionalBase|sfTester
+   * @return $this
    */
-  public function hasErrors($value = true)
+  public function hasErrors($value = true): self
   {
     if (null === $this->form)
     {
@@ -103,7 +103,7 @@ class sfTesterForm extends sfTester
       }
     }
 
-    return $this->getObjectToReturn();
+    return $this;
   }
 
   /**
@@ -124,9 +124,9 @@ class sfTesterForm extends sfTester
    * @param string $field The field name to check for an error (null for global errors)
    * @param mixed  $value The error message or the number of errors for the field (optional)
    *
-   * @return sfTestFunctionalBase|sfTester
+   * @return $this
    */
-  public function isError($field, $value = true)
+  public function isError(string $field, $value = true): self
   {
     if (null === $this->form)
     {
@@ -188,7 +188,7 @@ class sfTesterForm extends sfTester
       }
     }
 
-    return $this->getObjectToReturn();
+    return $this;
   }
 
   /**

--- a/lib/test/sfTesterForm.class.php
+++ b/lib/test/sfTesterForm.class.php
@@ -29,7 +29,9 @@ class sfTesterForm extends sfTester
   {
     parent::__construct($browser, $tester);
 
-    $this->browser->addListener('template.filter_parameters', [$this, 'filterTemplateParameters']);
+    $this->browser->addListener('template.filter_parameters', function (sfEvent $event, array $parameters): array {
+      return $this->filterTemplateParameters($parameters);
+    });
   }
 
   /**
@@ -103,9 +105,9 @@ class sfTesterForm extends sfTester
    *
    * @param mixed $value The error message or the number of errors for the field (optional)
    *
-   * @return sfTestFunctionalBase|sfTester
+   * @return $this
    */
-  public function hasGlobalError($value = true)
+  public function hasGlobalError($value = true): self
   {
     return $this->isError(null, $value);
   }
@@ -204,12 +206,11 @@ class sfTesterForm extends sfTester
   /**
    * Listens to the template.filter_parameters event to get the submitted form object.
    *
-   * @param sfEvent $event      The event
-   * @param array   $parameters An array of parameters passed to the template
+   * @param  array  $parameters  An array of parameters passed to the template
    *
    * @return array The array of parameters passed to the template
    */
-  public function filterTemplateParameters(sfEvent $event, $parameters)
+  private function filterTemplateParameters(array $parameters): array
   {
     if (!isset($parameters['sf_type']))
     {
@@ -236,7 +237,7 @@ class sfTesterForm extends sfTester
    * @return sfFormField
    */
 
-  public function getFormField($path)
+  public function getFormField(string $path): sfFormField
   {
     if (false !== $pos = strpos($path, '['))
     {

--- a/lib/test/sfTesterMailer.class.php
+++ b/lib/test/sfTesterMailer.class.php
@@ -47,11 +47,11 @@ class sfTesterMailer extends sfTester
   /**
    * Tests if message was send and optional how many.
    *
-   * @param int $nb number of messages
+   * @param int|null $nb number of messages
    *
-   * @return sfTestFunctionalBase|sfTester
+   * @return $this
    */
-  public function hasSent($nb = null)
+  public function hasSent(int $nb = null): self
   {
     if (null === $nb)
     {
@@ -62,7 +62,7 @@ class sfTesterMailer extends sfTester
       $this->tester->is($this->logger->countMessages(), $nb, sprintf('mailer sent %s email(s).', $nb));
     }
 
-    return $this->getObjectToReturn();
+    return $this;
   }
 
   /**
@@ -84,9 +84,9 @@ class sfTesterMailer extends sfTester
    * @param string|array $to       the email or array(email => alias)
    * @param int          $position address position
    *
-   * @return sfTestFunctionalBase|sfTester
+   * @return $this
    */
-  public function withMessage($to, $position = 1)
+  public function withMessage($to, int $position = 1): self
   {
     $messageEmail = $to;
     if(is_array($to))
@@ -130,9 +130,9 @@ class sfTesterMailer extends sfTester
    *
    * @param string $value regular expression or value
    *
-   * @return sfTestFunctionalBase|sfTester
+   * @return $this
    */
-  public function checkBody($value)
+  public function checkBody(string $value): self
   {
     if (!$this->message)
     {
@@ -190,7 +190,7 @@ class sfTesterMailer extends sfTester
       }
     }
 
-    return $this->getObjectToReturn();
+    return $this;
   }
 
   /**
@@ -199,9 +199,9 @@ class sfTesterMailer extends sfTester
    * @param string $key   entry to test
    * @param string $value regular expression or value
    *
-   * @return sfTestFunctionalBase|sfTester
+   * @return $this
    */
-  public function checkHeader($key, $value)
+  public function checkHeader(string $key, string $value): self
   {
     if (!$this->message)
     {
@@ -270,6 +270,6 @@ class sfTesterMailer extends sfTester
       }
     }
 
-    return $this->getObjectToReturn();
+    return $this;
   }
 }

--- a/lib/test/sfTesterMailer.class.php
+++ b/lib/test/sfTesterMailer.class.php
@@ -23,13 +23,6 @@ class sfTesterMailer extends sfTester
     $message = null;
 
   /**
-   * Prepares the tester.
-   */
-  public function prepare()
-  {
-  }
-
-  /**
    * Initializes the tester.
    */
   public function initialize()

--- a/lib/test/sfTesterRequest.class.php
+++ b/lib/test/sfTesterRequest.class.php
@@ -41,13 +41,13 @@ class sfTesterRequest extends sfTester
    * @param string $key
    * @param string $value
    *
-   * @return sfTestFunctionalBase|sfTester
+   * @return $this
    */
-  public function isParameter($key, $value)
+  public function isParameter(string $key, string $value): self
   {
     $this->tester->is($this->request->getParameter($key), $value, sprintf('request parameter "%s" is "%s"', $key, $value));
 
-    return $this->getObjectToReturn();
+    return $this;
   }
 
   /**
@@ -55,13 +55,13 @@ class sfTesterRequest extends sfTester
    *
    * @param  string $format  The request format
    *
-   * @return sfTestFunctionalBase|sfTester
+   * @return $this
    */
-  public function isFormat($format)
+  public function isFormat(string $format): self
   {
     $this->tester->is($this->request->getRequestFormat(), $format, sprintf('request format is "%s"', $format));
 
-    return $this->getObjectToReturn();
+    return $this;
   }
 
   /**
@@ -69,24 +69,24 @@ class sfTesterRequest extends sfTester
    *
    * @param  string  $method  The HTTP method name
    *
-   * @return sfTestFunctionalBase|sfTester
+   * @return $this
    */
-  public function isMethod($method)
+  public function isMethod(string $method): self
   {
     $this->tester->ok($this->request->isMethod($method), sprintf('request method is "%s"', strtoupper($method)));
 
-    return $this->getObjectToReturn();
+    return $this;
   }
 
   /**
    * Checks if a cookie exists.
    *
-   * @param string  $name   The cookie name
-   * @param Boolean $exists Whether the cookie must exist or not
+   * @param  string  $name    The cookie name
+   * @param  bool    $exists  Whether the cookie must exist or not
    *
-   * @return sfTestFunctionalBase|sfTester
+   * @return $this
    */
-  public function hasCookie($name, $exists = true)
+  public function hasCookie(string $name, bool $exists = true): self
   {
     if (!array_key_exists($name, $_COOKIE))
     {
@@ -99,7 +99,7 @@ class sfTesterRequest extends sfTester
         $this->tester->pass(sprintf('cookie "%s" does not exist.', $name));
       }
 
-      return $this->getObjectToReturn();
+      return $this;
     }
 
     if ($exists)
@@ -111,7 +111,7 @@ class sfTesterRequest extends sfTester
       $this->tester->fail(sprintf('cookie "%s" does not exist.', $name));
     }
 
-    return $this->getObjectToReturn();
+    return $this;
   }
 
   /**
@@ -120,15 +120,15 @@ class sfTesterRequest extends sfTester
    * @param string $name   The cookie name
    * @param mixed  $value  The expected value
    *
-   * @return sfTestFunctionalBase|sfTester
+   * @return $this
    */
-  public function isCookie($name, $value)
+  public function isCookie(string $name, $value): self
   {
     if (!array_key_exists($name, $_COOKIE))
     {
       $this->tester->fail(sprintf('cookie "%s" does not exist.', $name));
 
-      return $this->getObjectToReturn();
+      return $this;
     }
 
     if (preg_match('/^(!)?([^a-zA-Z0-9\\\\]).+?\\2[ims]?$/', $value, $match))
@@ -147,6 +147,6 @@ class sfTesterRequest extends sfTester
       $this->tester->is($_COOKIE[$name], $value, sprintf('cookie "%s" content is ok', $name));
     }
 
-    return $this->getObjectToReturn();
+    return $this;
   }
 }

--- a/lib/test/sfTesterRequest.class.php
+++ b/lib/test/sfTesterRequest.class.php
@@ -18,6 +18,7 @@
  */
 class sfTesterRequest extends sfTester
 {
+  /** @var sfWebRequest|null */
   protected $request;
 
   /**

--- a/lib/test/sfTesterRequest.class.php
+++ b/lib/test/sfTesterRequest.class.php
@@ -21,13 +21,6 @@ class sfTesterRequest extends sfTester
   protected $request;
 
   /**
-   * Prepares the tester.
-   */
-  public function prepare()
-  {
-  }
-
-  /**
    * Initializes the tester.
    */
   public function initialize()

--- a/lib/test/sfTesterResponse.class.php
+++ b/lib/test/sfTesterResponse.class.php
@@ -18,9 +18,11 @@
  */
 class sfTesterResponse extends sfTester
 {
-
+  /** @var sfWebResponse */
   protected $response = null;
+  /** @var DOMDocument|null */
   protected $dom = null;
+  /** @var sfDomCssSelector|null */
   protected $domCssSelector = null;
 
   /**
@@ -87,7 +89,7 @@ class sfTesterResponse extends sfTester
     }
     else if (preg_match('/^(!)?([^a-zA-Z0-9\\\\]).+?\\2[ims]?$/', $value, $match))
     {
-      $position = isset($options['position']) ? $options['position'] : 0;
+      $position = $options['position'] ?? 0;
       if ($match[1] == '!')
       {
         $this->tester->unlike(@$values[$position], substr($value, 1), sprintf('response selector "%s" does not match regex "%s"', $selector, substr($value, 1)));
@@ -99,7 +101,7 @@ class sfTesterResponse extends sfTester
     }
     else
     {
-      $position = isset($options['position']) ? $options['position'] : 0;
+      $position = $options['position'] ?? 0;
       $this->tester->is(@$values[$position], $value, sprintf('response selector "%s" matches "%s"', $selector, $value));
     }
 
@@ -114,8 +116,8 @@ class sfTesterResponse extends sfTester
   /**
    * Checks that a form is rendered correctly.
    *
-   * @param  sfForm|string $form     A form object or the name of a form class
-   * @param  string        $selector CSS selector for the root form element for this form
+   * @param  sfForm|class-string  $form      A form object or the name of a form class
+   * @param  string               $selector  CSS selector for the root form element for this form
    *
    * @return $this
    */
@@ -262,7 +264,7 @@ class sfTesterResponse extends sfTester
    *
    * @return $this
    */
-  public function isHeader($key, $value)
+  public function isHeader(string $key, string $value): self
   {
     $headers = explode(', ', $this->response->getHttpHeader($key));
     $ok = false;
@@ -337,7 +339,7 @@ class sfTesterResponse extends sfTester
   {
     foreach ($this->response->getCookies() as $cookie)
     {
-      if ($name == $cookie->get)
+      if ($name == $cookie['name'])
       {
         if (null === $value)
         {
@@ -436,7 +438,7 @@ class sfTesterResponse extends sfTester
    */
   public function debug($realOutput = false)
   {
-    print $this->tester->error('Response debug');
+    $this->tester->error('Response debug');
 
     if (!$realOutput && null !== sfException::getLastException())
     {

--- a/lib/test/sfTesterResponse.class.php
+++ b/lib/test/sfTesterResponse.class.php
@@ -24,13 +24,6 @@ class sfTesterResponse extends sfTester
   protected $domCssSelector = null;
 
   /**
-   * Prepares the tester.
-   */
-  public function prepare()
-  {
-  }
-
-  /**
    * Initializes the tester.
    */
   public function initialize()

--- a/lib/test/sfTesterResponse.class.php
+++ b/lib/test/sfTesterResponse.class.php
@@ -398,11 +398,11 @@ class sfTesterResponse extends sfTester
   /**
    * Tests the status code.
    *
-   * @param  int  $statusCode  Status code to check, default 200
+   * @param  int  $statusCode  Status code to check.
    *
    * @return $this
    */
-  public function isStatusCode(int $statusCode = 200): self
+  public function isStatusCode(int $statusCode): self
   {
     $this->tester->is($this->response->getStatusCode(), $statusCode, sprintf('status code is "%s"', $statusCode));
 

--- a/lib/test/sfTesterResponse.class.php
+++ b/lib/test/sfTesterResponse.class.php
@@ -18,10 +18,10 @@
  */
 class sfTesterResponse extends sfTester
 {
-  protected
-    $response       = null,
-    $dom            = null,
-    $domCssSelector = null;
+
+  protected $response = null;
+  protected $dom = null;
+  protected $domCssSelector = null;
 
   /**
    * Prepares the tester.
@@ -120,10 +120,10 @@ class sfTesterResponse extends sfTester
 
   /**
    * Checks that a form is rendered correctly.
-   * 
+   *
    * @param  sfForm|string $form     A form object or the name of a form class
    * @param  string        $selector CSS selector for the root form element for this form
-   * 
+   *
    * @return sfTestFunctionalBase|sfTester
    */
   public function checkForm($form, $selector = 'form')
@@ -333,18 +333,18 @@ class sfTesterResponse extends sfTester
 
   /**
    * Tests if a cookie was set.
-   * 
+   *
    * @param  string $name
    * @param  string $value
    * @param  array  $attributes Other cookie attributes to check (expires, path, domain, etc)
-   * 
+   *
    * @return sfTestFunctionalBase|sfTester
    */
   public function setsCookie($name, $value = null, $attributes = array())
   {
     foreach ($this->response->getCookies() as $cookie)
     {
-      if ($name == $cookie['name'])
+      if ($name == $cookie->get)
       {
         if (null === $value)
         {

--- a/lib/test/sfTesterResponse.class.php
+++ b/lib/test/sfTesterResponse.class.php
@@ -62,9 +62,9 @@ class sfTesterResponse extends sfTester
    * @param  mixed  $value     Flag for the selector
    * @param  array  $options   Options for the current test
    *
-   * @return sfTestFunctionalBase|sfTester
+   * @return $this
    */
-  public function checkElement($selector, $value = true, $options = array())
+  public function checkElement(string $selector, $value = true, array $options = []): self
   {
     if (null === $this->dom)
     {
@@ -115,7 +115,7 @@ class sfTesterResponse extends sfTester
       $this->tester->is(count($values), $options['count'], sprintf('response selector "%s" matches "%s" times', $selector, $options['count']));
     }
 
-    return $this->getObjectToReturn();
+    return $this;
   }
 
   /**
@@ -124,9 +124,9 @@ class sfTesterResponse extends sfTester
    * @param  sfForm|string $form     A form object or the name of a form class
    * @param  string        $selector CSS selector for the root form element for this form
    *
-   * @return sfTestFunctionalBase|sfTester
+   * @return $this
    */
-  public function checkForm($form, $selector = 'form')
+  public function checkForm($form, string $selector = 'form'): self
   {
     if (!$form instanceof sfForm)
     {
@@ -158,7 +158,7 @@ class sfTesterResponse extends sfTester
       }
     }
 
-    return $this->getObjectToReturn();
+    return $this;
   }
 
   /**
@@ -167,7 +167,7 @@ class sfTesterResponse extends sfTester
    * @param mixed $checkDTD Either true to validate against the response DTD or
    *                        provide the path to a *.xsd, *.rng or *.rnc schema
    *
-   * @return sfTestFunctionalBase|sfTester
+   * @return $this
    *
    * @throws LogicException If the response is neither XML nor (X)HTML
    */
@@ -258,7 +258,7 @@ class sfTesterResponse extends sfTester
       throw new LogicException(sprintf('Unable to validate responses of content type "%s"', $this->response->getContentType()));
     }
 
-    return $this->getObjectToReturn();
+    return $this;
   }
 
   /**
@@ -267,7 +267,7 @@ class sfTesterResponse extends sfTester
    * @param  string $key
    * @param  string $value
    *
-   * @return sfTestFunctionalBase|sfTester
+   * @return $this
    */
   public function isHeader($key, $value)
   {
@@ -328,19 +328,19 @@ class sfTesterResponse extends sfTester
       }
     }
 
-    return $this->getObjectToReturn();
+    return $this;
   }
 
   /**
    * Tests if a cookie was set.
    *
-   * @param  string $name
-   * @param  string $value
-   * @param  array  $attributes Other cookie attributes to check (expires, path, domain, etc)
+   * @param  string               $name
+   * @param  string|null          $value
+   * @param  array<string,mixed>  $attributes  Other cookie attributes to check (expires, path, domain, etc)
    *
-   * @return sfTestFunctionalBase|sfTester
+   * @return $this
    */
-  public function setsCookie($name, $value = null, $attributes = array())
+  public function setsCookie(string $name, string $value = null, array $attributes = []): self
   {
     foreach ($this->response->getCookies() as $cookie)
     {
@@ -365,13 +365,13 @@ class sfTesterResponse extends sfTester
           $this->tester->is($cookie[$attributeName], $attributeValue, sprintf('"%s" cookie "%s" attribute is "%s"', $name, $attributeName, $attributeValue));
         }
 
-        return $this->getObjectToReturn();
+        return $this;
       }
     }
 
     $this->tester->fail(sprintf('response sets cookie "%s"', $name));
 
-    return $this->getObjectToReturn();
+    return $this;
   }
 
   /**
@@ -379,9 +379,9 @@ class sfTesterResponse extends sfTester
    *
    * @param string Regex
    *
-   * @return sfTestFunctionalBase|sfTester
+   * @return $this
    */
-  public function matches($regex)
+  public function matches(string $regex): self
   {
     if (!preg_match('/^(!)?([^a-zA-Z0-9\\\\]).+?\\2[ims]?$/', $regex, $match))
     {
@@ -397,21 +397,21 @@ class sfTesterResponse extends sfTester
       $this->tester->like($this->response->getContent(), $regex, sprintf('response content matches regex "%s"', $regex));
     }
 
-    return $this->getObjectToReturn();
+    return $this;
   }
 
   /**
    * Tests the status code.
    *
-   * @param string $statusCode Status code to check, default 200
+   * @param  int  $statusCode  Status code to check, default 200
    *
-   * @return sfTestFunctionalBase|sfTester
+   * @return $this
    */
-  public function isStatusCode($statusCode = 200)
+  public function isStatusCode(int $statusCode = 200): self
   {
     $this->tester->is($this->response->getStatusCode(), $statusCode, sprintf('status code is "%s"', $statusCode));
 
-    return $this->getObjectToReturn();
+    return $this;
   }
 
   /**
@@ -419,9 +419,9 @@ class sfTesterResponse extends sfTester
    *
    * @param  bool $boolean  Flag for redirection mode
    *
-   * @return sfTestFunctionalBase|sfTester
+   * @return $this
    */
-  public function isRedirected($boolean = true)
+  public function isRedirected(bool $boolean = true): self
   {
     if ($location = $this->response->getHttpHeader('location'))
     {
@@ -432,7 +432,7 @@ class sfTesterResponse extends sfTester
       $boolean ? $this->tester->fail('page redirected') : $this->tester->pass('page not redirected');
     }
 
-    return $this->getObjectToReturn();
+    return $this;
   }
 
   /**

--- a/lib/test/sfTesterUser.class.php
+++ b/lib/test/sfTesterUser.class.php
@@ -21,13 +21,6 @@ class sfTesterUser extends sfTester
   protected $user;
 
   /**
-   * Prepares the tester.
-   */
-  public function prepare()
-  {
-  }
-
-  /**
    * Initializes the tester.
    */
   public function initialize()

--- a/lib/test/sfTesterUser.class.php
+++ b/lib/test/sfTesterUser.class.php
@@ -38,17 +38,17 @@ class sfTesterUser extends sfTester
   /**
    * Tests a user attribute value.
    *
-   * @param string $key
-   * @param string $value
-   * @param string $ns
+   * @param  string       $key
+   * @param  string       $value
+   * @param  string|null  $ns
    *
-   * @return sfTestFunctionalBase|sfTester
+   * @return $this
    */
-  public function isAttribute($key, $value, $ns = null)
+  public function isAttribute(string $key, string $value, string $ns = null): self
   {
     $this->tester->is($this->user->getAttribute($key, null, $ns), $value, sprintf('user attribute "%s" is "%s"', $key, $value));
 
-    return $this->getObjectToReturn();
+    return $this;
   }
 
   /**
@@ -57,13 +57,13 @@ class sfTesterUser extends sfTester
    * @param string $key
    * @param string $value
    *
-   * @return sfTestFunctionalBase|sfTester
+   * @return $this
    */
-  public function isFlash($key, $value)
+  public function isFlash(string $key, string $value): self
   {
     $this->tester->is($this->user->getFlash($key), $value, sprintf('user flash "%s" is "%s"', $key, $value));
 
-    return $this->getObjectToReturn();
+    return $this;
   }
 
   /**
@@ -71,27 +71,27 @@ class sfTesterUser extends sfTester
    *
    * @param  string $culture  The user culture
    *
-   * @return sfTestFunctionalBase|sfTester
+   * @return $this
    */
-  public function isCulture($culture)
+  public function isCulture(string $culture): self
   {
     $this->tester->is($this->user->getCulture(), $culture, sprintf('user culture is "%s"', $culture));
 
-    return $this->getObjectToReturn();
+    return $this;
   }
 
   /**
    * Tests if the user is authenticated.
    *
-   * @param  Boolean $boolean Whether to check if the user is authenticated or not
+   * @param  bool  $boolean  Whether to check if the user is authenticated or not
    *
-   * @return sfTestFunctionalBase|sfTester
+   * @return $this
    */
-  public function isAuthenticated($boolean = true)
+  public function isAuthenticated(bool $boolean = true): self
   {
     $this->tester->is($this->user->isAuthenticated(), $boolean, sprintf('user is %sauthenticated', $boolean ? '' : 'not '));
 
-    return $this->getObjectToReturn();
+    return $this;
   }
 
   /**
@@ -101,12 +101,12 @@ class sfTesterUser extends sfTester
    * @param  bool  $boolean      Whether to check if the user have some credentials or not
    * @param  bool  $useAnd       specify the mode, either AND or OR
    *
-   * @return sfTestFunctionalBase|sfTester
+   * @return $this
    */
-  public function hasCredential($credentials, $boolean = true, $useAnd = true)
+  public function hasCredential($credentials, bool $boolean = true, bool $useAnd = true): self
   {
     $this->tester->is($this->user->hasCredential($credentials, $useAnd), $boolean, sprintf('user has %sthe right credentials', $boolean ? '' : 'not '));
 
-    return $this->getObjectToReturn();
+    return $this;
   }
 }

--- a/test/functional/authTest.php
+++ b/test/functional/authTest.php
@@ -18,36 +18,36 @@ class sfAuthTestBrowser extends sfTestBrowser
 {
   public function checkNonAuth(): self
   {
-    return $this->
-      get('/auth/basic')->
-      with('request')->begin()->
-        isParameter('module', 'auth')->
-        isParameter('action', 'basic')->
-      end()->
-      with('response')->begin()->
-        isStatusCode(401)->
-        checkElement('#user', '')->
-        checkElement('#password', '')->
-        checkElement('#msg', 'KO')->
-      end()
-    ;
+    return $this->get('/auth/basic')
+
+      ->with('request', function (sfTesterRequest $request) {
+        $request->isParameter('module', 'auth');
+        $request->isParameter('action', 'basic');
+      })
+
+      ->with('response', function (sfTesterResponse $response) {
+        $response->isStatusCode(401);
+        $response->checkElement('#user', '');
+        $response->checkElement('#password', '');
+        $response->checkElement('#msg', 'KO');
+      });
   }
 
   public function checkAuth(): self
   {
-    return $this->
-      get('/auth/basic')->
-      with('request')->begin()->
-        isParameter('module', 'auth')->
-        isParameter('action', 'basic')->
-      end()->
-      with('response')->begin()->
-        isStatusCode(200)->
-        checkElement('#user', 'foo')->
-        checkElement('#password', 'bar')->
-        checkElement('#msg', 'OK')->
-      end()
-    ;
+    return $this->get('/auth/basic')
+
+      ->with('request', function (sfTesterRequest $request) {
+        $request->isParameter('module', 'auth');
+        $request->isParameter('action', 'basic');
+      })
+
+      ->with('response', function (sfTesterResponse $response) {
+        $response->isStatusCode(200);
+        $response->checkElement('#user', 'foo');
+        $response->checkElement('#password', 'bar');
+        $response->checkElement('#msg', 'OK');
+      });
   }
 }
 

--- a/test/functional/authTest.php
+++ b/test/functional/authTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -16,7 +16,7 @@ if (!include(__DIR__.'/../bootstrap/functional.php'))
 
 class sfAuthTestBrowser extends sfTestBrowser
 {
-  public function checkNonAuth()
+  public function checkNonAuth(): self
   {
     return $this->
       get('/auth/basic')->
@@ -33,7 +33,7 @@ class sfAuthTestBrowser extends sfTestBrowser
     ;
   }
 
-  public function checkAuth()
+  public function checkAuth(): self
   {
     return $this->
       get('/auth/basic')->

--- a/test/functional/escapingTest.php
+++ b/test/functional/escapingTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -18,33 +18,32 @@ $b = new sfTestBrowser();
 
 $b->get('/escaping/on')
 
-  ->with('request')->begin()
-    ->isParameter('module', 'escaping')
-    ->isParameter('action', 'on')
-  ->end()
-
-  ->with('response')->begin()
-    ->isStatusCode(200)
-    ->matches('#<h1>Lorem &lt;strong&gt;ipsum&lt;/strong&gt; dolor sit amet.</h1>#')
-    ->matches('#<h2>Lorem &lt;strong&gt;ipsum&lt;/strong&gt; dolor sit amet.</h2>#')
-    ->matches('#<h3>Lorem &lt;strong&gt;ipsum&lt;/strong&gt; dolor sit amet.</h3>#')
-    ->matches('#<h4>Lorem <strong>ipsum</strong> dolor sit amet.</h4>#')
-    ->matches('#<h5>Lorem &lt;strong&gt;ipsum&lt;/strong&gt; dolor sit amet.</h5>#')
-    ->matches('#<h6>Lorem <strong>ipsum</strong> dolor sit amet.</h6>#')
-    ->checkElement('span.no', 2)
-  ->end()
+  ->with('request', function (sfTesterRequest $request) {
+    $request->isParameter('module', 'escaping');
+    $request->isParameter('action', 'on');
+  })
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(200);
+    $response->matches('#<h1>Lorem &lt;strong&gt;ipsum&lt;/strong&gt; dolor sit amet.</h1>#');
+    $response->matches('#<h2>Lorem &lt;strong&gt;ipsum&lt;/strong&gt; dolor sit amet.</h2>#');
+    $response->matches('#<h3>Lorem &lt;strong&gt;ipsum&lt;/strong&gt; dolor sit amet.</h3>#');
+    $response->matches('#<h4>Lorem <strong>ipsum</strong> dolor sit amet.</h4>#');
+    $response->matches('#<h5>Lorem &lt;strong&gt;ipsum&lt;/strong&gt; dolor sit amet.</h5>#');
+    $response->matches('#<h6>Lorem <strong>ipsum</strong> dolor sit amet.</h6>#');
+    $response->checkElement('span.no', 2);
+  })
 ;
 
 $b->get('/escaping/off')
 
-  ->with('request')->begin()
-    ->isParameter('module', 'escaping')
-    ->isParameter('action', 'off')
-  ->end()
+  ->with('request', function (sfTesterRequest $request) {
+    $request->isParameter('module', 'escaping');
+    $request->isParameter('action', 'off');
+  })
 
-  ->with('response')->begin()
-    ->isStatusCode(200)
-    ->matches('#<h1>Lorem <strong>ipsum</strong> dolor sit amet.</h1>#')
-    ->matches('#<h2>Lorem <strong>ipsum</strong> dolor sit amet.</h2>#')
-  ->end()
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(200);
+    $response->matches('#<h1>Lorem <strong>ipsum</strong> dolor sit amet.</h1>#');
+    $response->matches('#<h2>Lorem <strong>ipsum</strong> dolor sit amet.</h2>#');
+  })
 ;

--- a/test/functional/filterTest.php
+++ b/test/functional/filterTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -17,29 +17,31 @@ if (!include(__DIR__.'/../bootstrap/functional.php'))
 $b = new sfTestBrowser();
 
 // filter
-$b->
-  get('/filter')->
-  with('request')->begin()->
-    isParameter('module', 'filter')->
-    isParameter('action', 'index')->
-  end()->
-  with('response')->begin()->
-    isStatusCode(200)->
-    checkElement('div[class="before"]', 1)->
-    checkElement('div[class="after"]', 1)->
-  end()
+$b->get('/filter')
+
+  ->with('request', function (sfTesterRequest $request) {
+    $request->isParameter('module', 'filter');
+    $request->isParameter('action', 'index');
+  })
+
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(200);
+    $response->checkElement('div[class="before"]', 1);
+    $response->checkElement('div[class="after"]', 1);
+  })
 ;
 
 // filter with a forward in the same module
-$b->
-  get('/filter/indexWithForward')->
-  with('request')->begin()->
-    isParameter('module', 'filter')->
-    isParameter('action', 'indexWithForward')->
-  end()->
-  with('response')->begin()->
-    isStatusCode(200)->
-    checkElement('div[class="before"]', 2)->
-    checkElement('div[class="after"]', 1)->
-  end()
+$b->get('/filter/indexWithForward')
+
+  ->with('request', function (sfTesterRequest $request) {
+    $request->isParameter('module', 'filter');
+    $request->isParameter('action', 'indexWithForward');
+  })
+
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(200);
+    $response->checkElement('div[class="before"]', 2);
+    $response->checkElement('div[class="after"]', 1);
+  })
 ;

--- a/test/functional/formatTest.php
+++ b/test/functional/formatTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -16,107 +16,100 @@ if (!include(__DIR__.'/../bootstrap/functional.php'))
 
 $b = new sfTestBrowser();
 
-$b->
-  get('/format_test.js')->
-  with('request')->begin()->
-    isParameter('module', 'format')->
-    isParameter('action', 'index')->
-    isFormat('js')->
-  end()->
-  with('response')->begin()->
-    isStatusCode(200)->
-    isHeader('content-type', 'application/javascript')->
-    matches('!/<body>/')->
-    matches('/Some js headers/')->
-    matches('/This is a js file/')->
-  end()
+$b->get('/format_test.js')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->isParameter('module', 'format');
+    $request->isParameter('action', 'index');
+    $request->isFormat('js');
+  })
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(200);
+    $response->isHeader('content-type', 'application/javascript');
+    $response->matches('!/<body>/');
+    $response->matches('/Some js headers/');
+    $response->matches('/This is a js file/');
+  })
 ;
 
-$b->
-  get('/format_test.css')->
-  with('request')->begin()->
-    isParameter('module', 'format')->
-    isParameter('action', 'index')->
-    isFormat('css')->
-  end()->
-  with('response')->begin()->
-    isStatusCode(200)->
-    isHeader('content-type', 'text/css; charset=utf-8')->
-    matches('/This is a css file/')->
-  end()
+$b->get('/format_test.css')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->isParameter('module', 'format');
+    $request->isParameter('action', 'index');
+    $request->isFormat('css');
+  })
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(200);
+    $response->isHeader('content-type', 'text/css; charset=utf-8');
+    $response->matches('/This is a css file/');
+  })
 ;
 
-$b->
-  get('/format_test')->
-  with('request')->begin()->
-    isParameter('module', 'format')->
-    isParameter('action', 'index')->
-    isFormat('html')->
-  end()->
-  with('response')->begin()->
-    isStatusCode(200)->
-    isHeader('content-type', 'text/html; charset=utf-8')->
-    checkElement('body #content', 'This is an HTML file')->
-  end()
+$b->get('/format_test')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->isParameter('module', 'format');
+    $request->isParameter('action', 'index');
+    $request->isFormat('html');
+  })
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(200);
+    $response->isHeader('content-type', 'text/html; charset=utf-8');
+    $response->checkElement('body #content', 'This is an HTML file');
+  })
 ;
 
-$b->
-  get('/format_test.xml')->
-  with('request')->begin()->
-    isParameter('module', 'format')->
-    isParameter('action', 'index')->
-    isFormat('xml')->
-  end()->
-  with('response')->begin()->
-    isStatusCode(200)->
-    isHeader('content-type', 'text/xml; charset=utf-8')->
-    checkElement('sentences sentence:first', 'This is a XML file')->
-  end()
+$b->get('/format_test.xml')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->isParameter('module', 'format');
+    $request->isParameter('action', 'index');
+    $request->isFormat('xml');
+  })
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(200);
+    $response->isHeader('content-type', 'text/xml; charset=utf-8');
+    $response->checkElement('sentences sentence:first', 'This is a XML file');
+  })
 ;
 
-$b->
-  get('/format_test.foo')->
-  with('request')->begin()->
-    isParameter('module', 'format')->
-    isParameter('action', 'index')->
-    isFormat('foo')->
-  end()->
-  with('response')->begin()->
-    isStatusCode(200)->
-    isHeader('content-type', 'text/html; charset=utf-8')->
-    isHeader('x-foo', 'true')->
-    checkElement('body #content', 'This is an HTML file')->
-  end()
+$b->get('/format_test.foo')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->isParameter('module', 'format');
+    $request->isParameter('action', 'index');
+    $request->isFormat('foo');
+  })
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(200);
+    $response->isHeader('content-type', 'text/html; charset=utf-8');
+    $response->isHeader('x-foo', 'true');
+    $response->checkElement('body #content', 'This is an HTML file');
+  })
 ;
 
-$b->
-  get('/format/js')->
-  with('request')->begin()->
-    isParameter('module', 'format')->
-    isParameter('action', 'js')->
-    isFormat('js')->
-  end()->
-  with('response')->begin()->
-    isStatusCode(200)->
-    isHeader('content-type', 'application/javascript')->
-    matches('/A js file/')->
-  end()
+$b->get('/format/js')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->isParameter('module', 'format');
+    $request->isParameter('action', 'js');
+    $request->isFormat('js');
+  })
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(200);
+    $response->isHeader('content-type', 'application/javascript');
+    $response->matches('/A js file/');
+  })
 ;
 
-$b->
-  setHttpHeader('User-Agent', 'Mozilla/5.0 (iPhone; U; CPU like Mac OS X; en) AppleWebKit/420+ (KHTML, like Gecko) Version/3.0 Mobile/1A543a Safari/419.3')->
-  get('/format/forTheIPhone')->
-  with('request')->begin()->
-    isParameter('module', 'format')->
-    isParameter('action', 'forTheIPhone')->
-    isFormat('iphone')->
-  end()->
-  with('response')->begin()->
-    isStatusCode(200)->
-    isHeader('content-type', 'text/html; charset=utf-8')->
-    checkElement('#content', 'This is an HTML file for the iPhone')->
-    checkElement('link[href*="iphone.css"]')->
-  end()
+$b->setHttpHeader('User-Agent', 'Mozilla/5.0 (iPhone; U; CPU like Mac OS X; en) AppleWebKit/420+ (KHTML, like Gecko) Version/3.0 Mobile/1A543a Safari/419.3')
+  ->get('/format/forTheIPhone')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->isParameter('module', 'format');
+    $request->isParameter('action', 'forTheIPhone');
+    $request->isFormat('iphone');
+  })
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(200);
+    $response->isHeader('content-type', 'text/html; charset=utf-8');
+    $response->checkElement('#content', 'This is an HTML file for the iPhone');
+    $response->checkElement('link[href*="iphone.css"]');
+  })
 ;
 
 $b->

--- a/test/functional/genericTest.php
+++ b/test/functional/genericTest.php
@@ -17,21 +17,21 @@ if (!include(__DIR__.'/../bootstrap/functional.php'))
 $b = new sfTestBrowser();
 
 // default main page
-$b->
-  getAndCheck('default', 'index', '/')->
-  with('response')->begin()->
-    checkElement('body', '/congratulations/i')->
-    checkElement('link[href="/sf/sf_default/css/screen.css"]')->
-    checkElement('link[href="/css/main.css"]')->
-    checkElement('link[href="/css/multiple_media.css"][media="print,handheld"]')->
-    matches('#'.preg_quote('<!--[if lte IE 6]><link rel="stylesheet" type="text/css" media="screen" href="/css/ie6.css" /><![endif]-->').'#')->
-  end()
+$b->getAndCheck('default', 'index', '/')
+  ->with('response', function (sfTesterResponse $response) {
+    $response->checkElement('body', '/congratulations/i');
+    $response->checkElement('link[href="/sf/sf_default/css/screen.css"]');
+    $response->checkElement('link[href="/css/main.css"]');
+    $response->checkElement('link[href="/css/multiple_media.css"][media="print,handheld"]');
+    $response->matches('#' . preg_quote('<!--[if lte IE 6]><link rel="stylesheet" type="text/css" media="screen" href="/css/ie6.css" /><![endif]-->') . '#');
+  })
 ;
 
 // default 404
-$b->
-  get('/nonexistant')->
-  with('response')->isStatusCode(404)
+$b->get('/nonexistant')
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(404);
+  })
 ;
 /*
 $b->
@@ -41,147 +41,136 @@ $b->
 */
 
 // unexistant action
-$b->
-  get('/default/nonexistantaction')->
-  with('response')->isStatusCode(404)
+$b->get('/default/nonexistantaction')
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(404);
+  })
 ;
 
 // module.yml: enabled
-$b->
-  get('/configModuleDisabled')->
-  with('request')->begin()->
-    isForwardedTo('default', 'disabled')->
-  end()->
-  with('response')->begin()->
-    isStatusCode(200)->
-    checkElement('body', '/module is unavailable/i')->
-    checkElement('body', '!/congratulations/i')->
-    checkElement('link[href="/sf/sf_default/css/screen.css"]')->
-  end()
+$b->get('/configModuleDisabled')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->isForwardedTo('default', 'disabled');
+  })
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(200);
+    $response->checkElement('body', '/module is unavailable/i');
+    $response->checkElement('body', '!/congratulations/i');
+    $response->checkElement('link[href="/sf/sf_default/css/screen.css"]');
+  })
 ;
 
 // view.yml: has_layout
-$b->
-  get('/configViewHasLayout/withoutLayout')->
-  with('response')->begin()->
-    isStatusCode(200)->
-    checkElement('body', '/no layout/i')->
-    checkElement('head title', false)->
-  end()
+$b->get('/configViewHasLayout/withoutLayout')
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(200);
+    $response->checkElement('body', '/no layout/i');
+    $response->checkElement('head title', false);
+  })
 ;
 
 // security.yml: is_secure
-$b->
-  get('/configSecurityIsSecure')->
-  with('request')->begin()->
-    isForwardedTo('default', 'login')->
-  end()->
-  with('response')->begin()->
-    isStatusCode(200)->
-    checkElement('body', '/Login Required/i')->
+$b->get('/configSecurityIsSecure')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->isForwardedTo('default', 'login');
+  })
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(200);
+    $response->checkElement('body', '/Login Required/i');
 
     // check that there is no double output caused by the forwarding in a filter
-    checkElement('body', 1)->
-    checkElement('link[href="/sf/sf_default/css/screen.css"]')->
-  end()
+    $response->checkElement('body', 1);
+    $response->checkElement('link[href="/sf/sf_default/css/screen.css"]');
+  })
 ;
 
 // security.yml: case sensitivity
-$b->
-  get('/configSecurityIsSecureAction/index')->
-  with('request')->begin()->
-    isForwardedTo('default', 'login')->
-  end()->
-  with('response')->begin()->
-    isStatusCode(200)->
-    checkElement('body', '/Login Required/i')->
-  end()
+$b->get('/configSecurityIsSecureAction/index')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->isForwardedTo('default', 'login');
+  })
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(200);
+    $response->checkElement('body', '/Login Required/i');
+  })
 ;
 
-$b->
-  get('/configSecurityIsSecureAction/Index')->
-  with('request')->begin()->
-    isForwardedTo('default', 'login')->
-  end()->
-  with('response')->begin()->
-    isStatusCode(200)->
-    checkElement('body', '/Login Required/i')->
-  end()
+$b->get('/configSecurityIsSecureAction/Index')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->isForwardedTo('default', 'login');
+  })
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(200);
+    $response->checkElement('body', '/Login Required/i');
+  })
 ;
 
 // Max forwards
-$b->
-  get('/configSettingsMaxForwards/selfForward')->
-  with('response')->isStatusCode(500)->
-  throwsException(null, '/Too many forwards have been detected for this request/i')
-;
+$b->get('/configSettingsMaxForwards/selfForward')
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(500);
+    $response->throwsException(null, '/Too many forwards have been detected for this request/i');
+  });
 
 // filters.yml: add a filter
-$b->
-  get('/configFiltersSimpleFilter')->
-  with('response')->begin()->
-    isStatusCode(200)->
-    checkElement('body', '/in a filter/i')->
-    checkElement('body', '!/congratulation/i')->
-  end()
+$b->get('/configFiltersSimpleFilter')
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(200);
+    $response->checkElement('body', '/in a filter/i');
+    $response->checkElement('body', '!/congratulation/i');
+  })
 ;
 
 // css and js inclusions
-$b->
-  get('/assetInclusion/index')->
-  with('response')->begin()->
-    isStatusCode(200)->
-    checkElement('head link[rel="stylesheet"]', false)->
-    checkElement('head script[type="text/javascript"]', false)->
-  end()
+$b->get('/assetInclusion/index')
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(200);
+    $response->checkElement('head link[rel="stylesheet"]', false);
+    $response->checkElement('head script[type="text/javascript"]', false);
+  })
 ;
 
 // renderText
-$b->
-  get('/renderText')->
-  with('response')->begin()->
-    isStatusCode(200)->
-    matches('/foo/')->
-  end()
+$b->get('/renderText')
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(200);
+    $response->matches('/foo/');
+  })
 ;
 
 // view.yml when changing template
-$b->
-  get('/view')->
-  with('response')->begin()->
-    isStatusCode(200)->
-    isHeader('Content-Type', 'text/html; charset=utf-8')->
-    checkElement('head title', 'foo title')->
-  end()
+$b->get('/view')
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(200);
+    $response->isHeader('Content-Type', 'text/html; charset=utf-8');
+    $response->checkElement('head title', 'foo title');
+  })
 ;
 
 // view.yml with other than default content-type
-$b->
-  get('/view/plain')->
-  with('response')->begin()->
-    isHeader('Content-Type', 'text/plain; charset=utf-8')->
-    isStatusCode(200)->
-    matches('/<head>/')->
-    matches('/plaintext/')->
-  end()
+$b->get('/view/plain')
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isHeader('Content-Type', 'text/plain; charset=utf-8');
+    $response->isStatusCode(200);
+    $response->matches('/<head>/');
+    $response->matches('/plaintext/');
+  })
 ;
 
 // view.yml with other than default content-type and no layout
-$b->
-  get('/view/image')->
-  with('response')->begin()->
-    isStatusCode(200)->
-    isHeader('Content-Type', 'image/jpg')->
-    matches('/image/')->
-  end()
+$b->get('/view/image')
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(200);
+    $response->isHeader('Content-Type', 'image/jpg');
+    $response->matches('/image/');
+  })
 ;
 
 // getPresentationFor()
-$b->
-  get('/presentation')->
-  with('response')->begin()->
-    isStatusCode(200)->
-    checkElement('#foo', 'foo')->
-    checkElement('#foo_bis', 'foo')->
-  end()
+$b->get('/presentation')
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(200);
+    $response->checkElement('#foo', 'foo');
+    $response->checkElement('#foo_bis', 'foo');
+  })
 ;

--- a/test/functional/i18nFormTest.php
+++ b/test/functional/i18nFormTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -17,63 +17,66 @@ if (!include(__DIR__.'/../bootstrap/functional.php'))
 $b = new sfTestBrowser();
 
 // default culture (en)
-$b->
-  get('/en/i18n/i18nForm')->
-  with('request')->begin()->
-    isParameter('module', 'i18n')->
-    isParameter('action', 'i18nForm')->
-  end()->
-  with('user')->isCulture('en')->
-  with('response')->begin()->
-    isStatusCode(200)->
-    checkElement('label', 'First name', array('position' => 0))->
-    checkElement('label', 'Last name', array('position' => 1))->
-    checkElement('label', 'Email address', array('position' => 2))->
-    checkElement('td', '/Put your first name here/i', array('position' => 0))->
-  end()->
-  setField('i18n[email]', 'foo/bar')->
-  click('Submit')->
-  with('response')->begin()->
-    checkElement('ul li', 'Required.', array('position' => 0))->
-    checkElement('ul li', 'foo/bar is an invalid email address', array('position' => 2))->
-  end()
+$b->get('/en/i18n/i18nForm')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->isParameter('module', 'i18n');
+    $request->isParameter('action', 'i18nForm');
+  })
+  ->with('user', function (sfTesterUser $user) {
+    $user->isCulture('en');
+  })
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(200);
+    $response->checkElement('label', 'First name', ['position' => 0]);
+    $response->checkElement('label', 'Last name', ['position' => 1]);
+    $response->checkElement('label', 'Email address', ['position' => 2]);
+    $response->checkElement('td', '/Put your first name here/i', ['position' => 0]);
+  })
+  ->setField('i18n[email]', 'foo/bar')
+  ->click('Submit')
+  ->with('response', function (sfTesterResponse $response) {
+    $response->checkElement('ul li', 'Required.', ['position' => 0]);
+    $response->checkElement('ul li', 'foo/bar is an invalid email address', ['position' => 2]);
+  })
 ;
 
 // changed culture (fr)
-$b->
-  get('/fr/i18n/i18nForm')->
-  with('request')->begin()->
-    isParameter('module', 'i18n')->
-    isParameter('action', 'i18nForm')->
-  end()->
-  with('user')->isCulture('fr')->
-  with('response')->begin()->
-    isStatusCode(200)->
-    checkElement('label', 'Prénom', array('position' => 0))->
-    checkElement('label', 'Nom', array('position' => 1))->
-    checkElement('label', 'Adresse email', array('position' => 2))->
-    checkElement('td', '/Mettez votre prénom ici/i', array('position' => 0))->
-  end()->
-  setField('i18n[email]', 'foo/bar')->
-  click('Submit')->
-  with('response')->begin()->
-    checkElement('ul li', 'Champ requis.', array('position' => 0))->
-    checkElement('ul li', 'foo/bar est une adresse email invalide', array('position' => 2))->
-  end()
+$b->get('/fr/i18n/i18nForm')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->isParameter('module', 'i18n');
+    $request->isParameter('action', 'i18nForm');
+  })
+  ->with('user', function (sfTesterUser $user) {
+    $user->isCulture('fr');
+  })
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(200);
+    $response->checkElement('label', 'Prénom', ['position' => 0]);
+    $response->checkElement('label', 'Nom', ['position' => 1]);
+    $response->checkElement('label', 'Adresse email', ['position' => 2]);
+    $response->checkElement('td', '/Mettez votre prénom ici/i', ['position' => 0]);
+  })
+  ->setField('i18n[email]', 'foo/bar')
+  ->click('Submit')
+  ->with('response', function (sfTesterResponse $response) {
+    $response->checkElement('ul li', 'Champ requis.', ['position' => 0]);
+    $response->checkElement('ul li', 'foo/bar est une adresse email invalide', ['position' => 2]);
+  })
 ;
 
 // forms label custom catalogue test
-$b->
-  get('/fr/i18n/i18nCustomCatalogueForm')->
-  with('request')->begin()->
-    isParameter('module', 'i18n')->
-    isParameter('action', 'i18nCustomCatalogueForm')->
-  end()->
-  with('user')->isCulture('fr')->
-  with('response')->begin()->
-    isStatusCode(200)->
-    checkElement('label', 'Prénom!!!', array('position' => 0))->
-    checkElement('label', 'Nom!!!', array('position' => 1))->
-    checkElement('label', 'Adresse email!!!', array('position' => 2))->
-  end()
+$b->get('/fr/i18n/i18nCustomCatalogueForm')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->isParameter('module', 'i18n');
+    $request->isParameter('action', 'i18nCustomCatalogueForm');
+  })
+  ->with('user', function (sfTesterUser $user) {
+    $user->isCulture('fr');
+  })
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(200);
+    $response->checkElement('label', 'Prénom!!!', ['position' => 0]);
+    $response->checkElement('label', 'Nom!!!', ['position' => 1]);
+    $response->checkElement('label', 'Adresse email!!!', ['position' => 2]);
+  })
 ;

--- a/test/functional/i18nTest.php
+++ b/test/functional/i18nTest.php
@@ -18,87 +18,93 @@ class myTestBrowser extends sfTestBrowser
 {
   public function checkResponseForCulture(string $culture = 'fr'): self
   {
-    return $this->
-      with('response')->begin()->
-        // messages in the global directories
-        checkElement('#action', '/une phrase en français/i')->
-        checkElement('#template', '/une phrase en français/i')->
+    return $this->with('response', function (sfTesterResponse $response) {
+      // messages in the global directories
+      $response->checkElement('#action', '/une phrase en français/i');
+      $response->checkElement('#template', '/une phrase en français/i');
 
-        // messages in the module directories
-        checkElement('#action_local', '/une phrase locale en français/i')->
-        checkElement('#template_local', '/une phrase locale en français/i')->
+      // messages in the module directories
+      $response->checkElement('#action_local', '/une phrase locale en français/i');
+      $response->checkElement('#template_local', '/une phrase locale en français/i');
 
-        // messages in another global catalogue
-        checkElement('#action_other', '/une autre phrase en français/i')->
-        checkElement('#template_other', '/une autre phrase en français/i')->
+      // messages in another global catalogue
+      $response->checkElement('#action_other', '/une autre phrase en français/i');
+      $response->checkElement('#template_other', '/une autre phrase en français/i');
 
-        // messages in another module catalogue
-        checkElement('#action_other_local', '/une autre phrase locale en français/i')->
-        checkElement('#template_other_local', '/une autre phrase locale en français/i')->
-      end()
-    ;
+      // messages in another module catalogue
+      $response->checkElement('#action_other_local', '/une autre phrase locale en français/i');
+      $response->checkElement('#template_other_local', '/une autre phrase locale en français/i');
+    });
   }
 }
 
 $b = new myTestBrowser();
 
 // default culture (en)
-$b->
-  get('/')->
-  with('request')->begin()->
-    isParameter('module', 'i18n')->
-    isParameter('action', 'index')->
-  end()->
-  with('response')->begin()->
-    isStatusCode(200)->
-    checkElement('#action', '/an english sentence/i')->
-    checkElement('#template', '/an english sentence/i')->
-  end()->
-  with('user')->isCulture('en')
+$b->get('/')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->isParameter('module', 'i18n');
+    $request->isParameter('action', 'index');
+  })
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(200);
+    $response->checkElement('#action', '/an english sentence/i');
+    $response->checkElement('#template', '/an english sentence/i');
+  })
+  ->with('user', function (sfTesterUser $user) {
+    $user->isCulture('en');
+  })
 ;
 
-$b->
-  get('/fr/i18n/index')->
-  with('request')->begin()->
-    isParameter('module', 'i18n')->
-    isParameter('action', 'index')->
-  end()->
-  with('response')->isStatusCode(200)->
-  with('user')->isCulture('fr')->
-  checkResponseForCulture('fr')
+$b->get('/fr/i18n/index')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->isParameter('module', 'i18n');
+    $request->isParameter('action', 'index');
+  })
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(200);
+  })
+  ->with('user', function (sfTesterUser $user) {
+    $user->isCulture('fr');
+  })
+  ->checkResponseForCulture('fr')
 ;
 
 // change user culture in the action
-$b->
-  get('/en/i18n/indexForFr')->
-  with('request')->begin()->
-    isParameter('module', 'i18n')->
-    isParameter('action', 'indexForFr')->
-  end()->
-  with('response')->isStatusCode(200)->
-  with('user')->isCulture('fr')->
-  checkResponseForCulture('fr')
+$b->get('/en/i18n/indexForFr')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->isParameter('module', 'i18n');
+    $request->isParameter('action', 'indexForFr');
+  })
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(200);
+  })
+  ->with('user', function (sfTesterUser $user) {
+    $user->isCulture('fr');
+  })
+  ->checkResponseForCulture('fr')
 ;
 
 // messages for a module plugin
-$b->
-  get('/fr/sfI18NPlugin/index')->
-  with('request')->begin()->
-    isParameter('module', 'sfI18NPlugin')->
-    isParameter('action', 'index')->
-  end()->
-  with('user')->isCulture('fr')->
-  with('response')->begin()->
-    isStatusCode(200)->
-    checkElement('#action', '/une phrase en français - from plugin/i')->
-    checkElement('#template', '/une phrase en français - from plugin/i')->
-    checkElement('#action_local', '/une phrase locale en français - from plugin/i')->
-    checkElement('#template_local', '/une phrase locale en français - from plugin/i')->
-    checkElement('#action_other', '/une autre phrase en français - from plugin but translation overridden in the module/i')->
-    checkElement('#template_other', '/une autre phrase en français - from plugin but translation overridden in the module/i')->
-    checkElement('#action_yetAnother', '/encore une autre phrase en français - from plugin but translation overridden in the application/i')->
-    checkElement('#template_yetAnother', '/encore une autre phrase en français - from plugin but translation overridden in the application/i')->
-    checkElement('#action_testForPluginI18N', '/une phrase en français depuis un plugin - global/i')->
-    checkElement('#template_testForPluginI18N', '/une phrase en français depuis un plugin - global/i')->
-  end()
+$b->get('/fr/sfI18NPlugin/index')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->isParameter('module', 'sfI18NPlugin');
+    $request->isParameter('action', 'index');
+  })
+  ->with('user', function (sfTesterUser $user) {
+    $user->isCulture('fr');
+  })
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(200);
+    $response->checkElement('#action', '/une phrase en français - from plugin/i');
+    $response->checkElement('#template', '/une phrase en français - from plugin/i');
+    $response->checkElement('#action_local', '/une phrase locale en français - from plugin/i');
+    $response->checkElement('#template_local', '/une phrase locale en français - from plugin/i');
+    $response->checkElement('#action_other', '/une autre phrase en français - from plugin but translation overridden in the module/i');
+    $response->checkElement('#template_other', '/une autre phrase en français - from plugin but translation overridden in the module/i');
+    $response->checkElement('#action_yetAnother', '/encore une autre phrase en français - from plugin but translation overridden in the application/i');
+    $response->checkElement('#template_yetAnother', '/encore une autre phrase en français - from plugin but translation overridden in the application/i');
+    $response->checkElement('#action_testForPluginI18N', '/une phrase en français depuis un plugin - global/i');
+    $response->checkElement('#template_testForPluginI18N', '/une phrase en français depuis un plugin - global/i');
+  })
 ;

--- a/test/functional/i18nTest.php
+++ b/test/functional/i18nTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -16,7 +16,7 @@ if (!include(__DIR__.'/../bootstrap/functional.php'))
 
 class myTestBrowser extends sfTestBrowser
 {
-  public function checkResponseForCulture($culture = 'fr')
+  public function checkResponseForCulture(string $culture = 'fr'): self
   {
     return $this->
       with('response')->begin()->

--- a/test/functional/prodTest.php
+++ b/test/functional/prodTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -18,65 +18,48 @@ if (!include(__DIR__.'/../bootstrap/functional.php'))
 $b = new sfTestBrowser();
 
 // default main page (without cache)
-$b->
-  get('/')->
-  with('request')->begin()->
-    isParameter('module', 'default')->
-    isParameter('action', 'index')->
-  end()->
-  with('response')->begin()->
-    isStatusCode(200)->
-    checkElement('body', '/congratulations/i')->
-  end()
-;
-
-// default main page (with cache)
-$b->
-  get('/')->
-  with('request')->begin()->
-    isParameter('module', 'default')->
-    isParameter('action', 'index')->
-  end()->
-  with('response')->begin()->
-    isStatusCode(200)->
-    checkElement('body', '/congratulations/i')->
-  end()
+$b->get('/')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->isParameter('module', 'default');
+    $request->isParameter('action', 'index');
+  })
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(200);
+    $response->checkElement('body', '/congratulations/i');
+  })
 ;
 
 // 404
-$b->
-  get('/nonexistant')->
-  with('request')->begin()->
-    isForwardedTo('default', 'error404')->
-  end()->
-  with('response')->begin()->
-    isStatusCode(404)->
-    checkElement('body', '!/congratulations/i')->
-    checkElement('link[href="/sf/sf_default/css/screen.css"]')->
-  end()
+$b->get('/nonexistant')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->isForwardedTo('default', 'error404');
+  })
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(404);
+    $response->checkElement('body', '!/congratulations/i');
+    $response->checkElement('link[href="/sf/sf_default/css/screen.css"]');
+  })
 ;
 
-$b->
-  get('/nonexistant/')->
-  with('request')->begin()->
-    isForwardedTo('default', 'error404')->
-  end()->
-  with('response')->begin()->
-    isStatusCode(404)->
-    checkElement('body', '!/congratulations/i')->
-    checkElement('link[href="/sf/sf_default/css/screen.css"]')->
-  end()
+$b->get('/nonexistant/')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->isForwardedTo('default', 'error404');
+  })
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(404);
+    $response->checkElement('body', '!/congratulations/i');
+    $response->checkElement('link[href="/sf/sf_default/css/screen.css"]');
+  })
 ;
 
 // unexistant action
-$b->
-  get('/default/nonexistantaction')->
-  with('request')->begin()->
-    isForwardedTo('default', 'error404')->
-  end()->
-  with('response')->begin()->
-    isStatusCode(404)->
-    checkElement('body', '!/congratulations/i')->
-    checkElement('link[href="/sf/sf_default/css/screen.css"]')->
-  end()
+$b->get('/default/nonexistantaction')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->isForwardedTo('default', 'error404');
+  })
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(404);
+    $response->checkElement('body', '!/congratulations/i');
+    $response->checkElement('link[href="/sf/sf_default/css/screen.css"]');
+  })
 ;

--- a/test/functional/sfTestBrowserTest.php
+++ b/test/functional/sfTestBrowserTest.php
@@ -16,8 +16,9 @@ if (!include(__DIR__.'/../bootstrap/functional.php'))
 
 class TestBrowser extends sfTestBrowser
 {
-  public $events = array();
-  public function listen(sfEvent $event)
+  public $events = [];
+
+  public function listen(sfEvent $event): void
   {
     $this->events[] = $event;
   }

--- a/test/functional/sfTestBrowserTest.php
+++ b/test/functional/sfTestBrowserTest.php
@@ -32,83 +32,93 @@ $b->get('/');
 $b->test()->is(count($b->events), 1, 'browser can connect to context.load_factories');
 
 // exceptions
-$b->
-  get('/exception/noException')->
-  with('request')->begin()->
-    isParameter('module', 'exception')->
-    isParameter('action', 'noException')->
-  end()->
+$b->get('/exception/noException')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->isParameter('module', 'exception');
+    $request->isParameter('action', 'noException');
+  })
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(200);
+    $response->matches('/foo/');
+  });
 
-  with('response')->begin()->
-    isStatusCode(200)->
-    matches('/foo/')->
-  end()->
+$b->get('/exception/throwsException')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->isParameter('module', 'exception');
+    $request->isParameter('action', 'throwsException');
+  })
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(500);
+  })
+  ->throwsException(Exception::class);
 
-  get('/exception/throwsException')->
-  with('request')->begin()->
-    isParameter('module', 'exception')->
-    isParameter('action', 'throwsException')->
-  end()->
-  with('response')->isStatusCode(500)->
-  throwsException('Exception')->
+$b->get('/exception/throwsException')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->isParameter('module', 'exception');
+    $request->isParameter('action', 'throwsException');
+  })
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(500);
+  })
+  ->throwsException(Exception::class, '/Exception message/');
 
-  get('/exception/throwsException')->
-  with('request')->begin()->
-    isParameter('module', 'exception')->
-    isParameter('action', 'throwsException')->
-  end()->
-  with('response')->isStatusCode(500)->
-  throwsException('Exception', '/Exception message/')->
+$b->get('/exception/throwsException')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->isParameter('module', 'exception');
+    $request->isParameter('action', 'throwsException');
+  })
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(500);
+  })
+  ->throwsException(Exception::class, '/message/');
 
-  get('/exception/throwsException')->
-  with('request')->begin()->
-    isParameter('module', 'exception')->
-    isParameter('action', 'throwsException')->
-  end()->
-  with('response')->isStatusCode(500)->
-  throwsException('Exception', '/message/')->
+$b->get('/exception/throwsException')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->isParameter('module', 'exception');
+    $request->isParameter('action', 'throwsException');
+  })
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(500);
+  })
+  ->throwsException(null, '!/sfException/');
 
-  get('/exception/throwsException')->
-  with('request')->begin()->
-    isParameter('module', 'exception')->
-    isParameter('action', 'throwsException')->
-  end()->
-  with('response')->isStatusCode(500)->
-  throwsException(null, '!/sfException/')->
+$b->get('/exception/throwsSfException')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->isParameter('module', 'exception');
+    $request->isParameter('action', 'throwsSfException');
+  })
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(500);
+  })
+  ->throwsException(sfException::class);
 
-  get('/exception/throwsSfException')->
-  with('request')->begin()->
-    isParameter('module', 'exception')->
-    isParameter('action', 'throwsSfException')->
-  end()->
-  with('response')->isStatusCode(500)->
-  throwsException('sfException')->
+$b->get('/exception/throwsSfException')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->isParameter('module', 'exception');
+    $request->isParameter('action', 'throwsSfException');
+  })
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(500);
+  })
+  ->throwsException(sfException::class, 'sfException message');
 
-  get('/exception/throwsSfException')->
-  with('request')->begin()->
-    isParameter('module', 'exception')->
-    isParameter('action', 'throwsSfException')->
-  end()->
-  with('response')->isStatusCode(500)->
-  throwsException('sfException', 'sfException message')
-;
+$b->get('/browser')
+  ->with('response', function (sfTesterResponse $response) {
+    $response->matches('/html/');
+    $response->checkElement('h1', 'html');
+  });
 
-$b->
-  get('/browser')->
-  with('response')->begin()->
-    matches('/html/')->
-    checkElement('h1', 'html')->
-  end()->
-
-  get('/browser/text')->
-  with('response')->begin()->
-    matches('/text/')->
-  end()
+$b->get('/browser/text')
+  ->with('response', function (sfTesterResponse $response) {
+    $response->matches('/text/');
+  })
 ;
 
 try
 {
-  $b->with('response')->checkElement('h1', 'text');
+  $b->with('response', function (sfTesterResponse $response) {
+    $response->checkElement('h1', 'text');
+  });
   $b->test()->fail('The DOM is not accessible if the response content type is not HTML');
 }
 catch (LogicException $e)
@@ -117,148 +127,184 @@ catch (LogicException $e)
 }
 
 // check response headers
-$b->
-  get('/browser/responseHeader')->
-  with('response')->begin()->
-    isStatusCode()->
-    isHeader('content-type', 'text/plain; charset=utf-8')->
-    isHeader('content-type', '#text/plain#')->
-    isHeader('content-type', '!#text/html#')->
-    isHeader('foo', 'bar')->
-    isHeader('foo', 'foobar')->
-  end()
+$b->get('/browser/responseHeader')
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(200);
+    $response->isHeader('content-type', 'text/plain; charset=utf-8');
+    $response->isHeader('content-type', '#text/plain#');
+    $response->isHeader('content-type', '!#text/html#');
+    $response->isHeader('foo', 'bar');
+    $response->isHeader('foo', 'foobar');
+  })
 ;
 
 // cookies
-$b->
-  setCookie('foo', 'bar')->
-  setCookie('bar', 'foo')->
-  setCookie('foofoo', 'foo', time() - 10)->
+$b->setCookie('foo', 'bar')
+  ->setCookie('bar', 'foo')
+  ->setCookie('foofoo', 'foo', time() - 10);
 
-  get('/cookie')->
-  with('request')->begin()->
-    hasCookie('foofoo', false)->
-    hasCookie('foo')->
-    isCookie('foo', 'bar')->
-    isCookie('foo', '/a/')->
-    isCookie('foo', '!/z/')->
-  end()->
-  with('response')->checkElement('p', 'bar.foo-')->
-  get('/cookie')->
-  with('request')->begin()->
-    hasCookie('foo')->
-    isCookie('foo', 'bar')->
-    isCookie('foo', '/a/')->
-    isCookie('foo', '!/z/')->
-  end()->
-  with('response')->checkElement('p', 'bar.foo-')->
-  removeCookie('foo')->
-  get('/cookie')->
-  with('request')->begin()->
-    hasCookie('foo', false)->
-    hasCookie('bar')->
-  end()->
-  with('response')->checkElement('p', '.foo-')->
-  clearCookies()->
-  get('/cookie')->
-  with('request')->begin()->
-    hasCookie('foo', false)->
-    hasCookie('bar', false)->
-  end()->
-  with('response')->checkElement('p', '.-')
+$b->get('/cookie')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->hasCookie('foofoo', false);
+    $request->hasCookie('foo');
+    $request->isCookie('foo', 'bar');
+    $request->isCookie('foo', '/a/');
+    $request->isCookie('foo', '!/z/');
+  })
+  ->with('response', function (sfTesterResponse $response) {
+    $response->checkElement('p', 'bar.foo-');
+  });
+
+$b->get('/cookie')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->hasCookie('foo');
+    $request->isCookie('foo', 'bar');
+    $request->isCookie('foo', '/a/');
+    $request->isCookie('foo', '!/z/');
+  })
+  ->with('response', function (sfTesterResponse $response) {
+    $response->checkElement('p', 'bar.foo-');
+  });
+
+$b->removeCookie('foo');
+
+$b->get('/cookie')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->hasCookie('foo', false);
+    $request->hasCookie('bar');
+  })
+  ->with('response', function (sfTesterResponse $response) {
+    $response->checkElement('p', '.foo-');
+  });
+
+$b->clearCookies();
+
+$b->get('/cookie')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->hasCookie('foo', false);
+    $request->hasCookie('bar', false);
+  })
+  ->with('response', function (sfTesterResponse $response) {
+    $response->checkElement('p', '.-');
+  })
 ;
 
-$b->
-  setCookie('foo', 'bar')->
-  setCookie('bar', 'foo')->
+$b->setCookie('foo', 'bar')
+  ->setCookie('bar', 'foo');
 
-  get('/cookie/setCookie')->
+$b->get('/cookie/setCookie');
 
-  get('/cookie')->
-  with('request')->begin()->
-    hasCookie('foo')->
-    isCookie('foo', 'bar')->
-    isCookie('foo', '/a/')->
-    isCookie('foo', '!/z/')->
-  end()->
-  with('response')->checkElement('p', 'bar.foo-barfoo')->
-  get('/cookie')->
-  with('request')->begin()->
-    hasCookie('foo')->
-    isCookie('foo', 'bar')->
-    isCookie('foo', '/a/')->
-    isCookie('foo', '!/z/')->
-  end()->
-  with('response')->checkElement('p', 'bar.foo-barfoo')->
-  removeCookie('foo')->
-  get('/cookie')->
-  with('request')->begin()->
-    hasCookie('foo', false)->
-    hasCookie('bar')->
-  end()->
-  with('response')->checkElement('p', '.foo-barfoo')->
+$b->get('/cookie')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->hasCookie('foo');
+    $request->isCookie('foo', 'bar');
+    $request->isCookie('foo', '/a/');
+    $request->isCookie('foo', '!/z/');
+  })
+  ->with('response', function (sfTesterResponse $response) {
+    $response->checkElement('p', 'bar.foo-barfoo');
+  });
 
-  get('/cookie/removeCookie')->
+$b->get('/cookie')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->hasCookie('foo');
+    $request->isCookie('foo', 'bar');
+    $request->isCookie('foo', '/a/');
+    $request->isCookie('foo', '!/z/');
+  })
+  ->with('response', function (sfTesterResponse $response) {
+    $response->checkElement('p', 'bar.foo-barfoo');
+  });
 
-  get('/cookie')->
-  with('request')->begin()->
-    hasCookie('foo', false)->
-    hasCookie('bar')->
-  end()->
-  with('response')->checkElement('p', '.foo-')->
+$b->removeCookie('foo');
 
-  get('/cookie/setCookie')->
+$b->get('/cookie')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->hasCookie('foo', false);
+    $request->hasCookie('bar');
+  })
+  ->with('response', function (sfTesterResponse $response) {
+    $response->checkElement('p', '.foo-barfoo');
+  });
 
-  clearCookies()->
-  get('/cookie')->
-  with('request')->begin()->
-    hasCookie('foo', false)->
-    hasCookie('bar', false)->
-  end()->
-  with('response')->checkElement('p', '.-')
-;
+$b->get('/cookie/removeCookie');
 
-$b->
-  get('/browser')->
-  with('request')->isMethod('get')->
-  post('/browser')->
-  with('request')->isMethod('post')->
-  call('/browser', 'put')->
-  with('request')->isMethod('put')
-;
+$b->get('/cookie')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->hasCookie('foo', false);
+    $request->hasCookie('bar');
+  })
+  ->with('response', function (sfTesterResponse $response) {
+    $response->checkElement('p', '.foo-');
+  });
+
+$b->get('/cookie/setCookie');
+
+$b->clearCookies();
+
+$b->get('/cookie')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->hasCookie('foo', false);
+    $request->hasCookie('bar', false);
+  })
+
+  ->with('response', function (sfTesterResponse $response) {
+    $response->checkElement('p', '.-');
+  });
+
+$b->get('/browser')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->isMethod('get');
+  });
+
+$b->post('/browser')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->isMethod('post');
+  });
+
+$b->call('/browser', 'put')
+  ->with('request', function (sfTesterRequest $request) {
+    $request->isMethod('put');
+  });
 
 // sfBrowser: clean the custom view templates
-$b->
-  get('/browser/templateCustom')->
-  with('response')->checkElement('#test', 'template')->
+$b->get('/browser/templateCustom')
+  ->with('response', function (sfTesterResponse $response) {
+    $response->checkElement('#test', 'template');
+  });
 
-  get('/browser/templateCustom/custom/1')->
-  with('response')->checkElement('#test', 'template 1')->
+$b->get('/browser/templateCustom/custom/1')
+  ->with('response', function (sfTesterResponse $response) {
+    $response->checkElement('#test', 'template 1');
+  });
 
-  get('/browser/templateCustom')->
-  with('response')->checkElement('#test', 'template')
-;
+$b->get('/browser/templateCustom')
+  ->with('response', function (sfTesterResponse $response) {
+    $response->checkElement('#test', 'template');
+  });
 
-$b
-  ->getAndCheck('browser', 'redirect1', null, 302)
-
-  ->followRedirect()
-
-  ->with('request')->begin()
-    ->isParameter('module', 'browser')
-    ->isParameter('action', 'redirectTarget1')
-  ->end()
-
-  ->with('response')->isStatusCode(200)
-
-  ->getAndCheck('browser', 'redirect2', null, 302)
+$b->getAndCheck('browser', 'redirect1', null, 302)
 
   ->followRedirect()
 
-  ->with('request')->begin()
-    ->isParameter('module', 'browser')
-    ->isParameter('action', 'redirectTarget2')
-  ->end()
+  ->with('request', function (sfTesterRequest $request) {
+    $request->isParameter('module', 'browser');
+    $request->isParameter('action', 'redirectTarget1');
+  })
 
-  ->with('response')->isStatusCode(200)
-;
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(200);
+  });
+
+$b->getAndCheck('browser', 'redirect2', null, 302)
+
+  ->followRedirect()
+
+  ->with('request', function (sfTesterRequest $request) {
+    $request->isParameter('module', 'browser');
+    $request->isParameter('action', 'redirectTarget2');
+  })
+
+  ->with('response', function (sfTesterResponse $response) {
+    $response->isStatusCode(200);
+  });

--- a/test/unit/test/sfTestFunctionalTest.php
+++ b/test/unit/test/sfTestFunctionalTest.php
@@ -34,7 +34,7 @@ class mockTestFunctional extends sfTestFunctional
 {
   public $called = array();
 
-  public function call($uri, $method = 'get', $parameters = array(), $changeStack = true)
+  public function call(string $uri, string $method = 'get', array $parameters = [], bool $changeStack = true): sfTestFunctionalBase
   {
     $this->called[] = func_get_args();
   }

--- a/test/unit/test/sfTestFunctionalTest.php
+++ b/test/unit/test/sfTestFunctionalTest.php
@@ -37,6 +37,8 @@ class mockTestFunctional extends sfTestFunctional
   public function call(string $uri, string $method = 'get', array $parameters = [], bool $changeStack = true): sfTestFunctionalBase
   {
     $this->called[] = func_get_args();
+
+    return $this;
   }
 }
 

--- a/test/unit/validator/sfValidatorFileTest.php
+++ b/test/unit/validator/sfValidatorFileTest.php
@@ -106,7 +106,7 @@ $v = new testValidatorFile();
 $t->is($v->guessFromFileBinary($tmpDir.'/test.txt'), 'text/plain', '->guessFromFileBinary() guesses the type of a given file');
 $t->is($v->guessFromFileBinary($tmpDir.'/foo.txt'), null, '->guessFromFileBinary() returns null if the file type is not guessable');
 $t->ok(
-  in_array($v->guessFromFileBinary('/bin/ls'), ['application/x-executable', 'application/octet-stream', 'application/x-sharedlib']),
+  in_array($v->guessFromFileBinary('/bin/ls'), ['application/x-executable', 'application/x-pie-executable', 'application/octet-stream', 'application/x-sharedlib']),
   '->guessFromFileBinary() returns correct type if file is guessable'
 );
 


### PR DESCRIPTION
- Refactor tests-related classes and utils
  * replace `->begin()` ... `->end()` blocks with closures
  * change signature of `sfTestFunctionalBase::with()` (BC break)
  * drop `sfTestFunctionalBase::begin()` (BC break)
  * drop `sfTestFunctionalBase::end()` (BC break)
  * drop `sfTester::prepare()` (BC break)
  * drop `sfTester::begin()` (BC break)
  * drop `sfTester::end()` (BC break)
  * drop `sfTester::getObjectToReturn()` (BC break)
  * drop default argument value from `sfTesterResponse::isStatusCode()`
  * drop second argument from `sfTesterResponse::check()`

- Declare `dom` and `libxml` extensions as dev dependencies

