### PR TITLE
Refactor - Drop `#[ReturnTypeWillChange]` annotations

### DIFF
--- a/lib/escaper/sfOutputEscaperArrayDecorator.class.php
+++ b/lib/escaper/sfOutputEscaperArrayDecorator.class.php
@@ -56,8 +56,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
    *
    * @return mixed The escaped value
    */
-  #[\ReturnTypeWillChange]
-  public function offsetGet($offset)
+  public function offsetGet(mixed $offset = ''): mixed
   {
     return sfOutputEscaper::escape($this->escapingMethod, $this->value[$offset]);
   }
@@ -74,8 +73,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
    *
    * @throws sfException
    */
-  #[\ReturnTypeWillChange]
-  public function offsetSet($offset, $value): void
+  public function offsetSet(mixed $offset = '', mixed $value = ''): void
   {
     throw new sfException('Cannot set values.');
   }
@@ -91,8 +89,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
    *
    * @throws sfException
    */
-  #[\ReturnTypeWillChange]
-  public function offsetUnset($offset): void
+  public function offsetUnset(mixed $offset = ''): void
   {
     throw new sfException('Cannot unset values.');
   }

--- a/lib/escaper/sfOutputEscaperIteratorDecorator.class.php
+++ b/lib/escaper/sfOutputEscaperIteratorDecorator.class.php
@@ -68,8 +68,7 @@ class sfOutputEscaperIteratorDecorator extends sfOutputEscaperObjectDecorator im
    *
    * @return mixed The escaped value
    */
-  #[\ReturnTypeWillChange]
-  public function offsetGet($offset)
+  public function offsetGet(mixed $offset = ''): mixed
   {
     return sfOutputEscaper::escape($this->escapingMethod, $this->value[$offset]);
   }

--- a/lib/form/sfForm.class.php
+++ b/lib/form/sfForm.class.php
@@ -1076,23 +1076,22 @@ class sfForm implements ArrayAccess, IteratorAggregate, Countable
    *
    * @return sfFormField|sfFormFieldSchema A form field instance
    */
-  #[\ReturnTypeWillChange]
-  public function offsetGet($name)
+  public function offsetGet(mixed $offset): mixed
   {
-    if (!isset($this->formFields[$name]))
+    if (!isset($this->formFields[$offset]))
     {
-      if (!$widget = $this->widgetSchema[$name])
+      if (!$widget = $this->widgetSchema[$offset])
       {
-        throw new InvalidArgumentException(sprintf('Widget "%s" does not exist.', $name));
+        throw new InvalidArgumentException(sprintf('Widget "%s" does not exist.', $offset));
       }
 
       if ($this->isBound)
       {
-        $value = $this->taintedValues[$name] ?? null;
+        $value = $this->taintedValues[$offset] ?? null;
       }
-      else if (isset($this->defaults[$name]))
+      else if (isset($this->defaults[$offset]))
       {
-        $value = $this->defaults[$name];
+        $value = $this->defaults[$offset];
       }
       else
       {
@@ -1101,10 +1100,10 @@ class sfForm implements ArrayAccess, IteratorAggregate, Countable
 
       $class = $widget instanceof sfWidgetFormSchema ? 'sfFormFieldSchema' : 'sfFormField';
 
-      $this->formFields[$name] = new $class($widget, $this->getFormFieldSchema(), $name, $value, $this->errorSchema[$name]);
+      $this->formFields[$offset] = new $class($widget, $this->getFormFieldSchema(), $offset, $value, $this->errorSchema[$offset]);
     }
 
-    return $this->formFields[$name];
+    return $this->formFields[$offset];
   }
 
   /**

--- a/lib/form/sfFormFieldSchema.class.php
+++ b/lib/form/sfFormFieldSchema.class.php
@@ -103,17 +103,16 @@ class sfFormFieldSchema extends sfFormField implements ArrayAccess, IteratorAggr
    *
    * @return sfFormField A form field instance
    */
-  #[\ReturnTypeWillChange]
-  public function offsetGet($name)
+  public function offsetGet(mixed $offset = ''): mixed
   {
-    if (!isset($this->fields[$name]))
+    if (!isset($this->fields[$offset]))
     {
-      if (null === $widget = $this->widget[$name])
+      if (null === $widget = $this->widget[$offset])
       {
-        throw new InvalidArgumentException(sprintf('Widget "%s" does not exist.', $name));
+        throw new InvalidArgumentException(sprintf('Widget "%s" does not exist.', $offset));
       }
 
-      $error = isset($this->error[$name]) ? $this->error[$name] : null;
+      $error = isset($this->error[$offset]) ? $this->error[$offset] : null;
 
       if ($widget instanceof sfWidgetFormSchema)
       {
@@ -131,10 +130,10 @@ class sfFormFieldSchema extends sfFormField implements ArrayAccess, IteratorAggr
         $class = 'sfFormField';
       }
 
-      $this->fields[$name] = new $class($widget, $this, $name, isset($this->value[$name]) ? $this->value[$name] : null, $error);
+      $this->fields[$offset] = new $class($widget, $this, $offset, isset($this->value[$offset]) ? $this->value[$offset] : null, $error);
     }
 
-    return $this->fields[$name];
+    return $this->fields[$offset];
   }
 
   /**

--- a/lib/validator/sfValidatorErrorSchema.class.php
+++ b/lib/validator/sfValidatorErrorSchema.class.php
@@ -216,10 +216,9 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
    *
    * @return sfValidatorError A sfValidatorError instance
    */
-  #[\ReturnTypeWillChange]
-  public function offsetGet($name)
+  public function offsetGet(mixed $offset = ''): mixed
   {
-    return $this->errors[$name] ?? null;
+    return $this->errors[$offset] ?? null;
   }
 
   /**

--- a/lib/validator/sfValidatorSchema.class.php
+++ b/lib/validator/sfValidatorSchema.class.php
@@ -321,10 +321,9 @@ class sfValidatorSchema extends sfValidatorBase implements ArrayAccess
    *
    * @return sfValidatorBase The sfValidatorBase instance associated with the given name, null if it does not exist
    */
-  #[\ReturnTypeWillChange]
-  public function offsetGet($name)
+  public function offsetGet(mixed $offset): mixed
   {
-    return isset($this->fields[$name]) ? $this->fields[$name] : null;
+    return isset($this->fields[$offset]) ? $this->fields[$offset] : null;
   }
 
   /**

--- a/lib/widget/sfWidgetFormSchema.class.php
+++ b/lib/widget/sfWidgetFormSchema.class.php
@@ -667,14 +667,13 @@ class sfWidgetFormSchema extends sfWidgetForm implements ArrayAccess
   /**
    * Gets the field associated with the given name (implements the ArrayAccess interface).
    *
-   * @param string $name The field name
+   * @param string $offset The field name
    *
    * @return sfWidget|null The sfWidget instance associated with the given name, null if it does not exist
    */
-  #[\ReturnTypeWillChange]
-  public function offsetGet($name)
+  public function offsetGet(mixed $offset = ''): mixed
   {
-    return isset($this->fields[$name]) ? $this->fields[$name] : null;
+    return isset($this->fields[$offset]) ? $this->fields[$offset] : null;
   }
 
   /**

--- a/lib/widget/sfWidgetFormSchemaDecorator.class.php
+++ b/lib/widget/sfWidgetFormSchemaDecorator.class.php
@@ -355,10 +355,9 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
    * @see sfWidgetFormSchema
    * @inheritdoc
    */
-  #[\ReturnTypeWillChange]
-  public function offsetGet($name)
+  public function offsetGet(mixed $offset = ''): mixed
   {
-    return $this->widget[$name];
+    return $this->widget[$offset];
   }
 
   /**


### PR DESCRIPTION
They were introduced in the rushed #63 changeset.