### PR TITLE
Allow PHP8+

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ '7.4' ]
+        php: [ '7.4', '8.0', '8.1' ]
 
     steps:
       - uses: actions/checkout@master

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Fork of symfony 1.4 with dic, form enhancements, latest swiftmailer and better performance",
     "license": "MIT",
     "require": {
-        "php": ">=7.4,<7.5",
+        "php": ">=7.4",
         "swiftmailer/swiftmailer": "~5.2",
         "symfony/yaml": "^3.4|^4.0|^5.0"
     },

--- a/lib/cache/sfFileCache.class.php
+++ b/lib/cache/sfFileCache.class.php
@@ -256,7 +256,7 @@ class sfFileCache extends sfCache
         fseek($fp, 0, SEEK_END);
         $length = ftell($fp) - 24;
         fseek($fp, 24);
-        $data[self::READ_DATA] = @fread($fp, $length);
+        $data[self::READ_DATA] = $length ? @fread($fp, $length) : '';
       }
     }
     else

--- a/lib/escaper/sfOutputEscaperArrayDecorator.class.php
+++ b/lib/escaper/sfOutputEscaperArrayDecorator.class.php
@@ -30,7 +30,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
     parent::__construct($escapingMethod, $value);
   }
 
-  public function getIterator()
+  public function getIterator(): Traversable
   {
     foreach ($this->value as $key => $value) {
       yield $key => sfOutputEscaper::escape($this->escapingMethod, $value);
@@ -44,7 +44,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
    *
    * @return bool true if the offset isset; false otherwise
    */
-  public function offsetExists($offset)
+  public function offsetExists($offset): bool
   {
     return isset($this->value[$offset]);
   }
@@ -56,6 +56,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
    *
    * @return mixed The escaped value
    */
+  #[\ReturnTypeWillChange]
   public function offsetGet($offset)
   {
     return sfOutputEscaper::escape($this->escapingMethod, $this->value[$offset]);
@@ -73,6 +74,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
    *
    * @throws sfException
    */
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
     throw new sfException('Cannot set values.');
@@ -89,7 +91,8 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
    *
    * @throws sfException
    */
-  public function offsetUnset($offset)
+  #[\ReturnTypeWillChange]
+  public function offsetUnset($offset): void
   {
     throw new sfException('Cannot unset values.');
   }
@@ -99,7 +102,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
    *
    * @return int The size of the array
    */
-  public function count()
+  public function count(): int
   {
     return count($this->value);
   }

--- a/lib/i18n/sfCultureInfo.class.php
+++ b/lib/i18n/sfCultureInfo.class.php
@@ -92,11 +92,11 @@ class sfCultureInfo
    * @var sfNumberFormatInfo
    */
   protected $numberFormat;
-  
+
   /**
    * A list of properties that are accessable/writable.
    * @var array
-   */ 
+   */
   protected $properties = array();
 
   /**
@@ -191,9 +191,9 @@ class sfCultureInfo
   }
 
   /**
-   * Initializes a new instance of the sfCultureInfo class based on the 
+   * Initializes a new instance of the sfCultureInfo class based on the
    * culture specified by name. E.g. <code>new sfCultureInfo('en_AU');</code>
-   * The culture indentifier must be of the form 
+   * The culture indentifier must be of the form
    * "<language>_(country/region/variant)".
    *
    * @param string $culture a culture name, e.g. "en_AU".
@@ -323,7 +323,7 @@ class sfCultureInfo
    * this function.
    *
    * @param string $filename the ICU data filename
-   * @return array ICU data 
+   * @return array ICU data
    */
   protected function &getData($filename)
   {
@@ -347,7 +347,7 @@ class sfCultureInfo
    * Use merge=true to return the ICU including the parent culture.
    * E.g. The currency data for a variant, say "en_AU" contains one
    * entry, the currency for AUD, the other currency data are stored
-   * in the "en" data file. Thus to retrieve all the data regarding 
+   * in the "en" data file. Thus to retrieve all the data regarding
    * currency for "en_AU", you need to use findInfo("Currencies,true);.
    *
    * @param string  $path   the data you want to find.
@@ -429,9 +429,9 @@ class sfCultureInfo
       }
     }
   }
-  
+
   /**
-   * Gets the culture name in the format 
+   * Gets the culture name in the format
    * "<languagecode2>_(country/regioncode2)".
    *
    * @return string culture name.
@@ -504,10 +504,8 @@ class sfCultureInfo
 
   /**
    * Gets the culture name in English.
-   * Returns <code>array('Language','Country');</code>
-   * 'Country' is omitted if the culture is neutral.
    *
-   * @return array array with language and country as elements.
+   * @return string
    */
   public function getEnglishName()
   {
@@ -516,8 +514,7 @@ class sfCultureInfo
     $culture = $this->getInvariantCulture();
 
     $language = $culture->findInfo("Languages/{$lang}");
-    if (count($language) == 0)
-    {
+    if (empty($language)) {
       return $this->culture;
     }
 
@@ -547,7 +544,7 @@ class sfCultureInfo
   }
 
   /**
-   * Gets a value indicating whether the current sfCultureInfo 
+   * Gets a value indicating whether the current sfCultureInfo
    * represents a neutral culture. Returns true if the culture
    * only contains two characters.
    *
@@ -590,7 +587,7 @@ class sfCultureInfo
   }
 
   /**
-   * Gets the sfCultureInfo that represents the parent culture of the 
+   * Gets the sfCultureInfo that represents the parent culture of the
    * current sfCultureInfo
    *
    * @return sfCultureInfo parent culture information.
@@ -606,14 +603,14 @@ class sfCultureInfo
   }
 
   /**
-   * Gets the list of supported cultures filtered by the specified 
+   * Gets the list of supported cultures filtered by the specified
    * culture type. This is an EXPENSIVE function, it needs to traverse
    * a list of ICU files in the data directory.
    * This function can be called statically.
    *
    * @param int $type culture type, sfCultureInfo::ALL, sfCultureInfo::NEUTRAL
    * or sfCultureInfo::SPECIFIC.
-   * @return array list of culture information available. 
+   * @return array list of culture information available.
    */
   static function getCultures($type = sfCultureInfo::ALL)
   {
@@ -719,7 +716,7 @@ class sfCultureInfo
    *
    * @param  array $countries An array of countries used to restrict the returned array (null by default, which means all countries)
    *
-   * @return array a list of localized country names. 
+   * @return array a list of localized country names.
    */
   public function getCountries($countries = null)
   {

--- a/lib/i18n/sfI18N.class.php
+++ b/lib/i18n/sfI18N.class.php
@@ -267,7 +267,7 @@ class sfI18N
     [$day, $month, $year] = $this->getDateForCulture($dateTime, null === $culture ? $this->culture : $culture);
     [$hour, $minute] = $this->getTimeForCulture($dateTime, null === $culture ? $this->culture : $culture);
 
-    return null === $day ? null : mktime($hour, $minute, 0, $month, $day, $year);
+    return null === $day ? null : mktime($hour ?: 0, $minute ?: 0, 0, $month, $day, $year);
   }
 
   /**
@@ -332,7 +332,7 @@ class sfI18N
     $timeFormat = $timeFormatInfo->getShortTimePattern();
 
     // We construct the regexp based on time format
-    $timeRegexp = preg_replace(array('/[hm]+/i', '/a/'), array('(\d+)', '(\w+)'), preg_quote($timeFormat));
+    $timeRegexp = preg_replace(['/[hm]+/i', '/a/'], ['(\d+)', '(\w+)'], preg_quote($timeFormat));
 
     // We parse time format to see where things are (h, m)
     $timePositions = [

--- a/lib/log/sfFileLogger.class.php
+++ b/lib/log/sfFileLogger.class.php
@@ -23,7 +23,7 @@ class sfFileLogger extends sfLogger
   /** @var string */
   protected $format = '%time% %type% [%priority%] %message%%EOL%';
   /** @var string */
-  protected $timeFormat = '%b %d %H:%M:%S';
+  protected $timeFormat = 'M d H:i:s';
   /** @var resource */
   protected $fp;
 
@@ -35,7 +35,7 @@ class sfFileLogger extends sfLogger
    * - file:        The file path or a php wrapper to log messages
    *                You can use any support php wrapper. To write logs to the Apache error log, use php://stderr
    * - format:      The log line format (default to %time% %type% [%priority%] %message%%EOL%)
-   * - time_format: The log time strftime format (default to %b %d %H:%M:%S)
+   * - time_format: The log time using `date()` format (default to `M d H:i:s`)
    * - dir_mode:    The mode to use when creating a directory (default to 0777)
    * - file_mode:   The mode to use when creating a file (default to 0666)
    *
@@ -91,7 +91,7 @@ class sfFileLogger extends sfLogger
     fwrite($this->fp, strtr($this->format, array(
       '%type%'     => $this->type,
       '%message%'  => $message,
-      '%time%'     => strftime($this->timeFormat),
+      '%time%'     => date($this->timeFormat),
       '%priority%' => $this->getPriority($priority),
       '%EOL%'      => PHP_EOL,
     )));

--- a/lib/request/sfWebRequest.class.php
+++ b/lib/request/sfWebRequest.class.php
@@ -213,11 +213,11 @@ class sfWebRequest extends sfRequest
     // for IIS with rewrite module (IIFR, ISAPI Rewrite, ...)
     if ('HTTP_X_REWRITE_URL' == $this->getOption('path_info_key'))
     {
-      $uri = isset($pathArray['HTTP_X_REWRITE_URL']) ? $pathArray['HTTP_X_REWRITE_URL'] : '';
+      $uri = $pathArray['HTTP_X_REWRITE_URL'] ?? '';
     }
     else
     {
-      $uri = isset($pathArray['REQUEST_URI']) ? $pathArray['REQUEST_URI'] : '';
+      $uri = $pathArray['REQUEST_URI'] ?? '';
     }
 
     return $this->isAbsUri() ? $uri : $this->getUriPrefix().$uri;
@@ -232,7 +232,7 @@ class sfWebRequest extends sfRequest
   {
     $pathArray = $this->getPathInfoArray();
 
-    return isset($pathArray['REQUEST_URI']) ? 0 === strpos($pathArray['REQUEST_URI'], 'http') : false;
+    return 0 === strpos($pathArray['REQUEST_URI'] ?? '', 'http');
   }
 
   /**
@@ -294,7 +294,7 @@ class sfWebRequest extends sfRequest
     {
       if (isset($pathArray['REQUEST_URI']))
       {
-        $qs = isset($pathArray['QUERY_STRING']) ? $pathArray['QUERY_STRING'] : '';
+        $qs = $pathArray['QUERY_STRING'] ?? '';
         $script_name = $this->getScriptName();
         $uri_prefix = $this->isAbsUri() ? $this->getUriPrefix() : '';
         $pathInfo = preg_replace('/^'.preg_quote($uri_prefix, '/').'/','',$pathArray['REQUEST_URI']);
@@ -663,10 +663,8 @@ class sfWebRequest extends sfRequest
   {
     if (null === $this->relativeUrlRoot)
     {
-      if (!($this->relativeUrlRoot = $this->getOption('relative_url_root')))
-      {
-        $this->relativeUrlRoot = preg_replace('#/[^/]+\.php5?$#', '', $this->getScriptName());
-      }
+      $this->relativeUrlRoot = $this->getOption('relative_url_root')
+        ?: preg_replace('#/[^/]+\.php5?$#', '', $this->getScriptName());
     }
 
     return $this->relativeUrlRoot;

--- a/lib/request/sfWebRequest.class.php
+++ b/lib/request/sfWebRequest.class.php
@@ -193,7 +193,7 @@ class sfWebRequest extends sfRequest
   {
     $contentType = $this->getHttpHeader('Content-Type', null);
 
-    if ($trim && false !== $pos = strpos($contentType, ';'))
+    if ($contentType && $trim && false !== $pos = strpos($contentType, ';'))
     {
       $contentType = substr($contentType, 0, $pos);
     }

--- a/lib/response/sfWebResponse.class.php
+++ b/lib/response/sfWebResponse.class.php
@@ -122,7 +122,7 @@ class sfWebResponse extends sfResponse
     $this->options['charset'] = $this->options['charset'] ?? 'utf-8';
     $this->options['send_http_headers'] = $this->options['send_http_headers'] ?? true;
     $this->options['http_protocol'] = $this->options['http_protocol'] ?? 'HTTP/1.0';
-    $this->options['content_type'] = $this->fixContentType(isset($this->options['content_type']) ? $this->options['content_type'] : 'text/html');
+    $this->options['content_type'] = $this->fixContentType($this->options['content_type'] ?? 'text/html');
   }
 
   /**
@@ -256,8 +256,8 @@ class sfWebResponse extends sfResponse
 
     if (!$replace)
     {
-      $current = isset($this->headers[$name]) ? $this->headers[$name] : '';
-      $value = ($current ? $current.', ' : '').$value;
+      $current = $this->headers[$name] ?? '';
+      $value = ($current ? $current . ', ' : '') . $value;
     }
 
     $this->headers[$name] = $value;
@@ -275,7 +275,7 @@ class sfWebResponse extends sfResponse
   {
     $name = $this->normalizeHeaderName($name);
 
-    return isset($this->headers[$name]) ? $this->headers[$name] : $default;
+    return $this->headers[$name] ?? $default;
   }
 
   /**
@@ -486,7 +486,7 @@ class sfWebResponse extends sfResponse
       foreach (preg_split('/\s*,\s*/', $cacheControl) as $tmp)
       {
         $tmp = explode('=', $tmp);
-        $currentHeaders[$tmp[0]] = isset($tmp[1]) ? $tmp[1] : null;
+        $currentHeaders[$tmp[0]] = $tmp[1] ?? null;
       }
     }
     $currentHeaders[str_replace('_', '-', strtolower($name))] = $value;
@@ -537,7 +537,7 @@ class sfWebResponse extends sfResponse
     }
     elseif (!$replace)
     {
-      $current = isset($this->httpMetas[$key]) ? $this->httpMetas[$key] : '';
+      $current = $this->httpMetas[$key] ?? '';
       $value = ($current ? $current.', ' : '').$value;
     }
 
@@ -580,7 +580,7 @@ class sfWebResponse extends sfResponse
       $value = htmlspecialchars($value, ENT_QUOTES, $this->options['charset']);
     }
 
-    $current = isset($this->metas[$key]) ? $this->metas[$key] : null;
+    $current = $this->metas[$key] ?? null;
     if ($replace || !$current)
     {
       $this->metas[$key] = $value;
@@ -594,7 +594,7 @@ class sfWebResponse extends sfResponse
    */
   public function getTitle(): string
   {
-    return isset($this->metas['title']) ? $this->metas['title'] : '';
+    return $this->metas['title'] ?? '';
   }
 
   /**
@@ -856,7 +856,7 @@ class sfWebResponse extends sfResponse
 
     // HTTP protocol must be from the current request
     // this fix is not nice but that's the only way to fix it and keep BC (see #9254)
-    $this->options['http_protocol'] = isset($_SERVER['SERVER_PROTOCOL']) ? $_SERVER['SERVER_PROTOCOL'] : 'HTTP/1.0';
+    $this->options['http_protocol'] = $_SERVER['SERVER_PROTOCOL'] ?? 'HTTP/1.0';
   }
 
   /**

--- a/lib/routing/sfRoute.class.php
+++ b/lib/routing/sfRoute.class.php
@@ -235,7 +235,9 @@ class sfRoute
     {
       // replace variables
       $variables = $this->variables;
-      uasort($variables, array('sfRoute', 'generateCompareVarsByStrlen'));
+
+      uasort($variables, fn ($a, $b) => strlen($b) <=> strlen($a));
+
       foreach ($variables as $variable => $value)
       {
         $url = str_replace($value, urlencode($tparams[$variable]), $url);
@@ -260,11 +262,6 @@ class sfRoute
     }
 
     return $url;
-  }
-
-  static private function generateCompareVarsByStrlen($a, $b)
-  {
-    return strlen($a) < strlen($b);
   }
 
   /**

--- a/lib/storage/sfCacheSessionStorage.class.php
+++ b/lib/storage/sfCacheSessionStorage.class.php
@@ -83,7 +83,7 @@ class sfCacheSessionStorage extends sfStorage
 
     $cookie = $this->request->getCookie($this->options['session_name']);
 
-    if(strpos($cookie, ':') !== false)
+    if(strpos($cookie ?? '', ':') !== false)
     {
       // split cookie data id:signature(id+secret)
       [$id, $signature] = explode(':', $cookie, 2);

--- a/lib/util/sfBrowserBase.class.php
+++ b/lib/util/sfBrowserBase.class.php
@@ -372,7 +372,7 @@ abstract class sfBrowserBase
       }
       else
       {
-        @$this->dom->loadHTML($response->getContent());
+        @$this->dom->loadHTML($response->getContent() ?: '<html></html>');
       }
       $this->domCssSelector = new sfDomCssSelector($this->dom);
     }

--- a/lib/util/sfDomCssSelector.class.php
+++ b/lib/util/sfDomCssSelector.class.php
@@ -571,7 +571,7 @@ class sfDomCssSelector implements Countable, IteratorAggregate
    *
    * @param integer The number of matching nodes
    */
-  public function count()
+  public function count(): int
   {
     return count($this->nodes);
   }

--- a/test/functional/fixtures/apps/frontend/config/frontendConfiguration.class.php
+++ b/test/functional/fixtures/apps/frontend/config/frontendConfiguration.class.php
@@ -11,7 +11,7 @@ class frontendConfiguration extends sfApplicationConfiguration
 
   public function filter_parameters(sfEvent $event, array $parameters): array
   {
-    if (false !== stripos($event->getSubject()->getHttpHeader('user-agent'), 'iPhone'))
+    if (stripos($event->getSubject()->getHttpHeader('user-agent') ?? '', 'iPhone') !== false)
     {
       $event->getSubject()->setRequestFormat('iphone');
     }

--- a/test/unit/log/sfFileLoggerTest.php
+++ b/test/unit/log/sfFileLoggerTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -59,28 +59,28 @@ class TestLogger extends sfFileLogger
 // option: format
 $t->diag('option: format');
 unlink($file);
-$logger = new TestLogger($dispatcher, array('file' => $file));
+$logger = new TestLogger($dispatcher, ['file' => $file]);
 $logger->log('foo');
-$t->is(file_get_contents($file), strftime($logger->getTimeFormat()).' symfony [*6*] foo'.PHP_EOL, '->initialize() can take a format option');
+$t->is(file_get_contents($file), date($logger->getTimeFormat()).' symfony [*6*] foo'.PHP_EOL, '->initialize() can take a format option');
 
 unlink($file);
-$logger = new TestLogger($dispatcher, array('file' => $file, 'format' => '%message%'));
+$logger = new TestLogger($dispatcher, ['file' => $file, 'format' => '%message%']);
 $logger->log('foo');
 $t->is(file_get_contents($file), 'foo', '->initialize() can take a format option');
 
 // option: time_format
 $t->diag('option: time_format');
 unlink($file);
-$logger = new TestLogger($dispatcher, array('file' => $file, 'time_format' => '%Y %m %d'));
+$logger = new TestLogger($dispatcher, ['file' => $file, 'time_format' => '%Y %m %d']);
 $logger->log('foo');
-$t->is(file_get_contents($file), strftime($logger->getTimeFormat()).' symfony [*6*] foo'.PHP_EOL, '->initialize() can take a format option');
+$t->is(file_get_contents($file), date($logger->getTimeFormat()).' symfony [*6*] foo'.PHP_EOL, '->initialize() can take a format option');
 
 // option: type
 $t->diag('option: type');
 unlink($file);
-$logger = new TestLogger($dispatcher, array('file' => $file, 'type' => 'foo'));
+$logger = new TestLogger($dispatcher, ['file' => $file, 'type' => 'foo']);
 $logger->log('foo');
-$t->is(file_get_contents($file), strftime($logger->getTimeFormat()).' foo [*6*] foo'.PHP_EOL, '->initialize() can take a format option');
+$t->is(file_get_contents($file), date($logger->getTimeFormat()).' foo [*6*] foo'.PHP_EOL, '->initialize() can take a format option');
 
 // ->shutdown()
 $t->diag('->shutdown()');

--- a/test/unit/response/sfWebResponseTest.php
+++ b/test/unit/response/sfWebResponseTest.php
@@ -132,7 +132,7 @@ $t->is($response->getContentType(), $response->getHttpHeader('content-type'), '-
 
 $response->setContentType('text/xml');
 $response->setContentType('text/html');
-$t->is(count($response->getHttpHeader('content-type')), 1, '->setContentType() overrides previous content type if replace is true');
+$t->ok(strpos($response->getHttpHeader('content-type'), 'text/html') === 0, '->setContentType() overrides previous content type if replace is true');
 
 // ->getTitle() ->setTitle() ->prependTitle
 $t->diag('->getTitle() ->setTitle() ->prependTitle()');

--- a/test/unit/validator/sfValidatorErrorSchemaTest.php
+++ b/test/unit/validator/sfValidatorErrorSchemaTest.php
@@ -183,7 +183,7 @@ class NotSerializable
     throw new Exception('Not serializable');
   }
 
-  public function __unserialize()
+  public function __unserialize($data)
   {
     throw new Exception('Not serializable');
   }

--- a/test/unit/validator/sfValidatorErrorTest.php
+++ b/test/unit/validator/sfValidatorErrorTest.php
@@ -61,7 +61,7 @@ class NotSerializable
     throw new Exception('Not serializable');
   }
 
-  public function __unserialize()
+  public function __unserialize($data)
   {
     throw new Exception('Not serializable');
   }


### PR DESCRIPTION
- allow PHP8.0+ in composer.json
- add PHP8.0 and PHP8.1 to the test matrix
- switch `sfFileLogger` to using `date()` instead of deprecated `strftime` 
  (BC break: `time_format` option changes format)
- fix `uasort` comparison function returning `bool` instead of `int`
- fix type imcompatibilities with PHP8
- fix warnings on deprecated spec calls