### PR TITLE
Refactor - Drop `#[AllowDynamicProperties]` annotations

### DIFF
--- a/lib/service/sfServiceContainerBuilder.class.php
+++ b/lib/service/sfServiceContainerBuilder.class.php
@@ -16,13 +16,11 @@
  * @author     Fabien Potencier <fabien.potencier@symfony-project.com>
  * @version    SVN: $Id: sfServiceContainerBuilder.php 269 2009-03-26 20:39:16Z fabien $
  */
-#[AllowDynamicProperties]
 class sfServiceContainerBuilder extends sfServiceContainer
 {
-  protected
-    $definitions = array(),
-    $aliases     = array(),
-    $loading     = array();
+  protected $definitions = [];
+  protected $aliases     = [];
+  protected $loading     = [];
 
   /**
    * Sets a service.

--- a/lib/task/sfCommandApplicationTask.class.php
+++ b/lib/task/sfCommandApplicationTask.class.php
@@ -18,7 +18,6 @@
  *
  * @property sfApplicationConfiguration $configuration
  */
-#[AllowDynamicProperties]
 abstract class sfCommandApplicationTask extends sfTask
 {
   /** @var sfSymfonyCommandApplication */

--- a/lib/util/sfBrowser.class.php
+++ b/lib/util/sfBrowser.class.php
@@ -16,7 +16,6 @@
  * @author     Fabien Potencier <fabien.potencier@symfony-project.com>
  * @version    SVN: $Id$
  */
-#[AllowDynamicProperties]
 class sfBrowser extends sfBrowserBase
 {
   /**


### PR DESCRIPTION
They were introduced in the rushed #63 changeset.