### PR TITLE
Drop `ArrayAccess` from `sfContext` class

### DIFF
--- a/lib/util/sfContext.class.php
+++ b/lib/util/sfContext.class.php
@@ -22,30 +22,24 @@
  */
 class sfContext implements ArrayAccess
 {
-  /** @var sfEventDispatcher */
-  protected $dispatcher = null;
-  /** @var sfApplicationConfiguration */
-  protected $configuration = null;
-  /** @var array */
-  protected $mailerConfiguration = [];
-  /** @var array */
-  protected $serviceContainerConfiguration = [];
-  /** @var array */
-  protected $factories = [];
-  /** @var bool */
-  protected $hasShutdownUserAndStorage = false;
+  protected sfEventDispatcher $dispatcher;
+  protected sfApplicationConfiguration $configuration;
+  protected array $mailerConfiguration = [];
+  protected array $serviceContainerConfiguration = [];
+  protected array $factories = [];
+  protected bool $hasShutdownUserAndStorage = false;
 
-  /** @var \sfContext[] */
-  protected static $instances = [];
+  /** @var array<string,sfContext> */
+  protected static array $instances = [];
   /** @var string */
-  protected static $current = 'default';
+  protected static string $current = 'default';
 
   /**
    * Creates a new context instance.
    *
-   * @param  sfApplicationConfiguration $configuration  An sfApplicationConfiguration instance
-   * @param  string                     $name           A name for this context (application name by default)
-   * @param string                      $class          The context class to use (sfContext by default)
+   * @param sfApplicationConfiguration  $configuration An sfApplicationConfiguration instance
+   * @param string|null                 $name          A name for this context (application name by default)
+   * @param class-string                $class         The context class to use (sfContext by default)
    *
    * @return sfContext An sfContext instance
    *
@@ -94,11 +88,11 @@ class sfContext implements ArrayAccess
       sfException::createFromException($e)->printStackTrace();
     }
 
-    $this->dispatcher->connect('template.filter_parameters', array($this, 'filterTemplateParameters'));
-    $this->dispatcher->connect('response.fastcgi_finish_request', array($this, 'shutdownUserAndStorage'));
+    $this->dispatcher->connect('template.filter_parameters', [$this, 'filterTemplateParameters']);
+    $this->dispatcher->connect('response.fastcgi_finish_request', [$this, 'shutdownUserAndStorage']);
 
     // register our shutdown function
-    register_shutdown_function(array($this, 'shutdown'));
+    register_shutdown_function([$this, 'shutdown']);
   }
 
   /**
@@ -256,7 +250,7 @@ class sfContext implements ArrayAccess
    */
   public function getController(): ?sfFrontWebController
   {
-    return isset($this->factories['controller']) ? $this->factories['controller'] : null;
+    return $this->factories['controller'] ?? null;
   }
 
   /**
@@ -293,7 +287,7 @@ class sfContext implements ArrayAccess
   {
     if (!isset($this->factories['logger']))
     {
-      $this->factories['logger'] = new sfNoLogger($this->dispatcher);
+      $this->factories['logger'] = new sfNoLogger();
     }
 
     return $this->factories['logger'];
@@ -330,7 +324,7 @@ class sfContext implements ArrayAccess
    */
   public function getDatabaseManager(): ?sfDatabaseManager
   {
-    return isset($this->factories['databaseManager']) ? $this->factories['databaseManager'] : null;
+    return $this->factories['databaseManager'] ?? null;
   }
 
   /**
@@ -374,7 +368,7 @@ class sfContext implements ArrayAccess
    */
   public function getRequest(): ?sfRequest
   {
-    return isset($this->factories['request']) ? $this->factories['request'] : null;
+    return $this->factories['request'] ?? null;
   }
 
   /**
@@ -384,7 +378,7 @@ class sfContext implements ArrayAccess
    */
   public function getResponse(): ?sfResponse
   {
-    return isset($this->factories['response']) ? $this->factories['response'] : null;
+    return $this->factories['response'] ?? null;
   }
 
   /**
@@ -406,7 +400,7 @@ class sfContext implements ArrayAccess
    */
   public function getStorage(): ?sfStorage
   {
-    return isset($this->factories['storage']) ? $this->factories['storage'] : null;
+    return $this->factories['storage'] ?? null;
   }
 
   /**
@@ -433,7 +427,7 @@ class sfContext implements ArrayAccess
    */
   public function getRouting(): ?sfRouting
   {
-    return isset($this->factories['routing']) ? $this->factories['routing'] : null;
+    return $this->factories['routing'] ?? null;
   }
 
   /**
@@ -443,7 +437,7 @@ class sfContext implements ArrayAccess
    */
   public function getUser(): ?sfUser
   {
-    return isset($this->factories['user']) ? $this->factories['user'] : null;
+    return $this->factories['user'] ?? null;
   }
 
   /**

--- a/lib/util/sfContext.class.php
+++ b/lib/util/sfContext.class.php
@@ -567,34 +567,6 @@ class sfContext
   }
 
   /**
-   * The method name will be parsed to magically handle getMyFactory() and setMyFactory() methods.
-   *
-   * @param  string $method     The method name
-   * @param  array  $arguments  The method arguments
-   *
-   * @return mixed The returned value of the called method
-   *
-   * @throws <b>sfException</b> if call fails
-   */
-  public function __call($method, $arguments)
-  {
-    $verb = substr($method, 0, 3); // get | set
-    $factory = strtolower(substr($method, 3)); // factory name
-
-    if ('get' == $verb && $this->has($factory))
-    {
-      return $this->factories[$factory];
-    }
-    else if ('set' == $verb && isset($arguments[0]))
-    {
-      $this->set($factory, $arguments[0]);
-      return null;
-    }
-
-    throw new sfException(sprintf('Call to undefined method %s::%s.', get_class($this), $method));
-  }
-
-  /**
    * Execute the shutdown procedure.
    *
    * @return void

--- a/lib/util/sfContext.class.php
+++ b/lib/util/sfContext.class.php
@@ -20,7 +20,7 @@
  * @author     Sean Kerr <sean@code-box.org>
  * @version    SVN: $Id$
  */
-class sfContext implements ArrayAccess
+class sfContext
 {
   protected sfEventDispatcher $dispatcher;
   protected sfApplicationConfiguration $configuration;
@@ -489,51 +489,6 @@ class sfContext implements ArrayAccess
   public function getConfigCache(): sfConfigCache
   {
     return $this->configuration->getConfigCache();
-  }
-
-  /**
-   * Returns true if the context object exists (implements the ArrayAccess interface).
-   *
-   * @param  string $name The name of the context object
-   *
-   * @return Boolean true if the context object exists, false otherwise
-   */
-  public function offsetExists($name)
-  {
-    return $this->has($name);
-  }
-
-  /**
-   * Returns the context object associated with the name (implements the ArrayAccess interface).
-   *
-   * @param  string $name  The offset of the value to get
-   *
-   * @return mixed The context object if exists, null otherwise
-   */
-  public function offsetGet($name)
-  {
-    return $this->get($name);
-  }
-
-  /**
-   * Sets the context object associated with the offset (implements the ArrayAccess interface).
-   *
-   * @param string $offset Service name
-   * @param mixed  $value Service
-   */
-  public function offsetSet($offset, $value)
-  {
-    $this->set($offset, $value);
-  }
-
-  /**
-   * Unsets the context object associated with the offset (implements the ArrayAccess interface).
-   *
-   * @param string $offset The parameter name
-   */
-  public function offsetUnset($offset)
-  {
-    unset($this->factories[$offset]);
   }
 
   /**

--- a/test/functional/sfContextTest.php
+++ b/test/functional/sfContextTest.php
@@ -12,7 +12,7 @@ $app = 'frontend';
 require_once(__DIR__.'/../bootstrap/unit.php');
 require_once(__DIR__.'/../bootstrap/functional.php');
 
-$t = new lime_test(24);
+$t = new lime_test(21);
 
 class myContext extends sfContext
 {
@@ -72,22 +72,6 @@ try
 catch (sfException $e)
 {
   $t->pass('->get() throws an sfException if no object is stored for the given name');
-}
-
-$t->diag('->__call()');
-
-$context->setFoo4($i18n_context);
-$t->is($context->has('foo4'), true, '->__call() sets context objects by name using setName()');
-$t->isa_ok($context->getFoo4(), 'sfContext', '->__call() returns context objects by name using getName()');
-
-try
-{
-  $context->unknown();
-  $t->fail('->__call() throws an sfException if factory / method does not exist');
-}
-catch (sfException $e)
-{
-  $t->pass('->__call() throws an sfException if factory / method does not exist');
 }
 
 $t->diag('->getServiceContainer() test');

--- a/test/functional/sfContextTest.php
+++ b/test/functional/sfContextTest.php
@@ -12,7 +12,7 @@ $app = 'frontend';
 require_once(__DIR__.'/../bootstrap/unit.php');
 require_once(__DIR__.'/../bootstrap/functional.php');
 
-$t = new lime_test(29);
+$t = new lime_test(24);
 
 class myContext extends sfContext
 {
@@ -73,18 +73,6 @@ catch (sfException $e)
 {
   $t->pass('->get() throws an sfException if no object is stored for the given name');
 }
-
-$context['foo'] = $frontend_context;
-$t->diag('Array access for context objects');
-$t->is(isset($context['foo']), true, '->offsetExists() returns true if context object exists');
-$t->is(isset($context['foo2']), false, '->offsetExists() returns false if context object does not exist');
-$t->isa_ok($context['foo'], 'sfContext', '->offsetGet() returns attribute by name');
-
-$context['foo2'] = $i18n_context;
-$t->isa_ok($context['foo2'], 'sfContext', '->offsetSet() sets object by name');
-
-unset($context['foo2']);
-$t->is(isset($context['foo2']), false, '->offsetUnset() unsets object by name');
 
 $t->diag('->__call()');
 


### PR DESCRIPTION
- Drop `ArrayAccess` interface implementation
- Drop magic `__call` handler