### PR TITLE
Refactor - Add types

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Roadmap
 - Properties, arguments and return types everywhere 
 - Fix sfApplicationConfiguration / ProjectConfiguration
 - Replace sfLogger with PSR Logger
-- Descent service container, services auto-injection
+- Decent service container, services auto-injection
 - CommandBus + JobQueue
 - Logging with Logger object (not via sfEventDispatcher)
 - Drop sfContext

--- a/lib/action/sfAction.class.php
+++ b/lib/action/sfAction.class.php
@@ -24,22 +24,19 @@
 abstract class sfAction extends sfComponent
 {
   /** @var array */
-  protected $security = [];
+  protected array $security = [];
 
   /**
-   * Class constructor.
-   *
-   * @param sfContext $context    The current application context.
-   * @param string    $moduleName The module name.
-   * @param string    $actionName The action name.
+   * @param sfContext $context     The current application context.
+   * @param string    $moduleName  The module name.
+   * @param string    $actionName  The action name.
    */
   public function __construct(sfContext $context, string $moduleName, string $actionName)
   {
     parent::__construct($context, $moduleName, $actionName);
 
     // include security configuration
-    if ($file = $context->getConfigCache()->checkConfig("modules/{$this->getModuleName()}/config/security.yml", true))
-    {
+    if ($file = $context->getConfigCache()->checkConfig("modules/{$this->getModuleName()}/config/security.yml", true)) {
       require($file);
     }
   }
@@ -51,6 +48,7 @@ abstract class sfAction extends sfComponent
    */
   public function preExecute(): void
   {
+    // Point of extension for subclasses
   }
 
   /**
@@ -60,12 +58,14 @@ abstract class sfAction extends sfComponent
    */
   public function postExecute(): void
   {
+    // Point of extension for subclasses
   }
 
   /**
    * Forwards current action to the default 404 error action.
    *
-   * @param string $message Message of the generated exception
+   * @param string|null $message  Message of the generated exception
+   * @return never-returns
    *
    * @throws sfError404Exception
    *
@@ -78,15 +78,16 @@ abstract class sfAction extends sfComponent
   /**
    * Forwards current action to the default 404 error action unless the specified condition is true.
    *
-   * @param bool    $condition  A condition that evaluates to true or false
-   * @param string  $message    Message of the generated exception
+   * @param bool        $condition  A condition that evaluates to true or false
+   * @param string|null $message    Message of the generated exception
+   *
+   * @return void|never-returns
    *
    * @throws sfError404Exception
    */
   public function forward404Unless(bool $condition, string $message = null): void
   {
-    if (!$condition)
-    {
+    if ( ! $condition) {
       throw new sfError404Exception($this->get404Message($message));
     }
   }
@@ -94,15 +95,16 @@ abstract class sfAction extends sfComponent
   /**
    * Forwards current action to the default 404 error action if the specified condition is true.
    *
-   * @param bool    $condition  A condition that evaluates to true or false
-   * @param string  $message    Message of the generated exception
+   * @param bool        $condition  A condition that evaluates to true or false
+   * @param string|null $message    Message of the generated exception
+   *
+   * @return void|never-returns
    *
    * @throws sfError404Exception
    */
   public function forward404If(bool $condition, string $message = null): void
   {
-    if ($condition)
-    {
+    if ($condition) {
       throw new sfError404Exception($this->get404Message($message));
     }
   }
@@ -111,10 +113,12 @@ abstract class sfAction extends sfComponent
    * Redirects current action to the default 404 error action (with browser redirection).
    *
    * This method stops the current code flow.
+   *
+   * @return never-returns
    */
-  public function redirect404()
+  public function redirect404(): void
   {
-    return $this->redirect('/'.sfConfig::get('sf_error_404_module').'/'.sfConfig::get('sf_error_404_action'));
+    $this->redirect('/' . sfConfig::get('sf_error_404_module') . '/' . sfConfig::get('sf_error_404_action'));
   }
 
   /**
@@ -122,16 +126,19 @@ abstract class sfAction extends sfComponent
    *
    * This method stops the action. So, no code is executed after a call to this method.
    *
-   * @param  string  $module  A module name
-   * @param  string  $action  An action name
+   * @param string $module  A module name
+   * @param string $action  An action name
+   *
+   * @return never-returns
    *
    * @throws sfStopException
    */
-  public function forward($module, $action)
+  public function forward(string $module, string $action): void
   {
-    if (sfConfig::get('sf_logging_enabled'))
-    {
-      $this->dispatcher->notify(new sfEvent($this, 'application.log', array(sprintf('Forward to action "%s/%s"', $module, $action))));
+    if (sfConfig::get('sf_logging_enabled')) {
+      $this->dispatcher->notify(
+        new sfEvent($this, 'application.log', [sprintf('Forward to action "%s/%s"', $module, $action)]),
+      );
     }
 
     $this->getController()->forward($module, $action);
@@ -144,16 +151,17 @@ abstract class sfAction extends sfComponent
    *
    * This method stops the action. So, no code is executed after a call to this method.
    *
-   * @param  bool   $condition  A condition that evaluates to true or false
-   * @param  string $module     A module name
-   * @param  string $action     An action name
+   * @param bool   $condition  A condition that evaluates to true or false
+   * @param string $module     A module name
+   * @param string $action     An action name
+   *
+   * @return void|never-returns
    *
    * @throws sfStopException
    */
-  public function forwardIf($condition, $module, $action)
+  public function forwardIf(bool $condition, string $module, string $action): void
   {
-    if ($condition)
-    {
+    if ($condition) {
       $this->forward($module, $action);
     }
   }
@@ -163,16 +171,17 @@ abstract class sfAction extends sfComponent
    *
    * This method stops the action. So, no code is executed after a call to this method.
    *
-   * @param  bool   $condition  A condition that evaluates to true or false
-   * @param  string $module     A module name
-   * @param  string $action     An action name
+   * @param bool   $condition  A condition that evaluates to true or false
+   * @param string $module     A module name
+   * @param string $action     An action name
+   *
+   * @return void|never-returns
    *
    * @throws sfStopException
    */
-  public function forwardUnless($condition, $module, $action)
+  public function forwardUnless(bool $condition, string $module, string $action): void
   {
-    if (!$condition)
-    {
+    if ( ! $condition) {
       $this->forward($module, $action);
     }
   }
@@ -186,10 +195,12 @@ abstract class sfAction extends sfComponent
    *
    * This method stops the action. So, no code is executed after a call to this method.
    *
-   * @param  string $url         Url
-   * @param  int    $statusCode  Status code (default to 302)
+   * @param string $url         Url
+   * @param int    $statusCode  Status code (default to 302)
    *
    * @throws sfStopException
+   *
+   * @return never-returns
    */
   public function redirect(string $url, int $statusCode = 302): void
   {
@@ -203,18 +214,19 @@ abstract class sfAction extends sfComponent
    *
    * This method stops the action. So, no code is executed after a call to this method.
    *
-   * @param  bool   $condition  A condition that evaluates to true or false
-   * @param  string $url        Url
-   * @param  int    $statusCode Status code (default to 302)
+   * @param bool   $condition   A condition that evaluates to true or false
+   * @param string $url         Url
+   * @param int    $statusCode  Status code (default to 302)
    *
    * @throws sfStopException
    *
    * @see redirect
+   *
+   * @return void|never-returns
    */
   public function redirectIf(bool $condition, string $url, int $statusCode = 302): void
   {
-    if ($condition)
-    {
+    if ($condition) {
       $this->redirect($url, $statusCode);
     }
   }
@@ -224,18 +236,19 @@ abstract class sfAction extends sfComponent
    *
    * This method stops the action. So, no code is executed after a call to this method.
    *
-   * @param  bool   $condition  A condition that evaluates to true or false
-   * @param  string $url        Url
-   * @param  int    $statusCode Status code (default to 302)
+   * @param bool   $condition   A condition that evaluates to true or false
+   * @param string $url         Url
+   * @param int    $statusCode  Status code (default to 302)
    *
    * @throws sfStopException
    *
    * @see redirect
+   *
+   * @return void|never-returns
    */
   public function redirectUnless(bool $condition, string $url, int $statusCode = 302): void
   {
-    if (!$condition)
-    {
+    if ( ! $condition) {
       $this->redirect($url, $statusCode);
     }
   }
@@ -247,13 +260,13 @@ abstract class sfAction extends sfComponent
    *
    * <code>return $this->renderText('some text')</code>
    *
-   * @param string $text Text to append to the response
+   * @param string $text  Text to append to the response
    *
    * @return string sfView::NONE
    */
   public function renderText(string $text): string
   {
-    $this->getResponse()->setContent($this->getResponse()->getContent().$text);
+    $this->getResponse()->setContent($this->getResponse()->getContent() . $text);
 
     return sfView::NONE;
   }
@@ -263,11 +276,11 @@ abstract class sfAction extends sfComponent
    *
    * <code>return $this->renderJson(array('username' => 'john'))</code>
    *
-   * @param mixed $data Data to encode as JSON
+   * @param mixed $data  Data to encode as JSON
    *
    * @return string sfView::NONE
    */
-  public function renderJson($data): string
+  public function renderJson(mixed $data): string
   {
     $this->getResponse()->setContentType('application/json');
     $this->getResponse()->setContent(json_encode($data));
@@ -284,12 +297,12 @@ abstract class sfAction extends sfComponent
    * If the vars parameter is set then only those values are
    * available in the partial.
    *
-   * @param  string $templateName partial name
-   * @param  array  $vars         vars
+   * @param string                   $templateName  Partial name
+   * @param array<string,mixed>|null $vars          Variables
    *
    * @return string The partial content
    */
-  public function getPartial(string $templateName, array $vars = null): string
+  public function getPartial(string $templateName, array | null $vars = null): string
   {
     $this->getContext()->getConfiguration()->loadHelpers(['Partial']);
 
@@ -305,8 +318,8 @@ abstract class sfAction extends sfComponent
    *
    * <code>return $this->renderPartial('foo/bar')</code>
    *
-   * @param  string $templateName partial name
-   * @param  array  $vars         vars
+   * @param string              $templateName  Partial name
+   * @param array<string,mixed> $vars          Variables
    *
    * @return string sfView::NONE
    *
@@ -326,13 +339,13 @@ abstract class sfAction extends sfComponent
    * If the vars parameter is set then only those values are
    * available in the component.
    *
-   * @param  string  $moduleName    module name
-   * @param  string  $componentName  component name
-   * @param  array   $vars          vars
+   * @param string     $moduleName     module name
+   * @param string     $componentName  component name
+   * @param array|null $vars           vars
    *
    * @return string  The component rendered content
    */
-  public function getComponent(string $moduleName, string $componentName, array $vars = null): string
+  public function getComponent(string $moduleName, string $componentName, array | null $vars = null): string
   {
     $this->getContext()->getConfiguration()->loadHelpers(['Partial']);
 
@@ -348,15 +361,15 @@ abstract class sfAction extends sfComponent
    *
    * <code>return $this->renderComponent('foo', 'bar')</code>
    *
-   * @param  string  $moduleName    module name
-   * @param  string  $componentName  component name
-   * @param  array   $vars          vars
+   * @param string     $moduleName     module name
+   * @param string     $componentName  component name
+   * @param array|null $vars           vars
    *
    * @return string  sfView::NONE
    *
    * @see    getComponent
    */
-  public function renderComponent(string $moduleName, string $componentName, array $vars = null): string
+  public function renderComponent(string $moduleName, string $componentName, array | null $vars = null): string
   {
     return $this->renderText($this->getComponent($moduleName, $componentName, $vars));
   }
@@ -374,7 +387,7 @@ abstract class sfAction extends sfComponent
   /**
    * Overrides the current security configuration for this module.
    *
-   * @param array $security The new security configuration
+   * @param array $security  The new security configuration
    */
   public function setSecurityConfiguration(array $security): void
   {
@@ -384,22 +397,20 @@ abstract class sfAction extends sfComponent
   /**
    * Returns a value from security.yml.
    *
-   * @param string $name    The name of the value to pull from security.yml
-   * @param mixed  $default The default value to return if none is found in security.yml
+   * @param string $name     The name of the value to pull from security.yml
+   * @param mixed  $default  The default value to return if none is found in security.yml
    *
    * @return mixed
    */
-  public function getSecurityValue(string $name, $default = null)
+  public function getSecurityValue(string $name, mixed $default = null): mixed
   {
     $actionName = strtolower($this->getActionName());
 
-    if (isset($this->security[$actionName][$name]))
-    {
+    if (isset($this->security[$actionName][$name])) {
       return $this->security[$actionName][$name];
     }
 
-    if (isset($this->security['all'][$name]))
-    {
+    if (isset($this->security['all'][$name])) {
       return $this->security['all'][$name];
     }
 
@@ -431,23 +442,21 @@ abstract class sfAction extends sfComponent
    *
    * See 'Naming Conventions' in the 'Symfony View' documentation.
    *
-   * @param string $name    Template name
-   * @param string $module  The module (current if null)
+   * @param string      $name    Template name
+   * @param string|null $module  The module (current if null)
    */
   public function setTemplate(string $name, string $module = null): void
   {
-    if (sfConfig::get('sf_logging_enabled'))
-    {
-      $this->dispatcher->notify(new sfEvent($this, 'application.log', array(sprintf('Change template to "%s/%s"', null === $module ? 'CURRENT' : $module, $name))));
+    if (sfConfig::get('sf_logging_enabled')) {
+      $this->dispatcher->notify(new sfEvent($this, 'application.log', [sprintf('Change template to "%s/%s"', null === $module ? 'CURRENT' : $module, $name)]));
     }
 
-    if (null !== $module)
-    {
-      $dir = $this->context->getConfiguration()->getTemplateDir($module, $name.sfView::SUCCESS.'.php');
-      $name = $dir.'/'.$name;
+    if (null !== $module) {
+      $dir  = $this->context->getConfiguration()->getTemplateDir($module, $name . sfView::SUCCESS . '.php');
+      $name = $dir . '/' . $name;
     }
 
-    sfConfig::set('symfony.view.'.$this->getModuleName().'_'.$this->getActionName().'_template', $name);
+    sfConfig::set('symfony.view.' . $this->getModuleName() . '_' . $this->getActionName() . '_template', $name);
   }
 
   /**
@@ -458,11 +467,11 @@ abstract class sfAction extends sfComponent
    *
    * See 'Naming Conventions' in the 'Symfony View' documentation.
    *
-   * @return string Template name. Returns null if no template has been set within the action
+   * @return string|null Template name. Returns null if no template has been set within the action
    */
   public function getTemplate(): ?string
   {
-    return sfConfig::get('symfony.view.'.$this->getModuleName().'_'.$this->getActionName().'_template');
+    return sfConfig::get('symfony.view.' . $this->getModuleName() . '_' . $this->getActionName() . '_template');
   }
 
   /**
@@ -472,16 +481,15 @@ abstract class sfAction extends sfComponent
    *
    * To revert the layout to the one configured in the view.yml, set the template name to null.
    *
-   * @param mixed $name Layout name or false to de-activate the layout
+   * @param string|false $name  Layout name or false to de-activate the layout
    */
-  public function setLayout($name): void
+  public function setLayout(string | false $name): void
   {
-    if (sfConfig::get('sf_logging_enabled'))
-    {
-      $this->dispatcher->notify(new sfEvent($this, 'application.log', array(sprintf('Change layout to "%s"', $name))));
+    if (sfConfig::get('sf_logging_enabled')) {
+      $this->dispatcher->notify(new sfEvent($this, 'application.log', [sprintf('Change layout to "%s"', $name)]));
     }
 
-    sfConfig::set('symfony.view.'.$this->getModuleName().'_'.$this->getActionName().'_layout', $name);
+    sfConfig::set('symfony.view.' . $this->getModuleName() . '_' . $this->getActionName() . '_layout', $name);
   }
 
   /**
@@ -492,19 +500,19 @@ abstract class sfAction extends sfComponent
    *
    * @return string|false|null Layout name. Returns null if no layout has been set within the action
    */
-  public function getLayout()
+  public function getLayout(): string | false | null
   {
-    return sfConfig::get('symfony.view.'.$this->getModuleName().'_'.$this->getActionName().'_layout');
+    return sfConfig::get('symfony.view.' . $this->getModuleName() . '_' . $this->getActionName() . '_layout');
   }
 
   /**
    * Changes the default view class used for rendering the template associated with the current action.
    *
-   * @param string $class View class name
+   * @param class-string $class  View class name
    */
   public function setViewClass(string $class): void
   {
-    sfConfig::set('mod_'.strtolower($this->getModuleName()).'_view_class', $class);
+    sfConfig::set('mod_' . strtolower($this->getModuleName()) . '_view_class', $class);
   }
 
   /**
@@ -520,7 +528,7 @@ abstract class sfAction extends sfComponent
   /**
    * Returns a formatted message for a 404 error.
    *
-   * @param  string $message An error message (null by default)
+   * @param string|null $message  An error message (null by default)
    *
    * @return string The error message or a default one if null
    */

--- a/lib/action/sfActionStack.class.php
+++ b/lib/action/sfActionStack.class.php
@@ -22,14 +22,14 @@
 class sfActionStack
 {
   /** @var sfActionStackEntry[] */
-  protected $stack = [];
+  protected array $stack = [];
 
   /**
    * Adds an entry to the action stack.
    *
-   * @param string   $moduleName     A module name
-   * @param string   $actionName     An action name
-   * @param sfAction $actionInstance An sfAction implementation instance
+   * @param string   $moduleName      A module name
+   * @param string   $actionName      An action name
+   * @param sfAction $actionInstance  An sfAction implementation instance
    *
    * @return sfActionStackEntry sfActionStackEntry instance
    */
@@ -46,26 +46,19 @@ class sfActionStack
   /**
    * Retrieves the entry at a specific index.
    *
-   * @param int $index An entry index
+   * @param int $index  An entry index
    *
-   * @return sfActionStackEntry An action stack entry implementation.
+   * @return sfActionStackEntry|null An action stack entry implementation.
    */
   public function getEntry(int $index): ?sfActionStackEntry
   {
-    $retval = null;
-
-    if ($index > -1 && $index < count($this->stack))
-    {
-      $retval = $this->stack[$index];
-    }
-
-    return $retval;
+    return $this->stack[$index] ?? null;
   }
 
   /**
    * Removes the entry at a specific index.
    *
-   * @return sfActionStackEntry An action stack entry implementation.
+   * @return sfActionStackEntry|null An action stack entry implementation.
    */
   public function popEntry(): ?sfActionStackEntry
   {
@@ -75,36 +68,22 @@ class sfActionStack
   /**
    * Retrieves the first entry.
    *
-   * @return mixed An action stack entry implementation or null if there is no sfAction instance in the stack
+   * @return sfActionStackEntry|null An action stack entry implementation or null if there is no sfAction instance in the stack
    */
   public function getFirstEntry(): ?sfActionStackEntry
   {
-    $retval = null;
-
-    if (isset($this->stack[0]))
-    {
-      $retval = $this->stack[0];
-    }
-
-    return $retval;
+    return $this->stack[0] ?? null;
   }
 
   /**
    * Retrieves the last entry.
    *
-   * @return mixed An action stack entry implementation or null if there is no sfAction instance in the stack
+   * @return sfActionStackEntry|null An action stack entry implementation or null if there is no sfAction instance in the stack
    */
   public function getLastEntry(): ?sfActionStackEntry
   {
     $count  = count($this->stack);
-    $retval = null;
-
-    if (isset($this->stack[0]))
-    {
-      $retval = $this->stack[$count - 1];
-    }
-
-    return $retval;
+    return $this->stack[$count - 1] ?? null;
   }
 
   /**

--- a/lib/action/sfActionStackEntry.class.php
+++ b/lib/action/sfActionStackEntry.class.php
@@ -21,13 +21,15 @@
 class sfActionStackEntry
 {
   /** @var \sfAction */
-  protected $actionInstance = null;
+  protected sfAction $actionInstance;
+
   /** @var string */
-  protected $actionName = null;
+  protected string $actionName;
+
   /** @var string */
-  protected $moduleName = null;
-  /** @var null */
-  protected $presentation = null;
+  protected string $moduleName;
+
+  protected string | null $presentation = null;
 
   /**
    * Class constructor.
@@ -48,7 +50,7 @@ class sfActionStackEntry
    *
    * @return string An action name
    */
-  public function getActionName()
+  public function getActionName(): string
   {
     return $this->actionName;
   }
@@ -80,7 +82,7 @@ class sfActionStackEntry
    *
    * @return string Rendered view presentation
    */
-  public function & getPresentation()
+  public function getPresentation(): string
   {
     return $this->presentation;
   }
@@ -90,8 +92,8 @@ class sfActionStackEntry
    *
    * @param string $presentation A rendered presentation.
    */
-  public function setPresentation(&$presentation)
+  public function setPresentation(string $presentation): void
   {
-    $this->presentation =& $presentation;
+    $this->presentation = $presentation;
   }
 }

--- a/lib/action/sfActions.class.php
+++ b/lib/action/sfActions.class.php
@@ -26,7 +26,7 @@ abstract class sfActions extends sfAction
    * This method try to execute the executeXXX() method of the current object where XXX is the
    * defined action name.
    *
-   * @param sfRequest $request The current sfRequest object
+   * @param sfRequest $request  The current sfRequest object
    *
    * @return string    A string containing the view name associated with this action
    *
@@ -34,26 +34,25 @@ abstract class sfActions extends sfAction
    *
    * @see sfAction
    */
-  public function execute(sfRequest $request)
+  public function execute(sfRequest $request): mixed
   {
     // dispatch action
-    $actionToRun = 'execute'.ucfirst($this->getActionName());
+    $actionToRun = 'execute' . ucfirst($this->getActionName());
 
-    if ($actionToRun === 'execute')
-    {
+    if ($actionToRun === 'execute') {
       // no action given
       throw new sfInitializationException(sprintf('sfAction initialization failed for module "%s". There was no action given.', $this->getModuleName()));
     }
 
-    if (!is_callable(array($this, $actionToRun)))
-    {
+    if ( ! is_callable([$this, $actionToRun])) {
       // action not found
-      throw new sfInitializationException(sprintf('sfAction initialization failed for module "%s", action "%s". You must create a "%s" method.', $this->getModuleName(), $this->getActionName(), $actionToRun));
+      throw new sfInitializationException(
+        sprintf('sfAction initialization failed for module "%s", action "%s". You must create a "%s" method.', $this->getModuleName(), $this->getActionName(), $actionToRun)
+      );
     }
 
-    if (sfConfig::get('sf_logging_enabled'))
-    {
-      $this->dispatcher->notify(new sfEvent($this, 'application.log', array(sprintf('Call "%s->%s()"', get_class($this), $actionToRun))));
+    if (sfConfig::get('sf_logging_enabled')) {
+      $this->dispatcher->notify(new sfEvent($this, 'application.log', [sprintf('Call "%s->%s()"', get_class($this), $actionToRun)]));
     }
 
     // run action

--- a/lib/action/sfComponent.class.php
+++ b/lib/action/sfComponent.class.php
@@ -19,28 +19,33 @@
 abstract class sfComponent
 {
   /** @var string */
-  protected $moduleName;
+  protected string $moduleName;
+
   /** @var string */
-  protected $actionName;
+  protected string $actionName;
+
   /** @var sfContext */
-  protected $context;
+  protected sfContext $context;
+
   /** @var sfEventDispatcher */
-  protected $dispatcher;
+  protected sfEventDispatcher $dispatcher;
+
   /** @var sfRequest */
-  protected $request;
+  protected sfRequest $request;
+
   /** @var sfResponse */
-  protected $response;
+  protected sfResponse $response;
+
   /** @var sfParameterHolder */
-  protected $varHolder;
+  protected sfParameterHolder $varHolder;
+
   /** @var sfParameterHolder */
-  protected $requestParameterHolder;
+  protected sfParameterHolder $requestParameterHolder;
 
   /**
-   * Class constructor.
-   *
    * @param sfContext $context
-   * @param string $moduleName
-   * @param string $actionName
+   * @param string    $moduleName
+   * @param string    $actionName
    */
   public function __construct(sfContext $context, string $moduleName, string $actionName)
   {
@@ -65,11 +70,11 @@ abstract class sfComponent
    * user account, a shopping cart, or even a something as simple as a
    * single product.
    *
-   * @param sfRequest $request The current sfRequest object
+   * @param sfRequest $request  The current sfRequest object
    *
    * @return mixed     A string containing the view name associated with this action
    */
-  abstract function execute(sfRequest $request);
+  abstract function execute(sfRequest $request): mixed;
 
   /**
    * Gets the module name associated with this component.
@@ -114,11 +119,11 @@ abstract class sfComponent
   /**
    * Retrieves a service from the service container.
    *
-   * @param  string $id The service identifier
+   * @param string $id  The service identifier
    *
    * @return object The service instance
    */
-  public function getService(string $id)
+  public function getService(string $id): mixed
   {
     return $this->getServiceContainer()->getService($id);
   }
@@ -136,31 +141,30 @@ abstract class sfComponent
   /**
    * Logs a message using the sfLogger object.
    *
-   * @param mixed  $message  String or object containing the message to log
-   * @param string $priority The priority of the message
-   *                         (available priorities: emerg, alert, crit, err,
-   *                         warning, notice, info, debug)
+   * @param mixed  $message   String or object containing the message to log
+   * @param string $priority  The priority of the message
+   *                          (available priorities: emerg, alert, crit, err,
+   *                          warning, notice, info, debug)
    *
    * @see sfLogger
    */
-  public function logMessage($message, string $priority = 'info'): void
+  public function logMessage(string $message, string $priority = 'info'): void
   {
-    if (sfConfig::get('sf_logging_enabled'))
-    {
-      $this->dispatcher->notify(new sfEvent($this, 'application.log', array($message, 'priority' => constant('sfLogger::'.strtoupper($priority)))));
+    if (sfConfig::get('sf_logging_enabled')) {
+      $this->dispatcher->notify(new sfEvent($this, 'application.log', [$message, 'priority' => constant('sfLogger::' . strtoupper($priority))]));
     }
   }
 
   /**
    * Gets the translation for the given string
    *
-   * @param  string $string     The string to translate
-   * @param  array  $args       An array of arguments for the translation
-   * @param  string $catalogue  The catalogue name
+   * @param string $string     The string to translate
+   * @param array  $args       An array of arguments for the translation
+   * @param string $catalogue  The catalogue name
    *
    * @return string The translated string
    */
-  public function __(string $string, array $args = array(), string $catalogue = 'messages'): string
+  public function __(string $string, array $args = [], string $catalogue = 'messages'): string
   {
     return $this->context->getI18N()->__($string, $args, $catalogue);
   }
@@ -172,12 +176,12 @@ abstract class sfComponent
    *
    * <code>$this->getRequest()->getParameterHolder()->get($name)</code>
    *
-   * @param string $name    The parameter name
-   * @param mixed  $default The default value if parameter does not exist
+   * @param string $name     The parameter name
+   * @param mixed  $default  The default value if parameter does not exist
    *
-   * @return string The request parameter value
+   * @return mixed The request parameter value
    */
-  public function getRequestParameter(string $name, $default = null)
+  public function getRequestParameter(string $name, mixed $default = null): mixed
   {
     return $this->requestParameterHolder->get($name, $default);
   }
@@ -189,7 +193,7 @@ abstract class sfComponent
    *
    * <code>$this->getRequest()->getParameterHolder()->has($name)</code>
    *
-   * @param string $name The parameter name
+   * @param string $name  The parameter name
    * @return boolean true if the request parameter exists, false otherwise
    */
   public function hasRequestParameter(string $name): bool
@@ -246,13 +250,13 @@ abstract class sfComponent
    *
    * <code>$this->getContext()->getRouting()->generate(...)</code>
    *
-   * @param string  $route    The route name
-   * @param array   $params   An array of parameters for the route
-   * @param Boolean $absolute Whether to generate an absolute URL or not
+   * @param string  $route     The route name
+   * @param array   $params    An array of parameters for the route
+   * @param Boolean $absolute  Whether to generate an absolute URL or not
    *
    * @return string  The URL
    */
-  public function generateUrl(string $route, array $params = array(), bool $absolute = false): string
+  public function generateUrl(string $route, array $params = [], bool $absolute = false): string
   {
     return $this->context->getRouting()->generate($route, $params, $absolute);
   }
@@ -288,11 +292,11 @@ abstract class sfComponent
    * by symfony, so this is your responsability to ensure that the
    * value is escaped properly.
    *
-   * @param string  $name  The variable name
-   * @param mixed   $value The variable value
-   * @param Boolean $safe  true if the value is safe for output (false by default)
+   * @param string  $name   The variable name
+   * @param mixed   $value  The variable value
+   * @param Boolean $safe   true if the value is safe for output (false by default)
    */
-  public function setVar(string $name, $value, bool $safe = false): void
+  public function setVar(string $name, mixed $value, bool $safe = false): void
   {
     $this->varHolder->set($name, $safe ? new sfOutputEscaperSafe($value) : $value);
   }
@@ -300,11 +304,11 @@ abstract class sfComponent
   /**
    * Gets a variable set for the template.
    *
-   * @param string $name The variable name
+   * @param string $name  The variable name
    *
    * @return mixed  The variable value
    */
-  public function getVar(string $name)
+  public function getVar(string $name): mixed
   {
     return $this->varHolder->get($name);
   }
@@ -326,8 +330,8 @@ abstract class sfComponent
    *
    * <code>$this->setVar('name', 'value')</code>
    *
-   * @param string $key   The variable name
-   * @param string $value The variable value
+   * @param string $key    The variable name
+   * @param string $value  The variable value
    *
    * @return boolean always true
    *
@@ -345,7 +349,7 @@ abstract class sfComponent
    *
    * <code>$this->getVar('name')</code>
    *
-   * @param string $key The variable name
+   * @param string $key  The variable name
    *
    * @return mixed The variable value
    *
@@ -363,7 +367,7 @@ abstract class sfComponent
    *
    * <code>$this->getVarHolder()->has('name')</code>
    *
-   * @param string $name The variable name
+   * @param string $name  The variable name
    *
    * @return boolean true if the variable is set
    */
@@ -379,7 +383,7 @@ abstract class sfComponent
    *
    * <code>$this->getVarHolder()->remove('name')</code>
    *
-   * @param string $name The variable Name
+   * @param string $name  The variable Name
    */
   public function __unset($name)
   {

--- a/lib/action/sfComponents.class.php
+++ b/lib/action/sfComponents.class.php
@@ -25,7 +25,7 @@ abstract class sfComponents extends sfComponent
    *
    * @see sfComponent
    */
-  public function execute(sfRequest $request)
+  public function execute(sfRequest $request): mixed
   {
     throw new sfInitializationException('sfComponents initialization failed.');
   }

--- a/lib/cache/sfCache.class.php
+++ b/lib/cache/sfCache.class.php
@@ -75,13 +75,13 @@ abstract class sfCache
   /**
    * Saves some data in the cache.
    *
-   * @param string $key      The cache key
-   * @param string $data     The data to put in cache
-   * @param int    $lifetime The lifetime
+   * @param string   $key       The cache key
+   * @param string   $data      The data to put in cache
+   * @param int|null $lifetime  The lifetime
    *
-   * @return Boolean true if no problem
+   * @return bool true if no problem
    */
-  abstract public function set(string $key, string $data, int $lifetime = null): bool;
+  abstract public function set(string $key, string $data, int | null $lifetime = null): bool;
 
   /**
    * Removes a content from the cache.

--- a/lib/cache/sfFileCache.class.php
+++ b/lib/cache/sfFileCache.class.php
@@ -83,10 +83,9 @@ class sfFileCache extends sfCache
    * @see sfCache
    * @inheritdoc
    */
-  public function set(string $key, string $data, int $lifetime = null): bool
+  public function set(string $key, string $data, int | null $lifetime = null): bool
   {
-    if ($this->getOption('automatic_cleaning_factor') > 0 && mt_rand(1, $this->getOption('automatic_cleaning_factor')) == 1)
-    {
+    if ($this->getOption('automatic_cleaning_factor') > 0 && mt_rand(1, $this->getOption('automatic_cleaning_factor')) == 1) {
       $this->clean(sfCache::OLD);
     }
 

--- a/lib/command/cli.php
+++ b/lib/command/cli.php
@@ -9,31 +9,22 @@
  */
 
 // Try autoloading using composer if available.
-if (file_exists(__DIR__.'/../../../../vendor/autoload.php'))
-{
-  require_once __DIR__.'/../../../../vendor/autoload.php';
-}
-elseif (file_exists(__DIR__.'/../../vendor/autoload.php'))
-{
-  require_once __DIR__.'/../../vendor/autoload.php';
-}
-else
-{
+if (file_exists(__DIR__ . '/../../../../vendor/autoload.php')) {
+  require_once __DIR__ . '/../../../../vendor/autoload.php';
+} elseif (file_exists(__DIR__ . '/../../vendor/autoload.php')) {
+  require_once __DIR__ . '/../../vendor/autoload.php';
+} else {
   throw new RuntimeException('Cannot locate composer\'s vendor/autoload.php');
 }
 
-try
-{
+try {
   $dispatcher = new sfEventDispatcher();
-  $logger = new sfCommandLogger($dispatcher);
+  $logger     = new sfCommandLogger($dispatcher);
 
-  $application = new sfSymfonyCommandApplication($dispatcher, null, array('symfony_lib_dir' => realpath(__DIR__.'/..')));
-  $statusCode = $application->run();
-}
-catch (Exception $e)
-{
-  if (!isset($application))
-  {
+  $application = new sfSymfonyCommandApplication($dispatcher, null, ['symfony_lib_dir' => realpath(__DIR__ . '/..')]);
+  $statusCode  = $application->run();
+} catch (Exception $e) {
+  if ( ! isset($application)) {
     throw $e;
   }
 

--- a/lib/command/sfAnsiColorFormatter.class.php
+++ b/lib/command/sfAnsiColorFormatter.class.php
@@ -18,24 +18,24 @@
  */
 class sfAnsiColorFormatter extends sfFormatter
 {
-  protected
-    $styles = array(
-      'ERROR'    => array('bg' => 'red', 'fg' => 'white', 'bold' => true),
-      'INFO'     => array('fg' => 'green', 'bold' => true),
-      'COMMENT'  => array('fg' => 'yellow'),
-      'QUESTION' => array('bg' => 'cyan', 'fg' => 'black', 'bold' => false),
-    ),
-    $options    = array('bold' => 1, 'underscore' => 4, 'blink' => 5, 'reverse' => 7, 'conceal' => 8),
-    $foreground = array('black' => 30, 'red' => 31, 'green' => 32, 'yellow' => 33, 'blue' => 34, 'magenta' => 35, 'cyan' => 36, 'white' => 37),
-    $background = array('black' => 40, 'red' => 41, 'green' => 42, 'yellow' => 43, 'blue' => 44, 'magenta' => 45, 'cyan' => 46, 'white' => 47);
+  protected array $styles = [
+    'ERROR'    => ['bg' => 'red', 'fg' => 'white', 'bold' => true],
+    'INFO'     => ['fg' => 'green', 'bold' => true],
+    'COMMENT'  => ['fg' => 'yellow'],
+    'QUESTION' => ['bg' => 'cyan', 'fg' => 'black', 'bold' => false],
+  ];
+
+  protected array $options    = ['bold' => 1, 'underscore' => 4, 'blink' => 5, 'reverse' => 7, 'conceal' => 8];
+  protected array $foreground = ['black' => 30, 'red' => 31, 'green' => 32, 'yellow' => 33, 'blue' => 34, 'magenta' => 35, 'cyan' => 36, 'white' => 37];
+  protected array $background = ['black' => 40, 'red' => 41, 'green' => 42, 'yellow' => 43, 'blue' => 44, 'magenta' => 45, 'cyan' => 46, 'white' => 47];
 
   /**
    * Sets a new style.
    *
-   * @param string $name    The style name
-   * @param array  $options An array of options
+   * @param string $name     The style name
+   * @param array  $options  An array of options
    */
-  public function setStyle($name, $options = array())
+  public function setStyle(string $name, array $options = []): void
   {
     $this->styles[$name] = $options;
   }
@@ -43,57 +43,50 @@ class sfAnsiColorFormatter extends sfFormatter
   /**
    * Formats a text according to the given style or parameters.
    *
-   * @param  string   $text       The test to style
-   * @param  mixed    $parameters An array of options or a style name
+   * @param string $text        The test to style
+   * @param mixed  $parameters  An array of options or a style name
    *
    * @return string The styled text
    */
-  public function format($text = '', $parameters = array())
+  public function format(string $text = '', string | array $parameters = []): string
   {
-    if (!is_array($parameters) && 'NONE' == $parameters)
-    {
+    if ($parameters === 'NONE') {
       return $text;
     }
 
-    if (!is_array($parameters) && isset($this->styles[$parameters]))
-    {
+    if (is_string($parameters) && isset($this->styles[$parameters])) {
       $parameters = $this->styles[$parameters];
     }
 
-    $codes = array();
-    if (isset($parameters['fg']))
-    {
+    $codes = [];
+    if (isset($parameters['fg'])) {
       $codes[] = $this->foreground[$parameters['fg']];
     }
-    if (isset($parameters['bg']))
-    {
+    if (isset($parameters['bg'])) {
       $codes[] = $this->background[$parameters['bg']];
     }
-    foreach ($this->options as $option => $value)
-    {
-      if (isset($parameters[$option]) && $parameters[$option])
-      {
+    foreach ($this->options as $option => $value) {
+      if ( ! empty($parameters[$option])) {
         $codes[] = $value;
       }
     }
 
-    return "\033[".implode(';', $codes).'m'.$text."\033[0m";
+    return "\033[" . implode(';', $codes) . 'm' . $text . "\033[0m";
   }
-  
+
   /**
    * Formats a message within a section.
    *
-   * @param string  $section The section name
-   * @param string  $text    The text message
-   * @param integer $size    The maximum size allowed for a line
-   * @param string  $style   The color scheme to apply to the section string (INFO, ERROR, COMMENT or QUESTION)
+   * @param string   $section  The section name
+   * @param string   $text     The text message
+   * @param int|null $size     The maximum size allowed for a line
+   * @param string   $style    The color scheme to apply to the section string (INFO, ERROR, COMMENT or QUESTION)
    *
    * @return string
    */
-  public function formatSection($section, $text, $size = null, $style = 'INFO')
+  public function formatSection(string $section, string $text, int | null $size = null, string $style = 'INFO'): string
   {
-    if (null === $size)
-    {
+    if (null === $size) {
       $size = $this->size;
     }
 
@@ -106,25 +99,23 @@ class sfAnsiColorFormatter extends sfFormatter
   /**
    * Truncates a line.
    *
-   * @param string  $text The text
-   * @param integer $size The maximum size of the returned string
+   * @param string   $text  The text
+   * @param int|null $size  The maximum size of the returned string
    *
    * @return string The truncated string
    */
-  public function excerpt($text, $size = null)
+  public function excerpt(string $text, int | null $size = null): string
   {
-    if (!$size)
-    {
+    if ( ! $size) {
       $size = $this->size;
     }
 
-    if (strlen($text) < $size)
-    {
+    if (strlen($text) < $size) {
       return $text;
     }
 
     $subsize = floor(($size - 3) / 2);
 
-    return substr($text, 0, $subsize).$this->format('...', 'INFO').substr($text, -$subsize);
+    return substr($text, 0, $subsize) . $this->format('...', 'INFO') . substr($text, -$subsize);
   }
 }

--- a/lib/command/sfCommandArgument.class.php
+++ b/lib/command/sfCommandArgument.class.php
@@ -18,35 +18,50 @@
  */
 class sfCommandArgument
 {
-  const REQUIRED = 1;
-  const OPTIONAL = 2;
+  public const REQUIRED = 1;
+  public const OPTIONAL = 2;
 
-  const IS_ARRAY = 4;
+  public const IS_ARRAY = 4;
 
-  protected
-    $name    = null,
-    $mode    = null,
-    $default = null,
-    $help    = '';
+  /**
+   * The argument name
+   */
+  protected string $name;
+
+  /**
+   * The argument mode
+   *
+   * @see self::REQUIRED
+   * @see self::OPTIONAL
+   * @see self::IS_ARRAY
+   */
+  protected int $mode;
+
+  /**
+   * The default value
+   */
+  protected mixed $default;
+
+  /**
+   * Help text
+   */
+  protected string $help;
 
   /**
    * Constructor.
    *
-   * @param string  $name    The argument name
-   * @param integer $mode    The argument mode: self::REQUIRED or self::OPTIONAL
-   * @param string  $help    A help text
-   * @param mixed   $default The default value (for self::OPTIONAL mode only)
+   * @param string   $name     The argument name
+   * @param int|null $mode     The argument mode: self::REQUIRED or self::OPTIONAL
+   * @param string   $help     A help text
+   * @param mixed    $default  The default value (for self::OPTIONAL mode only)
    *
    * @throws sfCommandException
    */
-  public function __construct($name, $mode = null, $help = '', $default = null)
+  public function __construct(string $name, int | null $mode = null, string $help = '', mixed $default = null)
   {
-    if (null === $mode)
-    {
+    if (null === $mode) {
       $mode = self::OPTIONAL;
-    }
-    else if (is_string($mode) || $mode > 7)
-    {
+    } elseif (is_string($mode) || $mode > 7) {
       throw new sfCommandException(sprintf('Argument mode "%s" is not valid.', $mode));
     }
 
@@ -62,7 +77,7 @@ class sfCommandArgument
    *
    * @return string The argument name
    */
-  public function getName()
+  public function getName(): string
   {
     return $this->name;
   }
@@ -70,7 +85,7 @@ class sfCommandArgument
   /**
    * Returns true if the argument is required.
    *
-   * @return Boolean true if parameter mode is self::REQUIRED, false otherwise
+   * @return bool true if parameter mode is self::REQUIRED, false otherwise
    */
   public function isRequired()
   {
@@ -80,7 +95,7 @@ class sfCommandArgument
   /**
    * Returns true if the argument can take multiple values.
    *
-   * @return Boolean true if mode is self::IS_ARRAY, false otherwise
+   * @return bool true if mode is self::IS_ARRAY, false otherwise
    */
   public function isArray()
   {
@@ -90,25 +105,20 @@ class sfCommandArgument
   /**
    * Sets the default value.
    *
-   * @param mixed $default The default value
+   * @param mixed $default  The default value
    *
    * @throws sfCommandException
    */
   public function setDefault($default = null)
   {
-    if (self::REQUIRED === $this->mode && null !== $default)
-    {
+    if (self::REQUIRED === $this->mode && null !== $default) {
       throw new sfCommandException('Cannot set a default value except for sfCommandParameter::OPTIONAL mode.');
     }
 
-    if ($this->isArray())
-    {
-      if (null === $default)
-      {
-        $default = array();
-      }
-      else if (!is_array($default))
-      {
+    if ($this->isArray()) {
+      if (null === $default) {
+        $default = [];
+      } elseif ( ! is_array($default)) {
         throw new sfCommandException('A default value for an array argument must be an array.');
       }
     }

--- a/lib/command/sfCommandArgumentSet.class.php
+++ b/lib/command/sfCommandArgumentSet.class.php
@@ -18,18 +18,21 @@
  */
 class sfCommandArgumentSet
 {
-  protected
-    $arguments          = array(),
-    $requiredCount      = 0,
-    $hasAnArrayArgument = false,
-    $hasOptional        = false;
+  /**
+   * @var array<string,sfCommandArgument>
+   */
+  protected array $arguments = [];
+
+  protected int $requiredCount = 0;
+
+  protected bool $hasAnArrayArgument = false;
+
+  protected bool $hasOptional = false;
 
   /**
-   * Constructor.
-   *
-   * @param array $arguments An array of sfCommandArgument objects
+   * @param sfCommandArgument[] $arguments
    */
-  public function __construct($arguments = array())
+  public function __construct(array $arguments = [])
   {
     $this->setArguments($arguments);
   }
@@ -37,67 +40,57 @@ class sfCommandArgumentSet
   /**
    * Sets the sfCommandArgument objects.
    *
-   * @param array $arguments An array of sfCommandArgument objects
+   * @param sfCommandArgument[] $arguments
    */
-  public function setArguments($arguments = array())
+  public function setArguments(array $arguments): void
   {
-    $this->arguments     = array();
+    $this->arguments     = [];
     $this->requiredCount = 0;
     $this->hasOptional   = false;
+
     $this->addArguments($arguments);
   }
 
   /**
    * Add an array of sfCommandArgument objects.
    *
-   * @param array $arguments An array of sfCommandArgument objects
+   * @param sfCommandArgument[] $arguments
    */
-  public function addArguments($arguments = array())
+  public function addArguments(array $arguments): void
   {
-    if (null !== $arguments)
-    {
-      foreach ($arguments as $argument)
-      {
-        $this->addArgument($argument);
-      }
+    foreach ($arguments as $argument) {
+      $this->addArgument($argument);
     }
   }
 
   /**
-   * Add a sfCommandArgument objects.
+   * Add an sfCommandArgument object.
    *
-   * @param sfCommandArgument $argument A sfCommandArgument object
+   * @param sfCommandArgument $argument
    *
    * @throws sfCommandException
    */
-  public function addArgument(sfCommandArgument $argument)
+  public function addArgument(sfCommandArgument $argument): void
   {
-    if (isset($this->arguments[$argument->getName()]))
-    {
+    if (isset($this->arguments[$argument->getName()])) {
       throw new sfCommandException(sprintf('An argument with name "%s" already exist.', $argument->getName()));
     }
 
-    if ($this->hasAnArrayArgument)
-    {
+    if ($this->hasAnArrayArgument) {
       throw new sfCommandException('Cannot add an argument after an array argument.');
     }
 
-    if ($argument->isRequired() && $this->hasOptional)
-    {
+    if ($argument->isRequired() && $this->hasOptional) {
       throw new sfCommandException('Cannot add a required argument after an optional one.');
     }
 
-    if ($argument->isArray())
-    {
+    if ($argument->isArray()) {
       $this->hasAnArrayArgument = true;
     }
 
-    if ($argument->isRequired())
-    {
+    if ($argument->isRequired()) {
       ++$this->requiredCount;
-    }
-    else
-    {
+    } else {
       $this->hasOptional = true;
     }
 
@@ -107,16 +100,15 @@ class sfCommandArgumentSet
   /**
    * Returns an argument by name.
    *
-   * @param string $name The argument name
+   * @param string $name  The argument name
    *
-   * @return sfCommandArgument A sfCommandArgument object
+   * @return sfCommandArgument
    *
    * @throws sfCommandException
    */
-  public function getArgument($name)
+  public function getArgument(string $name): sfCommandArgument
   {
-    if (!$this->hasArgument($name))
-    {
+    if ( ! $this->hasArgument($name)) {
       throw new sfCommandException(sprintf('The "%s" argument does not exist.', $name));
     }
 
@@ -126,11 +118,11 @@ class sfCommandArgumentSet
   /**
    * Returns true if an argument object exists by name.
    *
-   * @param string $name The argument name
+   * @param string $name  The argument name
    *
-   * @return Boolean true if the argument object exists, false otherwise
+   * @return bool true if the argument object exists, false otherwise
    */
-  public function hasArgument($name)
+  public function hasArgument(string $name): bool
   {
     return isset($this->arguments[$name]);
   }
@@ -138,9 +130,9 @@ class sfCommandArgumentSet
   /**
    * Gets the array of sfCommandArgument objects.
    *
-   * @return sfCommandArgument[] An array of sfCommandArgument objects
+   * @return array<string,sfCommandArgument>
    */
-  public function getArguments()
+  public function getArguments(): array
   {
     return $this->arguments;
   }
@@ -148,9 +140,9 @@ class sfCommandArgumentSet
   /**
    * Returns the number of arguments.
    *
-   * @return integer The number of arguments
+   * @return int The number of arguments
    */
-  public function getArgumentCount()
+  public function getArgumentCount(): int
   {
     return $this->hasAnArrayArgument ? PHP_INT_MAX : count($this->arguments);
   }
@@ -158,9 +150,9 @@ class sfCommandArgumentSet
   /**
    * Returns the number of required arguments.
    *
-   * @return integer The number of required arguments
+   * @return int The number of required arguments
    */
-  public function getArgumentRequiredCount()
+  public function getArgumentRequiredCount(): int
   {
     return $this->requiredCount;
   }
@@ -168,13 +160,12 @@ class sfCommandArgumentSet
   /**
    * Gets the default values.
    *
-   * @return array An array of default values
+   * @return array<string,mixed> An array of default values
    */
-  public function getDefaults()
+  public function getDefaults(): array
   {
-    $values = array();
-    foreach ($this->arguments as $argument)
-    {
+    $values = [];
+    foreach ($this->arguments as $argument) {
       $values[$argument->getName()] = $argument->getDefault();
     }
 

--- a/lib/command/sfCommandLogger.class.php
+++ b/lib/command/sfCommandLogger.class.php
@@ -20,14 +20,14 @@ class sfCommandLogger extends sfConsoleLogger
   /**
    * Class constructor.
    *
-   * @param sfEventDispatcher $dispatcher A sfEventDispatcher instance
-   * @param array             $options    An array of options.
+   * @param sfEventDispatcher $dispatcher  A sfEventDispatcher instance
+   * @param array             $options     An array of options.
    *
    * @throws \sfConfigurationException
    */
-  public function __construct(sfEventDispatcher $dispatcher, $options = array())
+  public function __construct(sfEventDispatcher $dispatcher, array $options = [])
   {
-    $dispatcher->connect('command.log', array($this, 'listenToLogEvent'));
+    $dispatcher->connect('command.log', [$this, 'listenToLogEvent']);
 
     return parent::__construct($dispatcher, $options);
   }
@@ -35,25 +35,22 @@ class sfCommandLogger extends sfConsoleLogger
   /**
    * Listens to command.log events.
    *
-   * @param sfEvent $event An sfEvent instance
+   * @param sfEvent $event  An sfEvent instance
    */
-  public function listenToLogEvent(sfEvent $event)
+  public function listenToLogEvent(sfEvent $event): void
   {
     $priority = $event->getParameter('priority') ?? self::INFO;
 
     $prefix = '';
-    if ('application.log' == $event->getName())
-    {
-      $subject  = $event->getSubject();
-      $subject  = is_object($subject) ? get_class($subject) : (is_string($subject) ? $subject : 'main');
+    if ('application.log' == $event->getName()) {
+      $subject = $event->getSubject();
+      $subject = is_object($subject) ? get_class($subject) : (is_string($subject) ? $subject : 'main');
 
-      $prefix = '>> '.$subject.' ';
+      $prefix = '>> ' . $subject . ' ';
     }
 
-    foreach ($event->getParameters() as $key => $message)
-    {
-      if ('priority' === $key)
-      {
+    foreach ($event->getParameters() as $key => $message) {
+      if ('priority' === $key) {
         continue;
       }
 

--- a/lib/command/sfCommandOption.class.php
+++ b/lib/command/sfCommandOption.class.php
@@ -18,56 +18,72 @@
  */
 class sfCommandOption
 {
-  const PARAMETER_NONE     = 1;
-  const PARAMETER_REQUIRED = 2;
-  const PARAMETER_OPTIONAL = 4;
+  public const PARAMETER_NONE     = 1;
+  public const PARAMETER_REQUIRED = 2;
+  public const PARAMETER_OPTIONAL = 4;
 
-  const IS_ARRAY = 8;
-
-  protected
-    $name     = null,
-    $shortcut = null,
-    $mode     = null,
-    $default  = null,
-    $help     = '';
+  public const IS_ARRAY = 8;
 
   /**
-   * Constructor.
+   * The option name
+   */
+  protected string $name;
+
+  /**
+   * The shortcut
+   */
+  protected string | null $shortcut;
+
+  /**
+   * The option mode
    *
-   * @param string  $name     The option name
-   * @param string  $shortcut The shortcut (can be null)
-   * @param integer $mode     The option mode: self::PARAMETER_REQUIRED, self::PARAMETER_NONE or self::PARAMETER_OPTIONAL
-   * @param string  $help     A help text
-   * @param mixed   $default  The default value (must be null for self::PARAMETER_REQUIRED or self::PARAMETER_NONE)
+   * @see self::PARAMETER_REQUIRED
+   * @see self::PARAMETER_NONE
+   * @see self::PARAMETER_OPTIONAL
+   * @see self::IS_ARRAY
+   */
+  protected int $mode;
+
+  /**
+   * The default value
+   *
+   * (must be null for self::PARAMETER_REQUIRED or self::PARAMETER_NONE)
+   */
+  protected mixed $default;
+
+  /**
+   * Help text
+   */
+  protected string $help;
+
+  /**
+   * @param string      $name      The option name
+   * @param string|null $shortcut  The shortcut
+   * @param int|null    $mode      The option mode: self::PARAMETER_REQUIRED, self::PARAMETER_NONE or self::PARAMETER_OPTIONAL
+   * @param string      $help      A help text
+   * @param mixed       $default   The default value (must be null for self::PARAMETER_REQUIRED or self::PARAMETER_NONE)
    *
    * @throws sfCommandException
    */
-  public function __construct($name, $shortcut = null, $mode = null, $help = '', $default = null)
+  public function __construct(string $name, string | null $shortcut = null, int | null $mode = null, string $help = '', mixed $default = null)
   {
-    if ('--' == substr($name, 0, 2))
-    {
+    if ('--' == substr($name, 0, 2)) {
       $name = substr($name, 2);
     }
 
-    if (empty($shortcut))
-    {
+    if (empty($shortcut)) {
       $shortcut = null;
     }
 
-    if (null !== $shortcut)
-    {
-      if ('-' == $shortcut[0])
-      {
+    if (null !== $shortcut) {
+      if ('-' == $shortcut[0]) {
         $shortcut = substr($shortcut, 1);
       }
     }
 
-    if (null === $mode)
-    {
+    if (null === $mode) {
       $mode = self::PARAMETER_NONE;
-    }
-    else if (is_string($mode) || $mode > 15)
-    {
+    } elseif (is_string($mode) || $mode > 15) {
       throw new sfCommandException(sprintf('Option mode "%s" is not valid.', $mode));
     }
 
@@ -82,9 +98,9 @@ class sfCommandOption
   /**
    * Returns the shortcut.
    *
-   * @return string The shortcut
+   * @return string|null The shortcut
    */
-  public function getShortcut()
+  public function getShortcut(): ?string
   {
     return $this->shortcut;
   }
@@ -94,17 +110,17 @@ class sfCommandOption
    *
    * @return string The name
    */
-  public function getName()
+  public function getName(): string
   {
     return $this->name;
   }
 
   /**
-   * Returns true if the option accept a parameter.
+   * Returns true if the option accepts a parameter.
    *
-   * @return Boolean true if parameter mode is not self::PARAMETER_NONE, false otherwise
+   * @return bool true if parameter mode is not self::PARAMETER_NONE, false otherwise
    */
-  public function acceptParameter()
+  public function acceptParameter(): bool
   {
     return $this->isParameterRequired() || $this->isParameterOptional();
   }
@@ -112,9 +128,9 @@ class sfCommandOption
   /**
    * Returns true if the option requires a parameter.
    *
-   * @return Boolean true if parameter mode is self::PARAMETER_REQUIRED, false otherwise
+   * @return bool true if parameter mode is self::PARAMETER_REQUIRED, false otherwise
    */
-  public function isParameterRequired()
+  public function isParameterRequired(): bool
   {
     return self::PARAMETER_REQUIRED === (self::PARAMETER_REQUIRED & $this->mode);
   }
@@ -122,9 +138,9 @@ class sfCommandOption
   /**
    * Returns true if the option takes an optional parameter.
    *
-   * @return Boolean true if parameter mode is self::PARAMETER_OPTIONAL, false otherwise
+   * @return bool true if parameter mode is self::PARAMETER_OPTIONAL, false otherwise
    */
-  public function isParameterOptional()
+  public function isParameterOptional(): bool
   {
     return self::PARAMETER_OPTIONAL === (self::PARAMETER_OPTIONAL & $this->mode);
   }
@@ -132,9 +148,9 @@ class sfCommandOption
   /**
    * Returns true if the option can take multiple values.
    *
-   * @return Boolean true if mode is self::IS_ARRAY, false otherwise
+   * @return bool true if mode is self::IS_ARRAY, false otherwise
    */
-  public function isArray()
+  public function isArray(): bool
   {
     return self::IS_ARRAY === (self::IS_ARRAY & $this->mode);
   }
@@ -142,25 +158,20 @@ class sfCommandOption
   /**
    * Sets the default value.
    *
-   * @param mixed $default The default value
+   * @param mixed $default  The default value
    *
    * @throws sfCommandException
    */
-  public function setDefault($default = null)
+  public function setDefault(mixed $default = null): void
   {
-    if (self::PARAMETER_NONE === (self::PARAMETER_NONE & $this->mode) && null !== $default)
-    {
+    if (self::PARAMETER_NONE === (self::PARAMETER_NONE & $this->mode) && null !== $default) {
       throw new sfCommandException('Cannot set a default value when using sfCommandOption::PARAMETER_NONE mode.');
     }
 
-    if ($this->isArray())
-    {
-      if (null === $default)
-      {
-        $default = array();
-      }
-      else if (!is_array($default))
-      {
+    if ($this->isArray()) {
+      if (null === $default) {
+        $default = [];
+      } elseif ( ! is_array($default)) {
         throw new sfCommandException('A default value for an array option must be an array.');
       }
     }
@@ -173,7 +184,7 @@ class sfCommandOption
    *
    * @return mixed The default value
    */
-  public function getDefault()
+  public function getDefault(): mixed
   {
     return $this->default;
   }
@@ -183,7 +194,7 @@ class sfCommandOption
    *
    * @return string The help text
    */
-  public function getHelp()
+  public function getHelp(): string
   {
     return $this->help;
   }

--- a/lib/command/sfCommandOptionSet.class.php
+++ b/lib/command/sfCommandOptionSet.class.php
@@ -18,16 +18,17 @@
  */
 class sfCommandOptionSet
 {
-  protected
-    $options   = array(),
-    $shortcuts = array();
+  /**
+   * @var array<string,sfCommandOption>
+   */
+  protected array $options = [];
+
+  protected array $shortcuts = [];
 
   /**
-   * Constructor.
-   *
-   * @param array $options An array of sfCommandOption objects
+   * @param sfCommandOption[] $options
    */
-  public function __construct($options = array())
+  public function __construct(array $options = [])
   {
     $this->setOptions($options);
   }
@@ -35,24 +36,24 @@ class sfCommandOptionSet
   /**
    * Sets the sfCommandOption objects.
    *
-   * @param array $options An array of sfCommandOption objects
+   * @param sfCommandOption[] $options
    */
-  public function setOptions($options = array())
+  public function setOptions(array $options = []): void
   {
-    $this->options = array();
-    $this->shortcuts = array();
+    $this->options   = [];
+    $this->shortcuts = [];
+
     $this->addOptions($options);
   }
 
   /**
    * Add an array of sfCommandOption objects.
    *
-   * @param array $options An array of sfCommandOption objects
+   * @param array $options  An array of sfCommandOption objects
    */
-  public function addOptions($options = array())
+  public function addOptions(array $options = []): void
   {
-    foreach ($options as $option)
-    {
+    foreach ($options as $option) {
       $this->addOption($option);
     }
   }
@@ -60,24 +61,23 @@ class sfCommandOptionSet
   /**
    * Add a sfCommandOption objects.
    *
-   * @param sfCommandOption $option A sfCommandOption object
+   * @param sfCommandOption $option  A sfCommandOption object
    *
    * @throws sfCommandException
    */
-  public function addOption(sfCommandOption $option)
+  public function addOption(sfCommandOption $option): void
   {
-    if (isset($this->options[$option->getName()]))
-    {
+    if (isset($this->options[$option->getName()])) {
       throw new sfCommandException(sprintf('An option named "%s" already exist.', $option->getName()));
     }
-    else if (isset($this->shortcuts[$option->getShortcut()]))
-    {
+
+    if (isset($this->shortcuts[$option->getShortcut()])) {
       throw new sfCommandException(sprintf('An option with shortcut "%s" already exist.', $option->getShortcut()));
     }
 
     $this->options[$option->getName()] = $option;
-    if ($option->getShortcut())
-    {
+
+    if ($option->getShortcut()) {
       $this->shortcuts[$option->getShortcut()] = $option->getName();
     }
   }
@@ -85,16 +85,15 @@ class sfCommandOptionSet
   /**
    * Returns an option by name.
    *
-   * @param string $name The option name
+   * @param string $name  The option name
    *
    * @return sfCommandOption A sfCommandOption object
    *
    * @throws sfCommandException
    */
-  public function getOption($name)
+  public function getOption(string $name): sfCommandOption
   {
-    if (!$this->hasOption($name))
-    {
+    if ( ! $this->hasOption($name)) {
       throw new sfCommandException(sprintf('The "--%s" option does not exist.', $name));
     }
 
@@ -104,11 +103,11 @@ class sfCommandOptionSet
   /**
    * Returns true if an option object exists by name.
    *
-   * @param string $name The option name
+   * @param string $name  The option name
    *
-   * @return Boolean true if the option object exists, false otherwise
+   * @param bool true if the option object exists, false otherwise
    */
-  public function hasOption($name)
+  public function hasOption(string $name): bool
   {
     return isset($this->options[$name]);
   }
@@ -116,9 +115,9 @@ class sfCommandOptionSet
   /**
    * Gets the array of sfCommandOption objects.
    *
-   * @return sfCommandOption[] An array of sfCommandOption objects
+   * @return array<string,sfCommandOption>
    */
-  public function getOptions()
+  public function getOptions(): array
   {
     return $this->options;
   }
@@ -126,11 +125,11 @@ class sfCommandOptionSet
   /**
    * Returns true if an option object exists by shortcut.
    *
-   * @param string $name The option shortcut
+   * @param string $name  The option shortcut
    *
-   * @return Boolean true if the option object exists, false otherwise
+   * @param bool true if the option object exists, false otherwise
    */
-  public function hasShortcut($name)
+  public function hasShortcut(string $name): bool
   {
     return isset($this->shortcuts[$name]);
   }
@@ -142,7 +141,7 @@ class sfCommandOptionSet
    *
    * @return sfCommandOption A sfCommandOption object
    */
-  public function getOptionForShortcut($shortcut)
+  public function getOptionForShortcut(string $shortcut): sfCommandOption
   {
     return $this->getOption($this->shortcutToName($shortcut));
   }
@@ -150,13 +149,13 @@ class sfCommandOptionSet
   /**
    * Gets an array of default values.
    *
-   * @return array An array of all default values
+   * @return array<string,mixed> An array of all default values
    */
-  public function getDefaults()
+  public function getDefaults(): array
   {
-    $values = array();
-    foreach ($this->options as $option)
-    {
+    $values = [];
+
+    foreach ($this->options as $option) {
       $values[$option->getName()] = $option->getDefault();
     }
 
@@ -166,16 +165,15 @@ class sfCommandOptionSet
   /**
    * Returns the option name given a shortcut.
    *
-   * @param string $shortcut The shortcut
+   * @param string $shortcut  The shortcut
    *
    * @return string The option name
    *
    * @throws sfCommandException
    */
-  protected function shortcutToName($shortcut)
+  protected function shortcutToName(string $shortcut): string
   {
-    if (!isset($this->shortcuts[$shortcut]))
-    {
+    if ( ! isset($this->shortcuts[$shortcut])) {
       throw new sfCommandException(sprintf('The "-%s" option does not exist.', $shortcut));
     }
 

--- a/lib/command/sfFormatter.class.php
+++ b/lib/command/sfFormatter.class.php
@@ -18,21 +18,18 @@
  */
 class sfFormatter
 {
-  protected
-    $size = null;
+  private const DEFAULT_SIZE = 78;
 
-  function __construct($maxLineSize = null)
+  protected int | null $size = null;
+
+  function __construct(int | null $maxLineSize = null)
   {
-    if (null === $maxLineSize)
-    {
-      if (function_exists('shell_exec'))
-      {
+    if (null === $maxLineSize) {
+      if (function_exists('shell_exec')) {
         // this is tricky because "tput cols 2>&1" is not accurate
-        $maxLineSize = ctype_digit(trim(shell_exec('tput cols 2>&1'))) ? (integer) shell_exec('tput cols') : 78;
-      }
-      else
-      {
-        $maxLineSize = 78;
+        $maxLineSize = ctype_digit(trim(shell_exec('tput cols 2>&1'))) ? (integer)shell_exec('tput cols') : 78;
+      } else {
+        $maxLineSize = self::DEFAULT_SIZE;
       }
     }
 
@@ -42,22 +39,22 @@ class sfFormatter
   /**
    * Sets a new style.
    *
-   * @param string $name    The style name
-   * @param array  $options An array of options
+   * @param string $name     The style name
+   * @param array  $options  An array of options
    */
-  public function setStyle($name, $options = array())
+  public function setStyle(string $name, array $options = []): void
   {
   }
 
   /**
    * Formats a text according to the given parameters.
    *
-   * @param  string $text         The test to style
-   * @param  mixed  $parameters   An array of parameters
+   * @param string         $text        The test to style
+   * @param string | array $parameters  An array of parameters
    *
    * @return string The formatted text
    */
-  public function format($text = '', $parameters = array())
+  public function format(string $text = '', string | array $parameters = []): string
   {
     return $text;
   }
@@ -65,55 +62,50 @@ class sfFormatter
   /**
    * Formats a message within a section.
    *
-   * @param string  $section The section name
-   * @param string  $text    The text message
-   * @param integer $size    The maximum size allowed for a line
+   * @param string $section  The section name
+   * @param string $text     The text message
+   * @param int    $size     The maximum size allowed for a line
    *
    * @return string
    */
-  public function formatSection($section, $text, $size = null)
+  public function formatSection(string $section, string $text, int | null $size = null): string
   {
-    if (!$size)
-    {
-      $size = $this->size;
-    }
+    $size = $size ?: $this->size;
 
     $section = sprintf('>> %-9s ', $section);
 
-    return $section.$this->excerpt($text, $size - strlen($section));
+    return $section . $this->excerpt($text, $size - strlen($section));
   }
 
   /**
    * Truncates a line.
    *
-   * @param string  $text The text
-   * @param integer $size The maximum size of the returned string
+   * @param string $text  The text
+   * @param int    $size  The maximum size of the returned string
    *
    * @return string The truncated string
    */
-  public function excerpt($text, $size = null)
+  public function excerpt(string $text, int | null $size = null): string
   {
-    if (!$size)
-    {
+    if ( ! $size) {
       $size = $this->size;
     }
 
-    if (strlen($text) < $size)
-    {
+    if (strlen($text) < $size) {
       return $text;
     }
 
     $subsize = floor(($size - 3) / 2);
 
-    return substr($text, 0, $subsize).'...'.substr($text, -$subsize);
+    return substr($text, 0, $subsize) . '...' . substr($text, -$subsize);
   }
 
   /**
    * Sets the maximum line size.
    *
-   * @param integer $size The maximum line size for a message
+   * @param int $size  The maximum line size for a message
    */
-  public function setMaxLineSize($size)
+  public function setMaxLineSize(int $size): void
   {
     $this->size = $size;
   }

--- a/lib/command/sfSymfonyCommandApplication.class.php
+++ b/lib/command/sfSymfonyCommandApplication.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -18,26 +18,23 @@
  */
 class sfSymfonyCommandApplication extends sfCommandApplication
 {
-  protected $taskFiles = array();
-  
+  /** @var array<string,string> */
+  protected array $taskFiles = [];
+
   /**
    * Configures the current symfony command application.
    */
-  public function configure()
+  public function configure(): void
   {
-    if (!isset($this->options['symfony_lib_dir']))
-    {
+    if ( ! isset($this->options['symfony_lib_dir'])) {
       throw new sfInitializationException('You must pass a "symfony_lib_dir" option.');
     }
-    
-    $configurationFile = getcwd().'/config/ProjectConfiguration.class.php';
-    if (is_readable($configurationFile))
-    {
+
+    $configurationFile = getcwd() . '/config/ProjectConfiguration.class.php';
+    if (is_readable($configurationFile)) {
       require_once $configurationFile;
       $configuration = new ProjectConfiguration(getcwd(), $this->dispatcher);
-    }
-    else
-    {
+    } else {
       $configuration = new sfProjectConfiguration(getcwd(), $this->dispatcher);
     }
 
@@ -51,25 +48,23 @@ class sfSymfonyCommandApplication extends sfCommandApplication
   /**
    * Runs the current application.
    *
-   * @param mixed $options The command line options
+   * @param mixed $options  The command line options
    *
-   * @return integer 0 if everything went fine, or an error code
+   * @return int 0 if everything went fine, or an error code
    */
-  public function run($options = null)
+  public function run(array | string | null $options = null): int
   {
     $this->handleOptions($options);
     $arguments = $this->commandManager->getArgumentValues();
 
-    if (!isset($arguments['task']))
-    {
-      $arguments['task'] = 'list';
+    if ( ! isset($arguments['task'])) {
+      $arguments['task']    = 'list';
       $this->commandOptions .= $arguments['task'];
     }
 
     $this->currentTask = $this->getTaskToExecute($arguments['task']);
 
-    if ($this->currentTask instanceof sfCommandApplicationTask)
-    {
+    if ($this->currentTask instanceof sfCommandApplicationTask) {
       $this->currentTask->setCommandApplication($this);
     }
 
@@ -85,56 +80,51 @@ class sfSymfonyCommandApplication extends sfCommandApplication
    *
    * Looks for tasks in the symfony core, the current project and all project plugins.
    *
-   * @param sfProjectConfiguration $configuration The project configuration
+   * @param sfProjectConfiguration $configuration  The project configuration
    */
-  public function loadTasks(sfProjectConfiguration $configuration)
+  public function loadTasks(sfProjectConfiguration $configuration): void
   {
     // Symfony core tasks
-    $dirs = array(sfConfig::get('sf_symfony_lib_dir').'/task');
+    $dirs = [sfConfig::get('sf_symfony_lib_dir') . '/task'];
 
     // Plugin tasks
-    foreach ($configuration->getPluginPaths() as $path)
-    {
-      if (is_dir($taskPath = $path.'/lib/task'))
-      {
+    foreach ($configuration->getPluginPaths() as $path) {
+      if (is_dir($taskPath = $path . '/lib/task')) {
         $dirs[] = $taskPath;
       }
     }
 
     // project tasks
-    $dirs[] = sfConfig::get('sf_lib_dir').'/task';
+    $dirs[] = sfConfig::get('sf_lib_dir') . '/task';
 
     $finder = sfFinder::type('file')->name('*Task.class.php');
-    foreach ($finder->in($dirs) as $file)
-    {
+    foreach ($finder->in($dirs) as $file) {
       $this->taskFiles[basename($file, '.class.php')] = $file;
     }
 
     // register local autoloader for tasks
-    spl_autoload_register(array($this, 'autoloadTask'));
+    spl_autoload_register([$this, 'autoloadTask']);
 
     // require tasks
-    foreach ($this->taskFiles as $task => $file)
-    {
+    foreach ($this->taskFiles as $task => $file) {
       // forces autoloading of each task class
       class_exists($task, true);
     }
 
     // unregister local autoloader
-    spl_autoload_unregister(array($this, 'autoloadTask'));
+    spl_autoload_unregister([$this, 'autoloadTask']);
   }
 
   /**
    * Autoloads a task class
    *
-   * @param  string  $class  The task class name
+   * @param string $class  The task class name
    *
-   * @return Boolean
+   * @return bool
    */
-  public function autoloadTask($class)
+  public function autoloadTask(string $class): bool
   {
-    if (isset($this->taskFiles[$class]))
-    {
+    if (isset($this->taskFiles[$class])) {
       require_once $this->taskFiles[$class];
 
       return true;
@@ -146,8 +136,8 @@ class sfSymfonyCommandApplication extends sfCommandApplication
   /**
    * @see sfCommandApplication
    */
-  public function getLongVersion()
+  public function getLongVersion(): string
   {
-    return sprintf('%s version %s (%s)', $this->getName(), $this->formatter->format($this->getVersion(), 'INFO'), sfConfig::get('sf_symfony_lib_dir'))."\n";
+    return sprintf('%s version %s (%s)', $this->getName(), $this->formatter->format($this->getVersion(), 'INFO'), sfConfig::get('sf_symfony_lib_dir')) . "\n";
   }
 }

--- a/lib/config/sfApplicationConfiguration.class.php
+++ b/lib/config/sfApplicationConfiguration.class.php
@@ -19,36 +19,39 @@
 abstract class sfApplicationConfiguration extends ProjectConfiguration
 {
   /** @var bool */
-  static protected $coreLoaded = false;
-  /** @var bool[] [ string $helper_name => bool, ... ] */
-  static protected $loadedHelpers = [];
+  static protected bool $coreLoaded = false;
 
-  /** @var \sfConfigCache|null */
-  protected $configCache = null;
-  /** @var string */
-  protected $application = null;
-  /** @var string */
-  protected $environment = null;
-  /** @var bool */
-  protected $debug = false;
+  /** @var array<string,bool> [ string $helper_name => bool, ... ] */
+  static protected array $loadedHelpers = [];
+
+  protected sfConfigCache $configCache;
+
+  protected string $application;
+
+  protected string $environment;
+
+  protected bool $debug = false;
+
   /** @var array Multi-level configuration array structure */
-  protected $config = [];
+  protected array $config = [];
+
   /** @var mixed[] Multi-level configuration cache */
-  protected $cache = null;
+  protected array $cache = [];
 
   /**
    * Constructor.
    *
-   * @param string            $environment    The environment name
-   * @param bool              $debug          true to enable debug mode
-   * @param string            $rootDir        The project root directory
-   * @param sfEventDispatcher $dispatcher     An event dispatcher
+   * @param string                 $environment  The environment name
+   * @param bool                   $debug        true to enable debug mode
+   * @param string|null            $rootDir      The project root directory
+   * @param sfEventDispatcher|null $dispatcher   An event dispatcher
    */
   public function __construct(string $environment, bool $debug, string $rootDir = null, sfEventDispatcher $dispatcher = null)
   {
     $this->environment = $environment;
     $this->debug       = $debug;
     $this->application = str_replace('Configuration', '', get_class($this));
+    $this->configCache = new sfConfigCache($this);
 
     parent::__construct($rootDir, $dispatcher);
 
@@ -56,13 +59,11 @@ abstract class sfApplicationConfiguration extends ProjectConfiguration
 
     $this->initConfiguration();
 
-    if (sfConfig::get('sf_check_lock'))
-    {
+    if (sfConfig::get('sf_check_lock')) {
       $this->checkLock();
     }
 
-    if (is_file($file = sfConfig::get('sf_app_cache_dir').'/config/configuration.php'))
-    {
+    if (is_file($file = sfConfig::get('sf_app_cache_dir') . '/config/configuration.php')) {
       $this->cache = require $file;
     }
 
@@ -104,26 +105,22 @@ abstract class sfApplicationConfiguration extends ProjectConfiguration
     $configCache = $this->getConfigCache();
 
     // in debug mode, start global timer
-    if ($this->isDebug() && !sfConfig::get('sf_cli') && !sfWebDebugPanelTimer::isStarted())
-    {
+    if ($this->isDebug() && ! sfConfig::get('sf_cli') && ! sfWebDebugPanelTimer::isStarted()) {
       sfWebDebugPanelTimer::startTime();
     }
 
     // required core classes for the framework
-    if (!$this->isDebug() && !sfConfig::get('sf_test') && !sfConfig::get('sf_cli') && !self::$coreLoaded)
-    {
+    if ( ! $this->isDebug() && ! sfConfig::get('sf_test') && ! sfConfig::get('sf_cli') && ! self::$coreLoaded) {
       $configCache->import('config/core_compile.yml', false);
     }
 
     // load base settings
     include($configCache->checkConfig('config/settings.yml'));
-    if ($file = $configCache->checkConfig('config/app.yml', true))
-    {
+    if ($file = $configCache->checkConfig('config/app.yml', true)) {
       include($file);
     }
 
-    if (!sfConfig::get('sf_cli') && false !== sfConfig::get('sf_csrf_secret'))
-    {
+    if ( ! sfConfig::get('sf_cli') && false !== sfConfig::get('sf_csrf_secret')) {
       sfForm::enableCSRFProtection(sfConfig::get('sf_csrf_secret'));
     }
 
@@ -131,12 +128,9 @@ abstract class sfApplicationConfiguration extends ProjectConfiguration
     sfValidatorBase::setCharset(sfConfig::get('sf_charset'));
 
     // force setting default timezone if not set
-    if ($default_timezone = sfConfig::get('sf_default_timezone'))
-    {
+    if ($default_timezone = sfConfig::get('sf_default_timezone')) {
       date_default_timezone_set($default_timezone);
-    }
-    else if (sfConfig::get('sf_force_default_timezone', true))
-    {
+    } elseif (sfConfig::get('sf_force_default_timezone', true)) {
       date_default_timezone_set(@date_default_timezone_get());
     }
 
@@ -158,14 +152,12 @@ abstract class sfApplicationConfiguration extends ProjectConfiguration
    */
   protected function initializePlugins(): void
   {
-    foreach ($this->pluginConfigurations as $name => $configuration)
-    {
+    foreach ($this->pluginConfigurations as $name => $configuration) {
       if (
         false === $configuration->initialize()
         &&
-        is_readable($config = $configuration->getRootDir().'/config/config.php')
-      )
-      {
+        is_readable($config = $configuration->getRootDir() . '/config/config.php')
+      ) {
         require $config;
       }
     }
@@ -178,11 +170,6 @@ abstract class sfApplicationConfiguration extends ProjectConfiguration
    */
   public function getConfigCache(): sfConfigCache
   {
-    if (null === $this->configCache)
-    {
-      $this->configCache = new sfConfigCache($this);
-    }
-
     return $this->configCache;
   }
 
@@ -194,23 +181,20 @@ abstract class sfApplicationConfiguration extends ProjectConfiguration
   public function checkLock(): void
   {
     if (
-      $this->hasLockFile(sfConfig::get('sf_data_dir').DIRECTORY_SEPARATOR.$this->getApplication().'_'.$this->getEnvironment().'-cli.lck', 5)
+      $this->hasLockFile(sfConfig::get('sf_data_dir') . DIRECTORY_SEPARATOR . $this->getApplication() . '_' . $this->getEnvironment() . '-cli.lck', 5)
       ||
-      $this->hasLockFile(sfConfig::get('sf_data_dir').DIRECTORY_SEPARATOR.$this->getApplication().'_'.$this->getEnvironment().'.lck')
-    )
-    {
+      $this->hasLockFile(sfConfig::get('sf_data_dir') . DIRECTORY_SEPARATOR . $this->getApplication() . '_' . $this->getEnvironment() . '.lck')
+    ) {
       // application is not available - we'll find the most specific unavailable page...
-      $files = array(
-        sfConfig::get('sf_app_config_dir').'/unavailable.php',
-        sfConfig::get('sf_config_dir').'/unavailable.php',
-        sfConfig::get('sf_web_dir').'/errors/unavailable.php',
-        $this->getSymfonyLibDir().'/exception/data/unavailable.php',
-      );
+      $files = [
+        sfConfig::get('sf_app_config_dir') . '/unavailable.php',
+        sfConfig::get('sf_config_dir') . '/unavailable.php',
+        sfConfig::get('sf_web_dir') . '/errors/unavailable.php',
+        $this->getSymfonyLibDir() . '/exception/data/unavailable.php',
+      ];
 
-      foreach ($files as $file)
-      {
-        if (is_readable($file))
-        {
+      foreach ($files as $file) {
+        if (is_readable($file)) {
           header("HTTP/1.1 503 Service Temporarily Unavailable");
           header("Status: 503 Service Temporarily Unavailable");
 
@@ -226,25 +210,21 @@ abstract class sfApplicationConfiguration extends ProjectConfiguration
   /**
    * Determines if a lock file is present.
    *
-   * @param  string  $lockFile             Name of the lock file.
-   * @param  integer $maxLockFileLifeTime  A max amount of life time for the lock file.
+   * @param string  $lockFile             Name of the lock file.
+   * @param integer $maxLockFileLifeTime  A max amount of life time for the lock file.
    *
    * @return bool true, if the lock file is present, otherwise false.
    */
   protected function hasLockFile(string $lockFile, int $maxLockFileLifeTime = 0): bool
   {
     $isLocked = false;
-    if (is_readable($lockFile) && ($last_access = fileatime($lockFile)))
-    {
-      $now = time();
+    if (is_readable($lockFile) && ($last_access = fileatime($lockFile))) {
+      $now      = time();
       $timeDiff = $now - $last_access;
 
-      if (!$maxLockFileLifeTime || $timeDiff < $maxLockFileLifeTime)
-      {
+      if ( ! $maxLockFileLifeTime || $timeDiff < $maxLockFileLifeTime) {
         $isLocked = true;
-      }
-      else
-      {
+      } else {
         $isLocked = @unlink($lockFile) ? false : true;
       }
     }
@@ -255,39 +235,39 @@ abstract class sfApplicationConfiguration extends ProjectConfiguration
   /**
    * Sets the project root directory.
    *
-   * @param string $rootDir The project root directory
+   * @param string $rootDir  The project root directory
    */
   public function setRootDir(string $rootDir): void
   {
     parent::setRootDir($rootDir);
 
-    sfConfig::add(array(
+    sfConfig::add([
       'sf_app'         => $this->getApplication(),
       'sf_environment' => $this->getEnvironment(),
       'sf_debug'       => $this->isDebug(),
       'sf_cli'         => PHP_SAPI === 'cli',
-    ));
+    ]);
 
-    $this->setAppDir(sfConfig::get('sf_apps_dir').DIRECTORY_SEPARATOR.$this->getApplication());
+    $this->setAppDir(sfConfig::get('sf_apps_dir') . DIRECTORY_SEPARATOR . $this->getApplication());
   }
 
   /**
    * Sets the app directory.
    *
-   * @param string $appDir The absolute path to the app dir.
+   * @param string $appDir  The absolute path to the app dir.
    */
   public function setAppDir(string $appDir): void
   {
-    sfConfig::add(array(
-      'sf_app_dir' => $appDir,
+    sfConfig::add([
+      'sf_app_dir'          => $appDir,
 
       // SF_APP_DIR directory structure
-      'sf_app_config_dir'   => $appDir.DIRECTORY_SEPARATOR.'config',
-      'sf_app_lib_dir'      => $appDir.DIRECTORY_SEPARATOR.'lib',
-      'sf_app_module_dir'   => $appDir.DIRECTORY_SEPARATOR.'modules',
-      'sf_app_template_dir' => $appDir.DIRECTORY_SEPARATOR.'templates',
-      'sf_app_i18n_dir'     => $appDir.DIRECTORY_SEPARATOR.'i18n',
-    ));
+      'sf_app_config_dir'   => $appDir . DIRECTORY_SEPARATOR . 'config',
+      'sf_app_lib_dir'      => $appDir . DIRECTORY_SEPARATOR . 'lib',
+      'sf_app_module_dir'   => $appDir . DIRECTORY_SEPARATOR . 'modules',
+      'sf_app_template_dir' => $appDir . DIRECTORY_SEPARATOR . 'templates',
+      'sf_app_i18n_dir'     => $appDir . DIRECTORY_SEPARATOR . 'i18n',
+    ]);
   }
 
   /**
@@ -298,44 +278,40 @@ abstract class sfApplicationConfiguration extends ProjectConfiguration
   {
     parent::setCacheDir($cacheDir);
 
-    sfConfig::add(array(
-      'sf_app_base_cache_dir' => $cacheDir.DIRECTORY_SEPARATOR.$this->getApplication(),
-      'sf_app_cache_dir'      => $appCacheDir = $cacheDir.DIRECTORY_SEPARATOR.$this->getApplication().DIRECTORY_SEPARATOR.$this->getEnvironment(),
+    sfConfig::add([
+      'sf_app_base_cache_dir' => $cacheDir . DIRECTORY_SEPARATOR . $this->getApplication(),
+      'sf_app_cache_dir'      => $appCacheDir = $cacheDir . DIRECTORY_SEPARATOR . $this->getApplication() . DIRECTORY_SEPARATOR . $this->getEnvironment(),
 
       // SF_CACHE_DIR directory structure
-      'sf_template_cache_dir' => $appCacheDir.DIRECTORY_SEPARATOR.'template',
-      'sf_i18n_cache_dir'     => $appCacheDir.DIRECTORY_SEPARATOR.'i18n',
-      'sf_config_cache_dir'   => $appCacheDir.DIRECTORY_SEPARATOR.'config',
-      'sf_test_cache_dir'     => $appCacheDir.DIRECTORY_SEPARATOR.'test',
-      'sf_module_cache_dir'   => $appCacheDir.DIRECTORY_SEPARATOR.'modules',
-    ));
+      'sf_template_cache_dir' => $appCacheDir . DIRECTORY_SEPARATOR . 'template',
+      'sf_i18n_cache_dir'     => $appCacheDir . DIRECTORY_SEPARATOR . 'i18n',
+      'sf_config_cache_dir'   => $appCacheDir . DIRECTORY_SEPARATOR . 'config',
+      'sf_test_cache_dir'     => $appCacheDir . DIRECTORY_SEPARATOR . 'test',
+      'sf_module_cache_dir'   => $appCacheDir . DIRECTORY_SEPARATOR . 'modules',
+    ]);
   }
 
   /**
    * Gets directories where controller classes are stored for a given module.
    *
-   * @param string $moduleName The module name
+   * @param string $moduleName  The module name
    *
-   * @return string[] An array of directories
+   * @return array<string,bool> An array of directories
    */
   public function getControllerDirs(string $moduleName): array
   {
-    if (!isset($this->cache['getControllerDirs'][$moduleName]))
-    {
-      $dirs = array();
+    if ( ! isset($this->cache['getControllerDirs'][$moduleName])) {
+      $dirs = [];
 
-      $dirs[sfConfig::get('sf_app_module_dir').'/'.$moduleName.'/actions'] = false; // application
+      $dirs[sprintf("%s/%s/actions", sfConfig::get('sf_app_module_dir'), $moduleName)] = false; // application
 
-      foreach ($this->getPluginPaths() as $path)
-      {
-        if (is_dir($dir = $path.'/modules/'.$moduleName.'/actions'))
-        {
+      foreach ($this->getPluginPaths() as $path) {
+        if (is_dir($dir = "{$path}/modules/{$moduleName}/actions")) {
           $dirs[$dir] = true; // plugins
         }
       }
 
-      if (is_dir($dir = $this->getSymfonyLibDir().'/controller/'.$moduleName.'/actions'))
-      {
+      if (is_dir($dir = "{$this->getSymfonyLibDir()}/controller/{$moduleName}/actions")) {
         $dirs[$dir] = true; // core modules
       }
 
@@ -348,18 +324,18 @@ abstract class sfApplicationConfiguration extends ProjectConfiguration
   /**
    * Gets directories where lib files are stored for a given module.
    *
-   * @param string $moduleName The module name
+   * @param string $moduleName  The module name
    *
    * @return string[] An array of directories
    */
   public function getLibDirs(string $moduleName): array
   {
-    $dirs = array();
+    $dirs = [];
 
-    $dirs[] = sfConfig::get('sf_app_module_dir').'/'.$moduleName.'/lib';                  // application
-    $dirs = array_merge($dirs, $this->getPluginSubPaths('/modules/'.$moduleName.'/lib')); // plugins
-    $dirs[] = $this->getSymfonyLibDir().'/controller/'.$moduleName.'/lib';                // core modules
-    $dirs[] = sfConfig::get('sf_module_cache_dir').'/auto'.ucfirst($moduleName.'/lib');   // generated templates in cache
+    $dirs[] = sfConfig::get('sf_app_module_dir') . '/' . $moduleName . '/lib';                  // application
+    $dirs   = array_merge($dirs, $this->getPluginSubPaths('/modules/' . $moduleName . '/lib')); // plugins
+    $dirs[] = $this->getSymfonyLibDir() . '/controller/' . $moduleName . '/lib';                // core modules
+    $dirs[] = sfConfig::get('sf_module_cache_dir') . '/auto' . ucfirst($moduleName . '/lib');   // generated templates in cache
 
     return $dirs;
   }
@@ -367,18 +343,18 @@ abstract class sfApplicationConfiguration extends ProjectConfiguration
   /**
    * Gets directories where template files are stored for a given module.
    *
-   * @param string $moduleName The module name
+   * @param string $moduleName  The module name
    *
    * @return string[] An array of directories
    */
   public function getTemplateDirs(string $moduleName): array
   {
-    $dirs = array();
+    $dirs = [];
 
-    $dirs[] = sfConfig::get('sf_app_module_dir').'/'.$moduleName.'/templates';                  // application
-    $dirs = array_merge($dirs, $this->getPluginSubPaths('/modules/'.$moduleName.'/templates')); // plugins
-    $dirs[] = $this->getSymfonyLibDir().'/controller/'.$moduleName.'/templates';                // core modules
-    $dirs[] = sfConfig::get('sf_module_cache_dir').'/auto'.ucfirst($moduleName.'/templates');   // generated templates in cache
+    $dirs[] = sfConfig::get('sf_app_module_dir') . '/' . $moduleName . '/templates';                  // application
+    $dirs   = array_merge($dirs, $this->getPluginSubPaths('/modules/' . $moduleName . '/templates')); // plugins
+    $dirs[] = $this->getSymfonyLibDir() . '/controller/' . $moduleName . '/templates';                // core modules
+    $dirs[] = sfConfig::get('sf_module_cache_dir') . '/auto' . ucfirst($moduleName . '/templates');   // generated templates in cache
 
     return $dirs;
   }
@@ -386,29 +362,28 @@ abstract class sfApplicationConfiguration extends ProjectConfiguration
   /**
    * Gets the helper directories for a given module name.
    *
-   * @param  string $moduleName The module name
+   * @param string $moduleName  The module name
    *
    * @return string[]  An array of directories
    */
   public function getHelperDirs(string $moduleName = null): array
   {
-    $dirs = array();
+    $dirs = [];
 
-    if ($moduleName)
-    {
-      $dirs[] = sfConfig::get('sf_app_module_dir').'/'.$moduleName.'/lib/helper'; // module
+    if ($moduleName) {
+      $dirs[] = sfConfig::get('sf_app_module_dir') . '/' . $moduleName . '/lib/helper'; // module
 
-      $dirs = array_merge($dirs, $this->getPluginSubPaths('/modules/'.$moduleName.'/lib/helper'));
+      $dirs = array_merge($dirs, $this->getPluginSubPaths('/modules/' . $moduleName . '/lib/helper'));
     }
 
     return array_merge(
       $dirs,
-      array(
-        sfConfig::get('sf_app_lib_dir').'/helper',         // application
-        sfConfig::get('sf_lib_dir').'/helper',             // project
-      ),
+      [
+        sfConfig::get('sf_app_lib_dir') . '/helper',         // application
+        sfConfig::get('sf_lib_dir') . '/helper',             // project
+      ],
       $this->getPluginSubPaths('/lib/helper'),             // plugins
-      array($this->getSymfonyLibDir().'/helper')           // symfony
+      [$this->getSymfonyLibDir() . '/helper']           // symfony
     );
   }
 
@@ -422,13 +397,10 @@ abstract class sfApplicationConfiguration extends ProjectConfiguration
    */
   public function getTemplateDir(string $moduleName, string $templateFile): ?string
   {
-    if (!isset($this->cache['getTemplateDir'][$moduleName][$templateFile]))
-    {
+    if ( ! isset($this->cache['getTemplateDir'][$moduleName][$templateFile])) {
       $this->cache['getTemplateDir'][$moduleName][$templateFile] = null;
-      foreach ($this->getTemplateDirs($moduleName) as $dir)
-      {
-        if (is_readable($dir.'/'.$templateFile))
-        {
+      foreach ($this->getTemplateDirs($moduleName) as $dir) {
+        if (is_readable($dir . '/' . $templateFile)) {
           $this->cache['getTemplateDir'][$moduleName][$templateFile] = $dir;
           break;
         }
@@ -450,16 +422,16 @@ abstract class sfApplicationConfiguration extends ProjectConfiguration
   {
     $dir = $this->getTemplateDir($moduleName, $templateFile);
 
-    return $dir ? $dir.'/'.$templateFile : null;
+    return $dir ? $dir . '/' . $templateFile : null;
   }
+
   /**
    * @see sfProjectConfiguration
    * @return string[]
    */
   public function getPluginPaths(): array
   {
-    if (!isset($this->cache['getPluginPaths']))
-    {
+    if ( ! isset($this->cache['getPluginPaths'])) {
       $this->cache['getPluginPaths'] = parent::getPluginPaths();
     }
 
@@ -473,22 +445,20 @@ abstract class sfApplicationConfiguration extends ProjectConfiguration
    */
   public function getDecoratorDirs(): array
   {
-    return array(sfConfig::get('sf_app_template_dir'));
+    return [sfConfig::get('sf_app_template_dir')];
   }
 
   /**
    * Gets the decorator directory for a given template.
    *
-   * @param  string $template The template file
+   * @param string $template  The template file
    *
    * @return string A template directory
    */
   public function getDecoratorDir(string $template): ?string
   {
-    foreach ($this->getDecoratorDirs() as $dir)
-    {
-      if (is_readable($dir.'/'.$template))
-      {
+    foreach ($this->getDecoratorDirs() as $dir) {
+      if (is_readable($dir . '/' . $template)) {
         return $dir;
       }
     }
@@ -502,11 +472,10 @@ abstract class sfApplicationConfiguration extends ProjectConfiguration
    */
   public function getI18NGlobalDirs(): array
   {
-    $dirs = array();
+    $dirs = [];
 
     // application
-    if (is_dir($dir = sfConfig::get('sf_app_i18n_dir')))
-    {
+    if (is_dir($dir = sfConfig::get('sf_app_i18n_dir'))) {
       $dirs[] = $dir;
     }
 
@@ -517,29 +486,27 @@ abstract class sfApplicationConfiguration extends ProjectConfiguration
   /**
    * Gets the i18n directories to use for a given module.
    *
-   * @param string $moduleName The module name
+   * @param string $moduleName  The module name
    *
    * @return string[] An array of i18n directories
    */
   public function getI18NDirs(string $moduleName): array
   {
-    $dirs = array();
+    $dirs = [];
 
     // module
-    if (is_dir($dir = sfConfig::get('sf_app_module_dir').'/'.$moduleName.'/i18n'))
-    {
+    if (is_dir($dir = sfConfig::get('sf_app_module_dir') . '/' . $moduleName . '/i18n')) {
       $dirs[] = $dir;
     }
 
     // application
-    if (is_dir($dir = sfConfig::get('sf_app_i18n_dir')))
-    {
+    if (is_dir($dir = sfConfig::get('sf_app_i18n_dir'))) {
       $dirs[] = $dir;
     }
 
     return array_merge(
       $dirs,
-      $this->getPluginSubPaths('/modules/'.$moduleName.'/i18n'), // module in plugins
+      $this->getPluginSubPaths('/modules/' . $moduleName . '/i18n'), // module in plugins
       $this->getPluginSubPaths('/i18n')                          // plugins
     );
   }
@@ -547,48 +514,42 @@ abstract class sfApplicationConfiguration extends ProjectConfiguration
   /**
    * Gets the configuration file paths for a given relative configuration path.
    *
-   * @param string $configPath The configuration path
+   * @param string $configPath  The configuration path
    *
    * @return array An array of paths
    */
   public function getConfigPaths(string $configPath): array
   {
-    $globalConfigPath = basename(dirname($configPath)).'/'.basename($configPath);
+    $globalConfigPath = basename(dirname($configPath)) . '/' . basename($configPath);
 
-    $files = array(
-      $this->getSymfonyLibDir().'/config/'.$globalConfigPath, // symfony
-    );
+    $files = [
+      $this->getSymfonyLibDir() . '/config/' . $globalConfigPath, // symfony
+    ];
 
-    foreach ($this->getPluginPaths() as $path)
-    {
-      if (is_file($file = $path.'/'.$globalConfigPath))
-      {
+    foreach ($this->getPluginPaths() as $path) {
+      if (is_file($file = $path . '/' . $globalConfigPath)) {
         $files[] = $file;                                     // plugins
       }
     }
 
-    $files = array_merge($files, array(
-      $this->getRootDir().'/'.$globalConfigPath,              // project
-      $this->getRootDir().'/'.$configPath,                    // project
-      sfConfig::get('sf_app_dir').'/'.$globalConfigPath,      // application
-      sfConfig::get('sf_app_cache_dir').'/'.$configPath,      // generated modules
-    ));
+    $files = array_merge($files, [
+      $this->getRootDir() . '/' . $globalConfigPath,              // project
+      $this->getRootDir() . '/' . $configPath,                    // project
+      sfConfig::get('sf_app_dir') . '/' . $globalConfigPath,      // application
+      sfConfig::get('sf_app_cache_dir') . '/' . $configPath,      // generated modules
+    ]);
 
-    foreach ($this->getPluginPaths() as $path)
-    {
-      if (is_file($file = $path.'/'.$configPath))
-      {
+    foreach ($this->getPluginPaths() as $path) {
+      if (is_file($file = $path . '/' . $configPath)) {
         $files[] = $file;                                     // plugins
       }
     }
 
-    $files[] = sfConfig::get('sf_app_dir').'/'.$configPath;   // module
+    $files[] = sfConfig::get('sf_app_dir') . '/' . $configPath;   // module
 
-    $configs = array();
-    foreach (array_unique($files) as $file)
-    {
-      if (is_readable($file))
-      {
+    $configs = [];
+    foreach (array_unique($files) as $file) {
+      if (is_readable($file)) {
         $configs[] = $file;
       }
     }
@@ -599,49 +560,38 @@ abstract class sfApplicationConfiguration extends ProjectConfiguration
   /**
    * Loads helpers.
    *
-   * @param array|string $helpers    An array of helpers to load
-   * @param string       $moduleName A module name (optional)
+   * @param array|string $helpers     An array of helpers to load
+   * @param string       $moduleName  A module name (optional)
    */
   public function loadHelpers(array $helpers, string $moduleName = ''): void
   {
-    foreach ((array) $helpers as $helperName)
-    {
-      if (isset(self::$loadedHelpers[$helperName]))
-      {
+    foreach ((array)$helpers as $helperName) {
+      if (isset(self::$loadedHelpers[$helperName])) {
         continue;
       }
 
-      if (isset($this->cache['loadedHelpers'][$moduleName][$helperName]))
-      {
+      if (isset($this->cache['loadedHelpers'][$moduleName][$helperName])) {
         include_once $this->cache['loadedHelpers'][$moduleName][$helperName];
-      }
-      else if (isset($this->cache['loadedHelpers'][''][$helperName]))
-      {
+      } elseif (isset($this->cache['loadedHelpers'][''][$helperName])) {
         include_once $this->cache['loadedHelpers'][''][$helperName];
-      }
-      else
-      {
-        $fileName = $helperName.'Helper.php';
+      } else {
+        $fileName = $helperName . 'Helper.php';
 
-        if (!isset($dirs))
-        {
+        if ( ! isset($dirs)) {
           $dirs = $this->getHelperDirs($moduleName);
         }
 
-        foreach ($dirs as $dir)
-        {
+        foreach ($dirs as $dir) {
           $included = false;
-          if (is_readable($dir.'/'.$fileName))
-          {
-            include_once $dir.'/'.$fileName;
+          if (is_readable($dir . '/' . $fileName)) {
+            include_once $dir . '/' . $fileName;
             $included = true;
             break;
           }
         }
 
-        if (!$included)
-        {
-          throw new InvalidArgumentException(sprintf('Unable to load "%sHelper.php" helper in: %s.', $helperName, implode(', ', array_map(array('sfDebug', 'shortenFilePath'), $dirs))));
+        if ( ! $included) {
+          throw new InvalidArgumentException(sprintf('Unable to load "%sHelper.php" helper in: %s.', $helperName, implode(', ', array_map(['sfDebug', 'shortenFilePath'], $dirs))));
         }
       }
 

--- a/lib/config/sfApplicationConfiguration.class.php
+++ b/lib/config/sfApplicationConfiguration.class.php
@@ -152,14 +152,8 @@ abstract class sfApplicationConfiguration extends ProjectConfiguration
    */
   protected function initializePlugins(): void
   {
-    foreach ($this->pluginConfigurations as $name => $configuration) {
-      if (
-        false === $configuration->initialize()
-        &&
-        is_readable($config = $configuration->getRootDir() . '/config/config.php')
-      ) {
-        require $config;
-      }
+    foreach ($this->pluginConfigurations as $configuration) {
+      $configuration->initialize();
     }
   }
 

--- a/lib/config/sfConfig.class.php
+++ b/lib/config/sfConfig.class.php
@@ -19,7 +19,7 @@
 class sfConfig
 {
   /** @var array */
-  protected static $config = [];
+  protected static array $config = [];
 
   /**
    * Retrieves a config parameter.
@@ -29,9 +29,9 @@ class sfConfig
    *
    * @return mixed A config parameter value, if the config parameter exists, otherwise null
    */
-  public static function get(string $name, $default = null)
+  public static function get(string $name, mixed $default = null): mixed
   {
-    return isset(self::$config[$name]) ? self::$config[$name] : $default;
+    return self::$config[$name] ?? $default;
   }
 
   /**
@@ -54,7 +54,7 @@ class sfConfig
    * @param string $name  A config parameter name
    * @param mixed  $value A config parameter value
    */
-  public static function set(string $name, $value): void
+  public static function set(string $name, mixed $value): void
   {
     self::$config[$name] = $value;
   }

--- a/lib/config/sfPluginConfiguration.class.php
+++ b/lib/config/sfPluginConfiguration.class.php
@@ -19,33 +19,33 @@
 abstract class sfPluginConfiguration
 {
   /** @var \sfProjectConfiguration */
-  protected $configuration;
+  protected sfProjectConfiguration $configuration;
+
   /** @var \sfEventDispatcher */
-  protected $dispatcher;
+  protected sfEventDispatcher $dispatcher;
+
   /** @var string */
-  protected $name;
+  protected string $name;
+
   /** @var string */
-  protected $rootDir;
+  protected string $rootDir;
 
   /**
-   * Constructor.
-   *
-   * @param sfProjectConfiguration $configuration The project configuration
-   * @param string                 $rootDir       The plugin root directory
-   * @param string                 $name          The plugin name
+   * @param sfProjectConfiguration $configuration  The project configuration
+   * @param string|null            $rootDir        The plugin root directory
+   * @param string|null            $name           The plugin name
    */
-  public function __construct(sfProjectConfiguration $configuration, $rootDir = null, $name = null)
+  public function __construct(sfProjectConfiguration $configuration, string | null $rootDir = null, string | null $name = null)
   {
     $this->configuration = $configuration;
-    $this->dispatcher = $configuration->getEventDispatcher();
-    $this->rootDir = null === $rootDir ? $this->guessRootDir() : realpath($rootDir);
-    $this->name = null === $name ? $this->guessName() : $name;
+    $this->dispatcher    = $configuration->getEventDispatcher();
+    $this->rootDir       = null === $rootDir ? $this->guessRootDir() : realpath($rootDir);
+    $this->name          = null === $name ? $this->guessName() : $name;
 
     $this->setup();
     $this->configure();
 
-    if (!$this->configuration instanceof sfApplicationConfiguration)
-    {
+    if ( ! $this->configuration instanceof sfApplicationConfiguration) {
       $this->initialize();
     }
   }
@@ -55,23 +55,21 @@ abstract class sfPluginConfiguration
    *
    * This method can be used when creating a base plugin configuration class for other plugins to extend.
    */
-  public function setup()
+  public function setup(): void
   {
   }
 
   /**
    * Configures the plugin.
    */
-  public function configure()
+  public function configure(): void
   {
   }
 
   /**
    * Initializes the plugin.
-   *
-   * @return boolean|null If false sfApplicationConfiguration will look for a config.php (maintains BC with symfony < 1.2)
    */
-  public function initialize()
+  public function initialize(): void
   {
   }
 
@@ -80,7 +78,7 @@ abstract class sfPluginConfiguration
    *
    * @return string
    */
-  public function getRootDir()
+  public function getRootDir(): string
   {
     return $this->rootDir;
   }
@@ -90,7 +88,7 @@ abstract class sfPluginConfiguration
    *
    * @return string
    */
-  public function getName()
+  public function getName(): string
   {
     return $this->name;
   }
@@ -100,10 +98,11 @@ abstract class sfPluginConfiguration
    *
    * @return string
    */
-  protected function guessRootDir()
+  protected function guessRootDir(): string
   {
     $r = new ReflectionClass(get_class($this));
-    return realpath(dirname($r->getFileName()).'/..');
+
+    return realpath(dirname($r->getFileName()) . '/..');
   }
 
   /**
@@ -111,7 +110,7 @@ abstract class sfPluginConfiguration
    *
    * @return string
    */
-  protected function guessName()
+  protected function guessName(): string
   {
     return substr(get_class($this), 0, -13);
   }

--- a/lib/config/sfPluginConfigurationGeneric.class.php
+++ b/lib/config/sfPluginConfigurationGeneric.class.php
@@ -21,8 +21,7 @@ class sfPluginConfigurationGeneric extends sfPluginConfiguration
   /**
    * @see sfPluginConfiguration
    */
-  public function initialize()
+  public function initialize(): void
   {
-    return false;
   }
 }

--- a/lib/config/sfProjectConfiguration.class.php
+++ b/lib/config/sfProjectConfiguration.class.php
@@ -19,41 +19,44 @@
 class sfProjectConfiguration
 {
   /** @var string */
-  protected $rootDir = null;
-  /** @var string */
-  protected $symfonyLibDir = null;
-  /** @var sfEventDispatcher */
-  protected $dispatcher = null;
-  /** @var array */
-  protected $plugins = array();
-  /** @var array */
-  protected $pluginPaths = array();
-  /** @var array */
-  protected $overriddenPluginPaths = array();
-  /** @var sfPluginConfiguration[] */
-  protected $pluginConfigurations = array();
-  /** @var bool */
-  protected $pluginsLoaded = false;
+  protected string $rootDir;
 
-  /** @var sfApplicationConfiguration */
-  static protected $active = null;
+  /** @var string */
+  protected string $symfonyLibDir;
+
+  /** @var sfEventDispatcher */
+  protected sfEventDispatcher $dispatcher;
+
+  /** @var array */
+  protected array $plugins = [];
+
+  /** @var array */
+  protected array $pluginPaths = [];
+
+  /** @var array */
+  protected array $overriddenPluginPaths = [];
+
+  /** @var sfPluginConfiguration[] */
+  protected array $pluginConfigurations = [];
+
+  /** @var bool */
+  protected bool $pluginsLoaded = false;
+
+  static protected sfProjectConfiguration | sfApplicationConfiguration | null $active = null;
 
   /**
-   * Constructor.
-   *
-   * @param string              $rootDir    The project root directory
-   * @param sfEventDispatcher   $dispatcher The event dispatcher
+   * @param string|null            $rootDir     The project root directory
+   * @param sfEventDispatcher|null $dispatcher  The event dispatcher
    */
   public function __construct(string $rootDir = null, sfEventDispatcher $dispatcher = null)
   {
-    if (null === self::$active || $this instanceof sfApplicationConfiguration)
-    {
+    if (null === self::$active || $this instanceof sfApplicationConfiguration) {
       self::$active = $this;
     }
 
-    $this->rootDir = null === $rootDir ? static::guessRootDir() : realpath($rootDir);
-    $this->symfonyLibDir = realpath(__DIR__.'/..');
-    $this->dispatcher = null === $dispatcher ? new sfEventDispatcher() : $dispatcher;
+    $this->rootDir       = null === $rootDir ? static::guessRootDir() : realpath($rootDir);
+    $this->symfonyLibDir = realpath(__DIR__ . '/..');
+    $this->dispatcher    = $dispatcher ?: new sfEventDispatcher();
 
     ini_set('magic_quotes_runtime', 'off');
 
@@ -81,21 +84,16 @@ class sfProjectConfiguration
    */
   public function loadPlugins(): void
   {
-    foreach ($this->getPluginPaths() as $path)
-    {
-      if (false === $plugin = array_search($path, $this->overriddenPluginPaths))
-      {
+    foreach ($this->getPluginPaths() as $path) {
+      if (false === $plugin = array_search($path, $this->overriddenPluginPaths)) {
         $plugin = basename($path);
       }
-      $class = $plugin.'Configuration';
+      $class = $plugin . 'Configuration';
 
-      if (is_readable($file = sprintf('%s/config/%s.class.php', $path, $class)))
-      {
+      if (is_readable($file = sprintf('%s/config/%s.class.php', $path, $class))) {
         require_once $file;
         $configuration = new $class($this, $path, $plugin);
-      }
-      else
-      {
+      } else {
         $configuration = new sfPluginConfigurationGeneric($this, $path, $plugin);
       }
 
@@ -117,27 +115,27 @@ class sfProjectConfiguration
   /**
    * Sets the project root directory.
    *
-   * @param string $rootDir The project root directory
+   * @param string $rootDir  The project root directory
    */
   public function setRootDir(string $rootDir): void
   {
     $this->rootDir = $rootDir;
 
-    sfConfig::add(array(
-      'sf_root_dir' => $rootDir,
+    sfConfig::add([
+      'sf_root_dir'    => $rootDir,
 
       // global directory structure
-      'sf_apps_dir'    => $rootDir.DIRECTORY_SEPARATOR.'apps',
-      'sf_lib_dir'     => $rootDir.DIRECTORY_SEPARATOR.'lib',
-      'sf_log_dir'     => $rootDir.DIRECTORY_SEPARATOR.'log',
-      'sf_data_dir'    => $rootDir.DIRECTORY_SEPARATOR.'data',
-      'sf_config_dir'  => $rootDir.DIRECTORY_SEPARATOR.'config',
-      'sf_test_dir'    => $rootDir.DIRECTORY_SEPARATOR.'test',
-      'sf_plugins_dir' => $rootDir.DIRECTORY_SEPARATOR.'plugins',
-    ));
+      'sf_apps_dir'    => $rootDir . DIRECTORY_SEPARATOR . 'apps',
+      'sf_lib_dir'     => $rootDir . DIRECTORY_SEPARATOR . 'lib',
+      'sf_log_dir'     => $rootDir . DIRECTORY_SEPARATOR . 'log',
+      'sf_data_dir'    => $rootDir . DIRECTORY_SEPARATOR . 'data',
+      'sf_config_dir'  => $rootDir . DIRECTORY_SEPARATOR . 'config',
+      'sf_test_dir'    => $rootDir . DIRECTORY_SEPARATOR . 'test',
+      'sf_plugins_dir' => $rootDir . DIRECTORY_SEPARATOR . 'plugins',
+    ]);
 
-    $this->setWebDir($rootDir.DIRECTORY_SEPARATOR.'web');
-    $this->setCacheDir($rootDir.DIRECTORY_SEPARATOR.'cache');
+    $this->setWebDir($rootDir . DIRECTORY_SEPARATOR . 'web');
+    $this->setCacheDir($rootDir . DIRECTORY_SEPARATOR . 'cache');
   }
 
   /**
@@ -153,7 +151,7 @@ class sfProjectConfiguration
   /**
    * Sets the cache root directory.
    *
-   * @param string $cacheDir The absolute path to the cache dir.
+   * @param string $cacheDir  The absolute path to the cache dir.
    */
   public function setCacheDir(string $cacheDir): void
   {
@@ -163,7 +161,7 @@ class sfProjectConfiguration
   /**
    * Sets the log directory.
    *
-   * @param string $logDir The absolute path to the log dir.
+   * @param string $logDir  The absolute path to the log dir.
    */
   public function setLogDir(string $logDir): void
   {
@@ -173,15 +171,15 @@ class sfProjectConfiguration
   /**
    * Sets the web root directory.
    *
-   * @param string $webDir The absolute path to the web dir.
+   * @param string $webDir  The absolute path to the web dir.
    */
   public function setWebDir(string $webDir): void
   {
-    sfConfig::add(array(
+    sfConfig::add([
       'sf_web_dir'         => $webDir,
       'sf_upload_dir_name' => $uploadDirName = 'uploads',
-      'sf_upload_dir'      => $webDir.DIRECTORY_SEPARATOR.$uploadDirName,
-    ));
+      'sf_upload_dir'      => $webDir . DIRECTORY_SEPARATOR . $uploadDirName,
+    ]);
   }
 
   /**
@@ -194,7 +192,7 @@ class sfProjectConfiguration
   {
     return array_merge(
       $this->getPluginSubPaths('/lib/model'),     // plugins
-      array(sfConfig::get('sf_lib_dir').'/model') // project
+      [sfConfig::get('sf_lib_dir') . '/model'] // project
     );
   }
 
@@ -209,37 +207,37 @@ class sfProjectConfiguration
   public function getGeneratorTemplateDirs(string $class, string $theme): array
   {
     return array_merge(
-      array(sfConfig::get('sf_data_dir').'/generator/'.$class.'/'.$theme.'/template'), // project
-      $this->getPluginSubPaths('/data/generator/'.$class.'/'.$theme.'/template'),      // plugins
-      array(sfConfig::get('sf_data_dir').'/generator/'.$class.'/default/template'),    // project (default theme)
-      $this->getPluginSubPaths('/data/generator/'.$class.'/default/template')          // plugins (default theme)
+      [sfConfig::get('sf_data_dir') . '/generator/' . $class . '/' . $theme . '/template'], // project
+      $this->getPluginSubPaths('/data/generator/' . $class . '/' . $theme . '/template'),      // plugins
+      [sfConfig::get('sf_data_dir') . '/generator/' . $class . '/default/template'],    // project (default theme)
+      $this->getPluginSubPaths('/data/generator/' . $class . '/default/template')          // plugins (default theme)
     );
   }
 
   /**
    * Gets directories where the skeleton is stored for a generator class and a specific theme.
    *
-   * @param string $class   The generator class name
-   * @param string $theme   The theme name
+   * @param string $class  The generator class name
+   * @param string $theme  The theme name
    *
    * @return string[] An array of directories
    */
   public function getGeneratorSkeletonDirs(string $class, string $theme): array
   {
     return array_merge(
-      array(sfConfig::get('sf_data_dir').'/generator/'.$class.'/'.$theme.'/skeleton'), // project
-      $this->getPluginSubPaths('/data/generator/'.$class.'/'.$theme.'/skeleton'),      // plugins
-      array(sfConfig::get('sf_data_dir').'/generator/'.$class.'/default/skeleton'),    // project (default theme)
-      $this->getPluginSubPaths('/data/generator/'.$class.'/default/skeleton')          // plugins (default theme)
+      [sfConfig::get('sf_data_dir') . '/generator/' . $class . '/' . $theme . '/skeleton'], // project
+      $this->getPluginSubPaths('/data/generator/' . $class . '/' . $theme . '/skeleton'),      // plugins
+      [sfConfig::get('sf_data_dir') . '/generator/' . $class . '/default/skeleton'],    // project (default theme)
+      $this->getPluginSubPaths('/data/generator/' . $class . '/default/skeleton')          // plugins (default theme)
     );
   }
 
   /**
    * Gets the template to use for a generator class.
    *
-   * @param string $class   The generator class name
-   * @param string $theme   The theme name
-   * @param string $path    The template path
+   * @param string $class  The generator class name
+   * @param string $theme  The theme name
+   * @param string $path   The template path
    *
    * @return string A template path
    *
@@ -248,11 +246,9 @@ class sfProjectConfiguration
   public function getGeneratorTemplate(string $class, string $theme, string $path): string
   {
     $dirs = $this->getGeneratorTemplateDirs($class, $theme);
-    foreach ($dirs as $dir)
-    {
-      if (is_readable($dir.'/'.$path))
-      {
-        return $dir.'/'.$path;
+    foreach ($dirs as $dir) {
+      if (is_readable($dir . '/' . $path)) {
+        return $dir . '/' . $path;
       }
     }
 
@@ -262,44 +258,38 @@ class sfProjectConfiguration
   /**
    * Gets the configuration file paths for a given relative configuration path.
    *
-   * @param string $configPath The configuration path
+   * @param string $configPath  The configuration path
    *
    * @return string[] An array of paths
    */
   public function getConfigPaths(string $configPath): array
   {
-    $globalConfigPath = basename(dirname($configPath)).'/'.basename($configPath);
+    $globalConfigPath = basename(dirname($configPath)) . '/' . basename($configPath);
 
-    $files = array(
-      $this->getSymfonyLibDir().'/config/'.$globalConfigPath, // symfony
-    );
+    $files = [
+      $this->getSymfonyLibDir() . '/config/' . $globalConfigPath, // symfony
+    ];
 
-    foreach ($this->getPluginPaths() as $path)
-    {
-      if (is_file($file = $path.'/'.$globalConfigPath))
-      {
+    foreach ($this->getPluginPaths() as $path) {
+      if (is_file($file = $path . '/' . $globalConfigPath)) {
         $files[] = $file;                                     // plugins
       }
     }
 
-    $files = array_merge($files, array(
-      $this->getRootDir().'/'.$globalConfigPath,              // project
-      $this->getRootDir().'/'.$configPath,                    // project
-    ));
+    $files = array_merge($files, [
+      $this->getRootDir() . '/' . $globalConfigPath,              // project
+      $this->getRootDir() . '/' . $configPath,                    // project
+    ]);
 
-    foreach ($this->getPluginPaths() as $path)
-    {
-      if (is_file($file = $path.'/'.$configPath))
-      {
+    foreach ($this->getPluginPaths() as $path) {
+      if (is_file($file = $path . '/' . $configPath)) {
         $files[] = $file;                                     // plugins
       }
     }
 
-    $configs = array();
-    foreach (array_unique($files) as $file)
-    {
-      if (is_readable($file))
-      {
+    $configs = [];
+    foreach (array_unique($files) as $file) {
+      if (is_readable($file)) {
         $configs[] = $file;
       }
     }
@@ -310,26 +300,25 @@ class sfProjectConfiguration
   /**
    * Sets the enabled plugins.
    *
-   * @param string[] $plugins An array of plugin names
+   * @param string[] $plugins  An array of plugin names
    *
    * @throws LogicException If plugins have already been loaded
    */
   public function setPlugins(array $plugins): void
   {
-    if ($this->pluginsLoaded)
-    {
+    if ($this->pluginsLoaded) {
       throw new LogicException('Plugins have already been loaded.');
     }
 
     $this->plugins = $plugins;
 
-    $this->pluginPaths = array();
+    $this->pluginPaths = [];
   }
 
   /**
    * Enables a plugin or a list of plugins.
    *
-   * @param string[] $plugins A plugin name or a plugin list
+   * @param string[] $plugins  A plugin name or a plugin list
    */
   public function enablePlugins(array $plugins): void
   {
@@ -339,43 +328,37 @@ class sfProjectConfiguration
   /**
    * Disables a plugin.
    *
-   * @param string[] $plugins A plugin name or a plugin list
+   * @param string[] $plugins  A plugin name or a plugin list
    *
    * @throws LogicException If plugins have already been loaded
    */
   public function disablePlugins(array $plugins): void
   {
-    if ($this->pluginsLoaded)
-    {
+    if ($this->pluginsLoaded) {
       throw new LogicException('Plugins have already been loaded.');
     }
 
-    foreach ($plugins as $plugin)
-    {
-      if (false !== $pos = array_search($plugin, $this->plugins))
-      {
+    foreach ($plugins as $plugin) {
+      if (false !== $pos = array_search($plugin, $this->plugins)) {
         unset($this->plugins[$pos]);
-      }
-      else
-      {
+      } else {
         throw new InvalidArgumentException(sprintf('The plugin "%s" does not exist.', $plugin));
       }
     }
 
-    $this->pluginPaths = array();
+    $this->pluginPaths = [];
   }
 
   /**
    * Enabled all installed plugins except th = array()e one given as argument.
    *
-   * @param string[] $plugins A plugin name or a plugin list
+   * @param string[] $plugins  A plugin name or a plugin list
    *
    * @throws LogicException If plugins have already been loaded
    */
   public function enableAllPluginsExcept(array $plugins): void
   {
-    if ($this->pluginsLoaded)
-    {
+    if ($this->pluginsLoaded) {
       throw new LogicException('Plugins have already been loaded.');
     }
 
@@ -399,24 +382,21 @@ class sfProjectConfiguration
   /**
    * Gets the paths plugin sub-directories, minding overloaded plugins.
    *
-   * @param  string $subPath The subdirectory to look for
+   * @param string $subPath  The subdirectory to look for
    *
    * @return string[] The plugin paths.
    */
   public function getPluginSubPaths(string $subPath): array
   {
-    if (array_key_exists($subPath, $this->pluginPaths))
-    {
+    if (array_key_exists($subPath, $this->pluginPaths)) {
       return $this->pluginPaths[$subPath];
     }
 
-    $this->pluginPaths[$subPath] = array();
-    $pluginPaths = $this->getPluginPaths();
-    foreach ($pluginPaths as $pluginPath)
-    {
-      if (is_dir($pluginPath.$subPath))
-      {
-        $this->pluginPaths[$subPath][] = $pluginPath.$subPath;
+    $this->pluginPaths[$subPath] = [];
+    $pluginPaths                 = $this->getPluginPaths();
+    foreach ($pluginPaths as $pluginPath) {
+      if (is_dir($pluginPath . $subPath)) {
+        $this->pluginPaths[$subPath][] = $pluginPath . $subPath;
       }
     }
 
@@ -432,19 +412,14 @@ class sfProjectConfiguration
    */
   public function getPluginPaths(): array
   {
-    if (!isset($this->pluginPaths['']))
-    {
+    if ( ! isset($this->pluginPaths[''])) {
       $pluginPaths = $this->getAllPluginPaths();
 
-      $this->pluginPaths[''] = array();
-      foreach ($this->getPlugins() as $plugin)
-      {
-        if (isset($pluginPaths[$plugin]))
-        {
+      $this->pluginPaths[''] = [];
+      foreach ($this->getPlugins() as $plugin) {
+        if (isset($pluginPaths[$plugin])) {
           $this->pluginPaths[''][] = $pluginPaths[$plugin];
-        }
-        else
-        {
+        } else {
           throw new InvalidArgumentException(sprintf('The plugin "%s" does not exist.', $plugin));
         }
       }
@@ -460,23 +435,21 @@ class sfProjectConfiguration
    */
   public function getAllPluginPaths(): array
   {
-    $pluginPaths = array();
+    $pluginPaths = [];
 
     // search for *Plugin directories representing plugins
     // follow links and do not recurse. No need to exclude VC because they do not end with *Plugin
     $finder = sfFinder::type('dir')->maxdepth(0)->ignore_version_control(false)->follow_link()->name('*Plugin');
-    $dirs = array(
-      $this->getSymfonyLibDir().'/plugins',
+    $dirs   = [
+      $this->getSymfonyLibDir() . '/plugins',
       sfConfig::get('sf_plugins_dir'),
-    );
+    ];
 
-    foreach ($finder->in($dirs) as $path)
-    {
+    foreach ($finder->in($dirs) as $path) {
       $pluginPaths[basename($path)] = $path;
     }
 
-    foreach ($this->overriddenPluginPaths as $plugin => $path)
-    {
+    foreach ($this->overriddenPluginPaths as $plugin => $path) {
       $pluginPaths[$plugin] = $path;
     }
 
@@ -501,14 +474,13 @@ class sfProjectConfiguration
   /**
    * Returns the configuration for the requested plugin.
    *
-   * @param   string $name
+   * @param string $name
    *
    * @return  sfPluginConfiguration
    */
   public function getPluginConfiguration(string $name): sfPluginConfiguration
   {
-    if (!isset($this->pluginConfigurations[$name]))
-    {
+    if ( ! isset($this->pluginConfigurations[$name])) {
       throw new InvalidArgumentException(sprintf('There is no configuration object for the "%s" object.', $name));
     }
 
@@ -540,10 +512,9 @@ class sfProjectConfiguration
    *
    * @return sfProjectConfiguration|sfApplicationConfiguration The current sfProjectConfiguration instance
    */
-  static public function getActive(): sfProjectConfiguration
+  public static function getActive(): sfProjectConfiguration
   {
-    if (!static::hasActive())
-    {
+    if ( ! static::hasActive()) {
       throw new RuntimeException('There is no active configuration.');
     }
 
@@ -555,44 +526,48 @@ class sfProjectConfiguration
    *
    * @return bool
    */
-  static public function hasActive(): bool
+  public static function hasActive(): bool
   {
     return null !== self::$active;
   }
 
   /**
    * Guesses the project root directory.
+   *
    * @return string The project root directory
    */
-  static public function guessRootDir(): string
+  public static function guessRootDir(): string
   {
     $r = new ReflectionClass(ProjectConfiguration::class);
 
-    return realpath(dirname($r->getFileName()).'/..');
+    return realpath(dirname($r->getFileName()) . '/..');
   }
 
   /**
    * Returns a sfApplicationConfiguration configuration for a given application.
    *
-   * @param string            $application    An application name
-   * @param string            $environment    The environment name
-   * @param Boolean           $debug          true to enable debug mode
-   * @param string            $rootDir        The project root directory
-   * @param sfEventDispatcher $dispatcher     An event dispatcher
+   * @param string                 $application  An application name
+   * @param string                 $environment  The environment name
+   * @param Boolean                $debug        true to enable debug mode
+   * @param string|null            $rootDir      The project root directory
+   * @param sfEventDispatcher|null $dispatcher   An event dispatcher
    *
    * @return sfApplicationConfiguration A sfApplicationConfiguration instance
    */
-  static public function getApplicationConfiguration(string $application, string $environment, bool $debug, string $rootDir = null, sfEventDispatcher $dispatcher = null): sfApplicationConfiguration
-  {
-    $class = $application.'Configuration';
+  public static function getApplicationConfiguration(
+    string            $application,
+    string            $environment,
+    bool              $debug,
+    string            $rootDir = null,
+    sfEventDispatcher $dispatcher = null
+  ): sfApplicationConfiguration {
+    $class = $application . 'Configuration';
 
-    if (null === $rootDir)
-    {
+    if (null === $rootDir) {
       $rootDir = static::guessRootDir();
     }
 
-    if (!is_file($file = "{$rootDir}/apps/{$application}/config/{$class}.class.php"))
-    {
+    if ( ! is_file($file = "{$rootDir}/apps/{$application}/config/{$class}.class.php")) {
       throw new InvalidArgumentException(sprintf('The application "%s" does not exist.', $application));
     }
 

--- a/lib/controller/sfController.class.php
+++ b/lib/controller/sfController.class.php
@@ -21,24 +21,22 @@
 abstract class sfController
 {
   /** @var sfContext */
-  protected $context = null;
+  protected sfContext $context;
 
   /** @var sfEventDispatcher */
-  protected $dispatcher = null;
+  protected sfEventDispatcher $dispatcher;
 
-  /** @var string[] */
-  protected $controllerClasses = [];
-
-  /** @var int */
-  protected $renderMode = sfView::RENDER_CLIENT;
+  /** @var class-string[] */
+  protected array $controllerClasses = [];
 
   /** @var int */
-  protected $maxForwards = 5;
+  protected int $renderMode = sfView::RENDER_CLIENT;
+
+  /** @var int */
+  protected int $maxForwards = 5;
 
   /**
-   * Class constructor.
-   *
-   * @param sfContext $context A sfContext implementation instance
+   * @param sfContext $context  A sfContext implementation instance
    */
   public function __construct(sfContext $context)
   {
@@ -49,8 +47,8 @@ abstract class sfController
   /**
    * Indicates whether or not a module has a specific component.
    *
-   * @param string $moduleName    A module name
-   * @param string $componentName An component name
+   * @param string $moduleName     A module name
+   * @param string $componentName  An component name
    *
    * @return bool true, if the component exists, otherwise false
    */
@@ -62,8 +60,8 @@ abstract class sfController
   /**
    * Indicates whether or not a module has a specific action.
    *
-   * @param string $moduleName A module name
-   * @param string $actionName An action name
+   * @param string $moduleName  A module name
+   * @param string $actionName  An action name
    *
    * @return bool true, if the action exists, otherwise false
    */
@@ -76,10 +74,10 @@ abstract class sfController
    * Looks for a controller and optionally throw exceptions if existence is required (i.e.
    * in the case of {@link getController()}).
    *
-   * @param string  $moduleName      The name of the module
-   * @param string  $controllerName  The name of the controller within the module
-   * @param string  $extension       Either 'action' or 'component' depending on the type of controller to look for
-   * @param boolean $throwExceptions Whether to throw exceptions if the controller doesn't exist
+   * @param string  $moduleName       The name of the module
+   * @param string  $controllerName   The name of the controller within the module
+   * @param string  $extension        Either 'action' or 'component' depending on the type of controller to look for
+   * @param boolean $throwExceptions  Whether to throw exceptions if the controller doesn't exist
    *
    * @throws sfConfigurationException thrown if the module is not enabled
    * @throws sfControllerException    thrown if the controller doesn't exist and the $throwExceptions parameter is set to true
@@ -89,67 +87,58 @@ abstract class sfController
   protected function controllerExists(string $moduleName, string $controllerName, string $extension, bool $throwExceptions): bool
   {
     $dirs = $this->context->getConfiguration()->getControllerDirs($moduleName);
-    foreach ($dirs as $dir => $checkEnabled)
-    {
+    foreach ($dirs as $dir => $checkEnabled) {
       // plugin module enabled?
-      if ($checkEnabled && !in_array($moduleName, sfConfig::get('sf_enabled_modules')) && is_readable($dir))
-      {
+      if ($checkEnabled && ! in_array($moduleName, sfConfig::get('sf_enabled_modules')) && is_readable($dir)) {
         throw new sfConfigurationException(sprintf('The module "%s" is not enabled.', $moduleName));
       }
 
       // check for a module generator config file
-      $this->context->getConfigCache()->import('modules/'.$moduleName.'/config/generator.yml', false, true);
+      $this->context->getConfigCache()->import('modules/' . $moduleName . '/config/generator.yml', false, true);
 
       // one action per file or one file for all actions
       $classFile   = strtolower($extension);
       $classSuffix = ucfirst(strtolower($extension));
-      $file        = $dir.'/'.$controllerName.$classSuffix.'.class.php';
-      if (is_readable($file))
-      {
+      $file        = $dir . '/' . $controllerName . $classSuffix . '.class.php';
+      if (is_readable($file)) {
         // action class exists
         require_once($file);
 
-        $this->controllerClasses[$moduleName.'_'.$controllerName.'_'.$classSuffix] = $controllerName.$classSuffix;
+        $this->controllerClasses[$moduleName . '_' . $controllerName . '_' . $classSuffix] = $controllerName . $classSuffix;
 
         return true;
       }
 
-      $module_file = $dir.'/'.$classFile.'s.class.php';
-      if (is_readable($module_file))
-      {
+      $module_file = $dir . '/' . $classFile . 's.class.php';
+      if (is_readable($module_file)) {
         // module class exists
         require_once($module_file);
 
-        if (!class_exists($moduleName.$classSuffix.'s', false))
-        {
-          if ($throwExceptions)
-          {
-            throw new sfControllerException(sprintf('There is no "%s" class in your action file "%s".', $moduleName.$classSuffix.'s', $module_file));
+        if ( ! class_exists($moduleName . $classSuffix . 's', false)) {
+          if ($throwExceptions) {
+            throw new sfControllerException(sprintf('There is no "%s" class in your action file "%s".', $moduleName . $classSuffix . 's', $module_file));
           }
 
           return false;
         }
 
         // action is defined in this class?
-        if (!in_array('execute'.ucfirst($controllerName), get_class_methods($moduleName.$classSuffix.'s')))
-        {
-          if ($throwExceptions)
-          {
-            throw new sfControllerException(sprintf('There is no "%s" method in your action class "%s".', 'execute'.ucfirst($controllerName), $moduleName.$classSuffix.'s'));
+        if ( ! in_array('execute' . ucfirst($controllerName), get_class_methods($moduleName . $classSuffix . 's'))) {
+          if ($throwExceptions) {
+            throw new sfControllerException(sprintf('There is no "%s" method in your action class "%s".', 'execute' . ucfirst($controllerName), $moduleName . $classSuffix . 's'));
           }
 
           return false;
         }
 
-        $this->controllerClasses[$moduleName.'_'.$controllerName.'_'.$classSuffix] = $moduleName.$classSuffix.'s';
+        $this->controllerClasses[$moduleName . '_' . $controllerName . '_' . $classSuffix] = $moduleName . $classSuffix . 's';
         return true;
       }
     }
 
     // send an exception if debug
-    if ($throwExceptions && sfConfig::get('sf_debug'))
-    {
-      $dirs = array_map(array('sfDebug', 'shortenFilePath'), array_keys($dirs));
+    if ($throwExceptions && sfConfig::get('sf_debug')) {
+      $dirs = array_map(['sfDebug', 'shortenFilePath'], array_keys($dirs));
 
       throw new sfControllerException(sprintf('Controller "%s/%s" does not exist in: %s.', $moduleName, $controllerName, implode(', ', $dirs)));
     }
@@ -160,8 +149,8 @@ abstract class sfController
   /**
    * Forwards the request to another action.
    *
-   * @param string $moduleName A module name
-   * @param string $actionName An action name
+   * @param string $moduleName  A module name
+   * @param string $actionName  An action name
    *
    * @throws sfConfigurationException  If an invalid configuration setting has been found
    * @throws sfForwardException        If an error occurs while forwarding the request
@@ -174,21 +163,18 @@ abstract class sfController
     $moduleName = preg_replace('/[^a-z0-9_]+/i', '', $moduleName);
     $actionName = preg_replace('/[^a-z0-9_]+/i', '', $actionName);
 
-    if ($this->getActionStack()->getSize() >= $this->maxForwards)
-    {
+    if ($this->getActionStack()->getSize() >= $this->maxForwards) {
       // let's kill this party before it turns into cpu cycle hell
       throw new sfForwardException('Too many forwards have been detected for this request.');
     }
 
     // check for a module generator config file
-    $this->context->getConfigCache()->import('modules/'.$moduleName.'/config/generator.yml', false, true);
+    $this->context->getConfigCache()->import('modules/' . $moduleName . '/config/generator.yml', false, true);
 
-    if (!$this->actionExists($moduleName, $actionName))
-    {
+    if ( ! $this->actionExists($moduleName, $actionName)) {
       // the requested action doesn't exist
-      if (sfConfig::get('sf_logging_enabled'))
-      {
-        $this->dispatcher->notify(new sfEvent($this, 'application.log', array(sprintf('Action "%s/%s" does not exist', $moduleName, $actionName))));
+      if (sfConfig::get('sf_logging_enabled')) {
+        $this->dispatcher->notify(new sfEvent($this, 'application.log', [sprintf('Action "%s/%s" does not exist', $moduleName, $actionName)]));
       }
 
       throw new sfError404Exception(sprintf('Action "%s/%s" does not exist.', $moduleName, $actionName));
@@ -201,20 +187,17 @@ abstract class sfController
     $this->getActionStack()->addEntry($moduleName, $actionName, $actionInstance);
 
     // include module configuration
-    $viewClass = sfConfig::get('mod_'.strtolower($moduleName).'_view_class', false);
-    require($this->context->getConfigCache()->checkConfig('modules/'.$moduleName.'/config/module.yml'));
-    if (false !== $viewClass)
-    {
-      sfConfig::set('mod_'.strtolower($moduleName).'_view_class', $viewClass);
+    $viewClass = sfConfig::get('mod_' . strtolower($moduleName) . '_view_class', false);
+    require($this->context->getConfigCache()->checkConfig('modules/' . $moduleName . '/config/module.yml'));
+    if (false !== $viewClass) {
+      sfConfig::set('mod_' . strtolower($moduleName) . '_view_class', $viewClass);
     }
 
     // module enabled?
-    if (sfConfig::get('mod_'.strtolower($moduleName).'_enabled'))
-    {
+    if (sfConfig::get('mod_' . strtolower($moduleName) . '_enabled')) {
       // check for a module config.php
-      $moduleConfig = sfConfig::get('sf_app_module_dir').'/'.$moduleName.'/config/config.php';
-      if (is_readable($moduleConfig))
-      {
+      $moduleConfig = sfConfig::get('sf_app_module_dir') . '/' . $moduleName . '/config/config.php';
+      if (is_readable($moduleConfig)) {
         require_once($moduleConfig);
       }
 
@@ -222,28 +205,26 @@ abstract class sfController
       $filterChain = new sfFilterChain();
       $filterChain->loadConfiguration($actionInstance);
 
-      $this->context->getEventDispatcher()->notify(new sfEvent($this, 'controller.change_action', array('module' => $moduleName, 'action' => $actionName)));
+      $this->context->getEventDispatcher()->notify(new sfEvent($this, 'controller.change_action', ['module' => $moduleName, 'action' => $actionName]));
 
-      if ($moduleName == sfConfig::get('sf_error_404_module') && $actionName == sfConfig::get('sf_error_404_action'))
-      {
+      if ($moduleName == sfConfig::get('sf_error_404_module') && $actionName == sfConfig::get('sf_error_404_action')) {
         $this->context->getResponse()->setStatusCode(404);
         $this->context->getResponse()->setHttpHeader('Status', '404 Not Found');
 
-        $this->dispatcher->notify(new sfEvent($this, 'controller.page_not_found', array('module' => $moduleName, 'action' => $actionName)));
+        $this->dispatcher->notify(new sfEvent($this, 'controller.page_not_found', ['module' => $moduleName, 'action' => $actionName]));
       }
 
       // process the filter chain
       $filterChain->execute();
-    }
-    else
-    {
+    } else {
       $moduleName = sfConfig::get('sf_module_disabled_module');
       $actionName = sfConfig::get('sf_module_disabled_action');
 
-      if (!$this->actionExists($moduleName, $actionName))
-      {
+      if ( ! $this->actionExists($moduleName, $actionName)) {
         // cannot find mod disabled module/action
-        throw new sfConfigurationException(sprintf('Invalid configuration settings: [sf_module_disabled_module] "%s", [sf_module_disabled_action] "%s".', $moduleName, $actionName));
+        throw new sfConfigurationException(
+          sprintf('Invalid configuration settings: [sf_module_disabled_module] "%s", [sf_module_disabled_action] "%s".', $moduleName, $actionName)
+        );
       }
 
       $this->forward($moduleName, $actionName);
@@ -253,10 +234,10 @@ abstract class sfController
   /**
    * Retrieves an sfAction implementation instance.
    *
-   * @param string $moduleName A module name
-   * @param string $actionName An action name
+   * @param string $moduleName  A module name
+   * @param string $actionName  An action name
    *
-   * @return sfAction An sfAction implementation instance, if the action exists, otherwise null
+   * @return sfAction|null An sfAction implementation instance, if the action exists, otherwise null
    */
   public function getAction(string $moduleName, string $actionName): ?sfAction
   {
@@ -266,12 +247,12 @@ abstract class sfController
   /**
    * Retrieves a sfComponent implementation instance.
    *
-   * @param string $moduleName    A module name
-   * @param string $componentName A component name
+   * @param string $moduleName     A module name
+   * @param string $componentName  A component name
    *
-   * @return sfComponent A sfComponent implementation instance, if the component exists, otherwise null
+   * @return sfComponent|null A sfComponent implementation instance, if the component exists, otherwise null
    */
-  public function getComponent(string $moduleName, string $componentName): ?sfComponent
+  public function getComponent(string $moduleName, string $componentName): sfComponent | null
   {
     return $this->getController($moduleName, $componentName, 'component');
   }
@@ -279,34 +260,33 @@ abstract class sfController
   /**
    * Retrieves a controller implementation instance.
    *
-   * @param string $moduleName     A module name
-   * @param string $controllerName A component name
-   * @param string $extension      Either 'action' or 'component' depending on the type of controller to look for
+   * @param string $moduleName      A module name
+   * @param string $controllerName  A component name
+   * @param string $extension       Either 'action' or 'component' depending on the type of controller to look for
    *
-   * @return \sfComponent|\sfAction A controller implementation instance, if the controller exists, otherwise null
+   * @return sfComponent|sfAction A controller implementation instance, if the controller exists, otherwise null
    *
    * @see getComponent(), getAction()
    */
-  protected function getController(string $moduleName, string $controllerName, string $extension): sfComponent
+  protected function getController(string $moduleName, string $controllerName, string $extension): sfComponent | sfAction
   {
     $classSuffix = ucfirst(strtolower($extension));
-    if (!isset($this->controllerClasses[$moduleName.'_'.$controllerName.'_'.$classSuffix]))
-    {
+    if ( ! isset($this->controllerClasses[$moduleName . '_' . $controllerName . '_' . $classSuffix])) {
       $this->controllerExists($moduleName, $controllerName, $extension, true);
     }
 
-    $class = $this->controllerClasses[$moduleName.'_'.$controllerName.'_'.$classSuffix];
+    $class = $this->controllerClasses[$moduleName . '_' . $controllerName . '_' . $classSuffix];
 
     // fix for same name classes
-    $moduleClass = $moduleName.'_'.$class;
+    $moduleClass = $moduleName . '_' . $class;
 
-    if (class_exists($moduleClass, false))
-    {
+    if (class_exists($moduleClass, false)) {
       $class = $moduleClass;
     }
 
     /** @see \sfAction::__construct */
     /** @see \sfComponent::__construct */
+
     return new $class($this->context, $moduleName, $controllerName);
   }
 
@@ -335,35 +315,31 @@ abstract class sfController
   /**
    * Retrieves a sfView implementation instance.
    *
-   * @param string $moduleName A module name
-   * @param string $actionName An action name
-   * @param string $viewName   A view name
+   * @param string $moduleName  A module name
+   * @param string $actionName  An action name
+   * @param string $viewName    A view name
    *
    * @return sfView A sfView implementation instance, if the view exists, otherwise null
    */
   public function getView(string $moduleName, string $actionName, string $viewName): sfView
   {
     // user view exists?
-    $file = sfConfig::get('sf_app_module_dir').'/'.$moduleName.'/view/'.$actionName.$viewName.'View.class.php';
+    $file = sfConfig::get('sf_app_module_dir') . '/' . $moduleName . '/view/' . $actionName . $viewName . 'View.class.php';
 
-    if (is_readable($file))
-    {
+    if (is_readable($file)) {
       require_once($file);
 
-      $class = $actionName.$viewName.'View';
+      $class = $actionName . $viewName . 'View';
 
       // fix for same name classes
-      $moduleClass = $moduleName.'_'.$class;
+      $moduleClass = $moduleName . '_' . $class;
 
-      if (class_exists($moduleClass, false))
-      {
+      if (class_exists($moduleClass, false)) {
         $class = $moduleClass;
       }
-    }
-    else
-    {
+    } else {
       // view class (as configured in module.yml or defined in action)
-      $class = sfConfig::get('mod_'.strtolower($moduleName).'_view_class', 'sfPHP').'View';
+      $class = sfConfig::get('mod_' . strtolower($moduleName) . '_view_class', 'sfPHP') . 'View';
     }
 
     return new $class($this->context, $moduleName, $actionName, $viewName);
@@ -372,9 +348,9 @@ abstract class sfController
   /**
    * Returns the rendered view presentation of a given module/action.
    *
-   * @param string $module   A module name
-   * @param string $action   An action name
-   * @param string $viewName A View class name
+   * @param string      $module    A module name
+   * @param string      $action    An action name
+   * @param string|null $viewName  A View class name
    *
    * @return string The generated content
    *
@@ -383,9 +359,8 @@ abstract class sfController
    */
   public function getPresentationFor(string $module, string $action, string $viewName = null): string
   {
-    if (sfConfig::get('sf_logging_enabled'))
-    {
-      $this->dispatcher->notify(new sfEvent($this, 'application.log', array(sprintf('Get presentation for action "%s/%s" (view class: "%s")', $module, $action, $viewName))));
+    if (sfConfig::get('sf_logging_enabled')) {
+      $this->dispatcher->notify(new sfEvent($this, 'application.log', [sprintf('Get presentation for action "%s/%s" (view class: "%s")', $module, $action, $viewName)]));
     }
 
     // get original render mode
@@ -401,26 +376,21 @@ abstract class sfController
     $index = $actionStack->getSize();
 
     // set viewName if needed
-    if ($viewName)
-    {
-      $currentViewName = sfConfig::get('mod_'.strtolower($module).'_view_class');
-      sfConfig::set('mod_'.strtolower($module).'_view_class', $viewName);
+    if ($viewName) {
+      $currentViewName = sfConfig::get('mod_' . strtolower($module) . '_view_class');
+      sfConfig::set('mod_' . strtolower($module) . '_view_class', $viewName);
     }
 
-    try
-    {
+    try {
       // forward to the action
       $this->forward($module, $action);
-    }
-    catch (Exception $e)
-    {
+    } catch (Exception $e) {
       // put render mode back
       $this->setRenderMode($renderMode);
 
       // remove viewName
-      if ($viewName)
-      {
-        sfConfig::set('mod_'.strtolower($module).'_view_class', $currentViewName);
+      if ($viewName) {
+        sfConfig::set('mod_' . strtolower($module) . '_view_class', $currentViewName);
       }
 
       throw $e;
@@ -430,31 +400,26 @@ abstract class sfController
     $actionEntry = $actionStack->getEntry($index);
 
     // get raw content
-    $presentation =& $actionEntry->getPresentation();
+    $presentation = $actionEntry->getPresentation();
 
     // put render mode back
     $this->setRenderMode($renderMode);
 
     // remove the action entry
     $nb = $actionStack->getSize() - $index;
-    while ($nb-- > 0)
-    {
+    while ($nb-- > 0) {
       $actionEntry = $actionStack->popEntry();
 
-      if ($actionEntry->getModuleName() == sfConfig::get('sf_login_module') && $actionEntry->getActionName() == sfConfig::get('sf_login_action'))
-      {
+      if ($actionEntry->getModuleName() == sfConfig::get('sf_login_module') && $actionEntry->getActionName() == sfConfig::get('sf_login_action')) {
         throw new sfException('Your action is secured, but the user is not authenticated.');
-      }
-      else if ($actionEntry->getModuleName() == sfConfig::get('sf_secure_module') && $actionEntry->getActionName() == sfConfig::get('sf_secure_action'))
-      {
+      } elseif ($actionEntry->getModuleName() == sfConfig::get('sf_secure_module') && $actionEntry->getActionName() == sfConfig::get('sf_secure_action')) {
         throw new sfException('Your action is secured, but the user does not have access.');
       }
     }
 
     // remove viewName
-    if ($viewName)
-    {
-      sfConfig::set('mod_'.strtolower($module).'_view_class', $currentViewName);
+    if ($viewName) {
+      sfConfig::set('mod_' . strtolower($module) . '_view_class', $currentViewName);
     }
 
     return $presentation;
@@ -463,10 +428,10 @@ abstract class sfController
   /**
    * Sets the presentation rendering mode.
    *
-   * @param int $mode A rendering mode one of the following:
-   *                  - sfView::RENDER_CLIENT
-   *                  - sfView::RENDER_VAR
-   *                  - sfView::RENDER_NONE
+   * @param int $mode  A rendering mode one of the following:
+   *                   - sfView::RENDER_CLIENT
+   *                   - sfView::RENDER_VAR
+   *                   - sfView::RENDER_NONE
    *
    * @return void
    *
@@ -474,8 +439,7 @@ abstract class sfController
    */
   public function setRenderMode(int $mode): void
   {
-    if ($mode == sfView::RENDER_CLIENT || $mode == sfView::RENDER_VAR || $mode == sfView::RENDER_NONE)
-    {
+    if ($mode == sfView::RENDER_CLIENT || $mode == sfView::RENDER_VAR || $mode == sfView::RENDER_NONE) {
       $this->renderMode = $mode;
 
       return;

--- a/lib/controller/sfController.class.php
+++ b/lib/controller/sfController.class.php
@@ -357,7 +357,7 @@ abstract class sfController
    * @throws Exception
    * @throws sfException
    */
-  public function getPresentationFor(string $module, string $action, string $viewName = null): string
+  public function getPresentationFor(string $module, string $action, string | null $viewName = null): string
   {
     if (sfConfig::get('sf_logging_enabled')) {
       $this->dispatcher->notify(new sfEvent($this, 'application.log', [sprintf('Get presentation for action "%s/%s" (view class: "%s")', $module, $action, $viewName)]));

--- a/lib/controller/sfFrontWebController.class.php
+++ b/lib/controller/sfFrontWebController.class.php
@@ -29,10 +29,9 @@ class sfFrontWebController extends sfWebController
    */
   public function dispatch(): void
   {
-    try
-    {
+    try {
       // reinitialize filters (needed for unit and functional tests)
-      sfFilter::$filterCalled = array();
+      sfFilter::$filterCalled = [];
 
       // determine our module and action
       /** @var sfWebRequest $request */
@@ -40,20 +39,15 @@ class sfFrontWebController extends sfWebController
       $moduleName = $request->getParameter('module');
       $actionName = $request->getParameter('action');
 
-      if (empty($moduleName) || empty($actionName))
-      {
+      if (empty($moduleName) || empty($actionName)) {
         throw new sfError404Exception(sprintf('Empty module and/or action after parsing the URL "%s" (%s/%s).', $request->getPathInfo(), $moduleName, $actionName));
       }
 
       // make the first request
       $this->forward($moduleName, $actionName);
-    }
-    catch (sfException $e)
-    {
+    } catch (sfException $e) {
       $e->printStackTrace();
-    }
-    catch (Exception $e)
-    {
+    } catch (Exception $e) {
       sfException::createFromException($e)->printStackTrace();
     }
   }

--- a/lib/escaper/sfOutputEscaperArrayDecorator.class.php
+++ b/lib/escaper/sfOutputEscaperArrayDecorator.class.php
@@ -111,7 +111,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
    *
    * @return mixed The value
    */
-  public function getRaw($key)
+  public function getRaw($key): mixed
   {
     return $this->value[$key];
   }

--- a/lib/escaper/sfOutputEscaperGetterDecorator.class.php
+++ b/lib/escaper/sfOutputEscaperGetterDecorator.class.php
@@ -22,7 +22,7 @@ abstract class sfOutputEscaperGetterDecorator extends sfOutputEscaper
   /**
    * Returns the raw, unescaped value associated with the key supplied.
    *
-   * The key might be an index into an array or a value to be passed to the 
+   * The key might be an index into an array or a value to be passed to the
    * decorated object's get() method.
    *
    * @param  string $key  The key to retrieve
@@ -44,8 +44,7 @@ abstract class sfOutputEscaperGetterDecorator extends sfOutputEscaper
    */
   public function get($key, $escapingMethod = null)
   {
-    if (!$escapingMethod)
-    {
+    if ( ! $escapingMethod) {
       $escapingMethod = $this->escapingMethod;
     }
 

--- a/lib/escaper/sfOutputEscaperSafe.class.php
+++ b/lib/escaper/sfOutputEscaperSafe.class.php
@@ -18,20 +18,18 @@
  */
 class sfOutputEscaperSafe extends ArrayIterator
 {
-  protected
-    $value = null;
+  protected mixed $value = null;
 
   /**
    * Constructor.
    *
    * @param mixed $value  The value to mark as safe
    */
-  public function __construct($value)
+  public function __construct(mixed $value)
   {
     $this->value = $value;
 
-    if (is_array($value) || is_object($value))
-    {
+    if (is_array($value) || is_object($value)) {
       parent::__construct($value);
     }
   }

--- a/lib/event/sfEvent.class.php
+++ b/lib/event/sfEvent.class.php
@@ -19,11 +19,16 @@
 class sfEvent
 {
   /** @var mixed */
-  protected $subject;
+  protected mixed $subject;
+
   protected string $name;
+
+  /** @var array<string,mixed> */
   protected array $parameters;
+
   /** @var mixed */
-  protected $value = null;
+  protected mixed $value = null;
+
   protected bool $processed = false;
 
   /**
@@ -33,7 +38,7 @@ class sfEvent
    * @param string  $name       The event name
    * @param array   $parameters An array of parameters
    */
-  public function __construct($subject, string $name, array $parameters = [])
+  public function __construct(mixed $subject, string $name, array $parameters = [])
   {
     $this->subject = $subject;
     $this->name = $name;
@@ -45,7 +50,7 @@ class sfEvent
    *
    * @return mixed The subject
    */
-  public function getSubject()
+  public function getSubject(): mixed
   {
     return $this->subject;
   }
@@ -65,7 +70,7 @@ class sfEvent
    *
    * @param mixed  $value The return value
    */
-  public function setReturnValue($value): void
+  public function setReturnValue(mixed $value): void
   {
     $this->value = $value;
   }
@@ -75,7 +80,7 @@ class sfEvent
    *
    * @return mixed The return value
    */
-  public function getReturnValue()
+  public function getReturnValue(): mixed
   {
     return $this->value;
   }
@@ -93,7 +98,7 @@ class sfEvent
   /**
    * Returns whether the event has been processed by a listener or not.
    *
-   * @return Boolean true if the event has been processed, false otherwise
+   * @return bool true if the event has been processed, false otherwise
    */
   public function isProcessed(): bool
   {
@@ -129,7 +134,7 @@ class sfEvent
    *
    * @return mixed
    */
-  public function getParameter(string $name, $default = null)
+  public function getParameter(string $name, mixed $default = null): mixed
   {
     return $this->parameters[$name] ?? $default;
   }

--- a/lib/event/sfEventDispatcher.class.php
+++ b/lib/event/sfEventDispatcher.class.php
@@ -11,7 +11,7 @@
 /**
  * sfEventDispatcher implements a dispatcher object.
  *
- * @see http://developer.apple.com/documentation/Cocoa/Conceptual/Notifications/index.html Apple's Cocoa framework
+ * @see        http://developer.apple.com/documentation/Cocoa/Conceptual/Notifications/index.html Apple's Cocoa framework
  *
  * @package    symfony
  * @subpackage event
@@ -20,20 +20,19 @@
  */
 class sfEventDispatcher
 {
-  /** @var callable[][] */
-  protected $listeners = array();
+  /** @var array<string,callable[]> */
+  protected array $listeners = [];
 
   /**
    * Connects a listener to a given event name.
    *
-   * @param string  $name      An event name
+   * @param string   $name      An event name
    * @param callable $listener  A PHP callable
    */
   public function connect(string $name, callable $listener): void
   {
-    if (!isset($this->listeners[$name]))
-    {
-      $this->listeners[$name] = array();
+    if ( ! isset($this->listeners[$name])) {
+      $this->listeners[$name] = [];
     }
 
     $this->listeners[$name][] = $listener;
@@ -43,39 +42,38 @@ class sfEventDispatcher
    * Disconnects a listener for a given event name.
    *
    * @param string   $name      An event name
-   * @param mixed    $listener  A PHP callable
+   * @param callable $listener  A PHP callable
    *
-   * @return mixed false if listener does not exist, null otherwise
+   * @return bool true if at least one listener has been removed, false otherwise
    */
-  public function disconnect(string $name, callable $listener): ?bool
+  public function disconnect(string $name, callable $listener): bool
   {
-    if (!isset($this->listeners[$name]))
-    {
+    if ( ! isset($this->listeners[$name])) {
       return false;
     }
 
-    foreach ($this->listeners[$name] as $i => $callable)
-    {
-      if ($listener === $callable)
-      {
+    $ret = false;
+
+    foreach ($this->listeners[$name] as $i => $callable) {
+      if ($listener === $callable) {
         unset($this->listeners[$name][$i]);
+        $ret = true;
       }
     }
 
-    return null;
+    return $ret;
   }
 
   /**
    * Notifies all listeners of a given event.
    *
-   * @param sfEvent $event A sfEvent instance
+   * @param sfEvent $event  A sfEvent instance
    *
    * @return sfEvent The sfEvent instance
    */
   public function notify(sfEvent $event): sfEvent
   {
-    foreach ($this->getListeners($event->getName()) as $listener)
-    {
+    foreach ($this->getListeners($event->getName()) as $listener) {
       call_user_func($listener, $event);
     }
 
@@ -85,18 +83,16 @@ class sfEventDispatcher
   /**
    * Notifies all listeners of a given event until one returns a non null value.
    *
-   * @param  sfEvent $event A sfEvent instance
+   * @param sfEvent $event  A sfEvent instance
    *
    * @return sfEvent The sfEvent instance
    */
   public function notifyUntil(sfEvent $event): sfEvent
   {
-    foreach ($this->getListeners($event->getName()) as $listener)
-    {
-      if (call_user_func($listener, $event))
-      {
+    foreach ($this->getListeners($event->getName()) as $listener) {
+      if (call_user_func($listener, $event)) {
         $event->setProcessed(true);
-        break;
+        return $event;
       }
     }
 
@@ -106,16 +102,15 @@ class sfEventDispatcher
   /**
    * Filters a value by calling all listeners of a given event.
    *
-   * @param  sfEvent  $event   A sfEvent instance
-   * @param  mixed    $value   The value to be filtered
+   * @param sfEvent $event  A sfEvent instance
+   * @param mixed   $value  The value to be filtered
    *
    * @return sfEvent The sfEvent instance
    */
-  public function filter(sfEvent $event, $value): sfEvent
+  public function filter(sfEvent $event, mixed $value): sfEvent
   {
-    foreach ($this->getListeners($event->getName()) as $listener)
-    {
-      $value = call_user_func_array($listener, array($event, $value));
+    foreach ($this->getListeners($event->getName()) as $listener) {
+      $value = call_user_func($listener, $event, $value);
     }
 
     $event->setReturnValue($value);
@@ -126,34 +121,24 @@ class sfEventDispatcher
   /**
    * Returns true if the given event name has some listeners.
    *
-   * @param  string   $name    The event name
+   * @param string $name  The event name
    *
    * @return Boolean true if some listeners are connected, false otherwise
    */
   public function hasListeners(string $name): bool
   {
-    if (!isset($this->listeners[$name]))
-    {
-      $this->listeners[$name] = array();
-    }
-
-    return count($this->listeners[$name]) > 0;
+    return count($this->listeners[$name] ?? []) > 0;
   }
 
   /**
    * Returns all listeners associated with a given event name.
    *
-   * @param  string      $name    The event name
+   * @param string $name  The event name
    *
    * @return callable[]  An array of listeners
    */
-  public function getListeners($name): array
+  public function getListeners(string $name): array
   {
-    if (!isset($this->listeners[$name]))
-    {
-      return array();
-    }
-
-    return $this->listeners[$name];
+    return $this->listeners[$name] ?? [];
   }
 }

--- a/lib/i18n/sfI18N.class.php
+++ b/lib/i18n/sfI18N.class.php
@@ -45,11 +45,11 @@ class sfI18N
    *  * untranslated_prefix: The prefix to use when a message is not translated
    *  * untranslated_suffix: The suffix to use when a message is not translated
    *
-   * @param sfApplicationConfiguration $configuration   A sfApplicationConfiguration instance
-   * @param sfCache                    $cache           A sfCache instance
-   * @param array                      $options         An array of options
+   * @param sfApplicationConfiguration $configuration  A sfApplicationConfiguration instance
+   * @param sfCache|null               $cache          A sfCache instance
+   * @param array                      $options        An array of options
    */
-  public function __construct(sfApplicationConfiguration $configuration, sfCache $cache = null, array $options = [])
+  public function __construct(sfApplicationConfiguration $configuration, sfCache | null $cache = null, array $options = [])
   {
     $this->configuration = $configuration;
     $this->dispatcher = $configuration->getEventDispatcher();
@@ -100,10 +100,10 @@ class sfI18N
   /**
    * Sets the message source.
    *
-   * @param null  $dirs    An array of i18n directories if message source is a sfMessageSource_File subclass, null otherwise
-   * @param string $culture The culture
+   * @param null        $dirs     An array of i18n directories if message source is a sfMessageSource_File subclass, null otherwise
+   * @param string|null $culture  The culture
    */
-  public function setMessageSource($dirs, string $culture = null): void
+  public function setMessageSource($dirs, string | null $culture = null): void
   {
     if (null === $dirs)
     {
@@ -229,17 +229,18 @@ class sfI18N
   /**
    * Gets a country name.
    *
-   * @param  string $iso      The ISO code
-   * @param  string $culture  The culture for the translation
+   * @param string      $iso      The ISO code
+   * @param string|null $culture  The culture for the translation
    *
    * @return string The country name
    */
-  public function getCountry(string $iso, string $culture = null): string
+  public function getCountry(string $iso, string | null $culture = null): string
   {
-    $c = sfCultureInfo::getInstance(null === $culture ? $this->culture : $culture);
-    $countries = $c->getCountries();
+    $info = sfCultureInfo::getInstance(null === $culture ? $this->culture : $culture);
 
-    return (array_key_exists($iso, $countries)) ? $countries[$iso] : '';
+    $countries = $info->getCountries();
+
+    return $countries[$iso] ?? '';
   }
 
   /**
@@ -257,12 +258,12 @@ class sfI18N
   /**
    * Returns a timestamp from a date with time formatted with a given culture.
    *
-   * @param  string  $dateTime  The formatted date with time as string
-   * @param  string  $culture The culture
+   * @param string       $dateTime  The formatted date with time as string
+   * @param string| null $culture   The culture
    *
    * @return int|null The timestamp
    */
-  public function getTimestampForCulture(string $dateTime, string $culture = null): ?int
+  public function getTimestampForCulture(string $dateTime, string | null $culture = null): ?int
   {
     [$day, $month, $year] = $this->getDateForCulture($dateTime, null === $culture ? $this->culture : $culture);
     [$hour, $minute] = $this->getTimeForCulture($dateTime, null === $culture ? $this->culture : $culture);
@@ -273,15 +274,14 @@ class sfI18N
   /**
    * Returns the day, month and year from a date formatted with a given culture.
    *
-   * @param  string|null $date    The formatted date as string
-   * @param  string      $culture The culture
+   * @param string|null $date     The formatted date as string
+   * @param string|null $culture  The culture
    *
    * @return array|null   An array with the day, month and year
    */
-  public function getDateForCulture(?string $date, string $culture = null): ?array
+  public function getDateForCulture(string | null $date, string | null $culture = null): ?array
   {
-    if (!$date)
-    {
+    if ( ! $date) {
       return null;
     }
 
@@ -322,7 +322,7 @@ class sfI18N
    *
    * @return array|null   An array with the hour and minute
    */
-  public function getTimeForCulture(?string $time, string $culture = null): ?array
+  public function getTimeForCulture(string | null $time, string | null $culture = null): ?array
   {
     if (!$time) return null;
 

--- a/lib/log/sfAggregateLogger.class.php
+++ b/lib/log/sfAggregateLogger.class.php
@@ -19,7 +19,7 @@
 class sfAggregateLogger extends sfLogger
 {
   /** @var sfLoggerInterface[] */
-  protected $loggers = [];
+  protected array $loggers = [];
 
   /**
    * Class constructor.
@@ -28,8 +28,8 @@ class sfAggregateLogger extends sfLogger
    *
    * - loggers: Logger objects that extends sfLogger.
    *
-   * @param  sfEventDispatcher $dispatcher  A sfEventDispatcher instance
-   * @param  array             $options     An array of options.
+   * @param sfEventDispatcher $dispatcher  A sfEventDispatcher instance
+   * @param array             $options     An array of options.
    *
    * @throws sfInitializationException If an error occurs while initializing this sfLogger.
    */
@@ -37,11 +37,9 @@ class sfAggregateLogger extends sfLogger
   {
     $this->dispatcher = $dispatcher;
 
-    if (isset($options['loggers']))
-    {
-      if (!is_array($options['loggers']))
-      {
-        $options['loggers'] = array($options['loggers']);
+    if (isset($options['loggers'])) {
+      if ( ! is_array($options['loggers'])) {
+        $options['loggers'] = [$options['loggers']];
       }
 
       $this->addLoggers($options['loggers']);
@@ -53,9 +51,9 @@ class sfAggregateLogger extends sfLogger
   /**
    * Retrieves current loggers.
    *
-   * @return array List of loggers
+   * @return sfLoggerInterface[] List of loggers
    */
-  public function getLoggers()
+  public function getLoggers(): array
   {
     return $this->loggers;
   }
@@ -63,12 +61,11 @@ class sfAggregateLogger extends sfLogger
   /**
    * Adds an array of loggers.
    *
-   * @param object $loggers An array of Logger objects
+   * @param sfLoggerInterface[] $loggers  An array of Logger objects
    */
-  public function addLoggers($loggers)
+  public function addLoggers(array $loggers): void
   {
-    foreach ($loggers as $logger)
-    {
+    foreach ($loggers as $logger) {
       $this->addLogger($logger);
     }
   }
@@ -76,13 +73,13 @@ class sfAggregateLogger extends sfLogger
   /**
    * Adds a logger.
    *
-   * @param sfLoggerInterface $logger The Logger object
+   * @param sfLoggerInterface $logger  The Logger object
    */
-  public function addLogger(sfLoggerInterface $logger)
+  public function addLogger(sfLoggerInterface $logger): void
   {
     $this->loggers[] = $logger;
 
-    $this->dispatcher->disconnect('application.log', array($logger, 'listenToLogEvent'));
+    $this->dispatcher->disconnect('application.log', fn () => $logger->listenToLogEven());
   }
 
   /**
@@ -93,8 +90,7 @@ class sfAggregateLogger extends sfLogger
    */
   protected function doLog(string $message, int $priority): void
   {
-    foreach ($this->loggers as $logger)
-    {
+    foreach ($this->loggers as $logger) {
       $logger->log($message, $priority);
     }
   }
@@ -102,16 +98,14 @@ class sfAggregateLogger extends sfLogger
   /**
    * Executes the shutdown method.
    */
-  public function shutdown()
+  public function shutdown(): void
   {
-    foreach ($this->loggers as $logger)
-    {
-      if ($logger instanceof sfLogger)
-      {
+    foreach ($this->loggers as $logger) {
+      if ($logger instanceof sfLogger) {
         $logger->shutdown();
       }
     }
 
-    $this->loggers = array();
+    $this->loggers = [];
   }
 }

--- a/lib/log/sfEventLogger.class.php
+++ b/lib/log/sfEventLogger.class.php
@@ -11,11 +11,13 @@
 class sfEventLogger extends sfAbstractLogger implements sfLoggerInterface
 {
   /** * @var \sfEventDispatcher */
-  protected $dispatcher;
-  /** @var array */
-  protected $options;
+  protected sfEventDispatcher $dispatcher;
+
+  /** @var array<string,mixed> */
+  protected array $options;
+
   /** * @var int */
-  protected $level;
+  protected int $level;
 
   /**
    * {@inheritDoc}

--- a/lib/log/sfFileLogger.class.php
+++ b/lib/log/sfFileLogger.class.php
@@ -86,6 +86,11 @@ class sfFileLogger extends sfLogger
    */
   protected function doLog(string $message, int $priority): void
   {
+    if ( ! is_resource($this->fp)) {
+      // The stream must have been closed already (see shutdown())
+      return;
+    }
+
     flock($this->fp, LOCK_EX);
 
     fwrite($this->fp, strtr($this->format, [

--- a/lib/log/sfFileLogger.class.php
+++ b/lib/log/sfFileLogger.class.php
@@ -19,11 +19,14 @@
 class sfFileLogger extends sfLogger
 {
   /** @var string */
-  protected $type = 'symfony';
+  protected string $type = 'symfony';
+
   /** @var string */
-  protected $format = '%time% %type% [%priority%] %message%%EOL%';
+  protected string $format = '%time% %type% [%priority%] %message%%EOL%';
+
   /** @var string */
-  protected $timeFormat = 'M d H:i:s';
+  protected string $timeFormat = 'M d H:i:s';
+
   /** @var resource */
   protected $fp;
 
@@ -39,8 +42,8 @@ class sfFileLogger extends sfLogger
    * - dir_mode:    The mode to use when creating a directory (default to 0777)
    * - file_mode:   The mode to use when creating a file (default to 0666)
    *
-   * @param  sfEventDispatcher $dispatcher  A sfEventDispatcher instance
-   * @param  array             $options     An array of options.
+   * @param sfEventDispatcher $dispatcher  A sfEventDispatcher instance
+   * @param array             $options     An array of options.
    *
    * @throws sfConfigurationException
    * @throws sfInitializationException
@@ -48,31 +51,27 @@ class sfFileLogger extends sfLogger
    */
   public function __construct(sfEventDispatcher $dispatcher, array $options = [])
   {
-    if (!isset($options['file']))
-    {
+    if ( ! isset($options['file'])) {
       throw new sfConfigurationException('You must provide a "file" parameter for this logger.');
     }
 
-    $this->format = $options['format'] ?? $this->format;
+    $this->format     = $options['format'] ?? $this->format;
     $this->timeFormat = $options['time_format'] ?? $this->timeFormat;
-    $this->type = $options['type'] ?? $this->type;
+    $this->type       = $options['type'] ?? $this->type;
 
     $dir     = dirname($options['file']);
     $dirMode = $options['dir_mode'] ?? 0777;
-    if (!is_dir($dir) && !@mkdir($dir, $dirMode, true) && !is_dir($dir))
-    {
+    if ( ! is_dir($dir) && ! @mkdir($dir, $dirMode, true) && ! is_dir($dir)) {
       throw new \RuntimeException(sprintf('Logger was not able to create a directory "%s"', $dir));
     }
 
     $fileExists = file_exists($options['file']);
-    if (!is_writable($dir) || ($fileExists && !is_writable($options['file'])))
-    {
+    if ( ! is_writable($dir) || ($fileExists && ! is_writable($options['file']))) {
       throw new sfFileException(sprintf('Unable to open the log file "%s" for writing.', $options['file']));
     }
 
     $this->fp = fopen($options['file'], 'a');
-    if (!$fileExists)
-    {
+    if ( ! $fileExists) {
       chmod($options['file'], isset($options['file_mode']) ? $options['file_mode'] : 0666);
     }
 
@@ -88,24 +87,26 @@ class sfFileLogger extends sfLogger
   protected function doLog(string $message, int $priority): void
   {
     flock($this->fp, LOCK_EX);
-    fwrite($this->fp, strtr($this->format, array(
+
+    fwrite($this->fp, strtr($this->format, [
       '%type%'     => $this->type,
       '%message%'  => $message,
       '%time%'     => date($this->timeFormat),
       '%priority%' => $this->getPriority($priority),
       '%EOL%'      => PHP_EOL,
-    )));
+    ]));
+
     flock($this->fp, LOCK_UN);
   }
 
   /**
    * Returns the priority string to use in log messages.
    *
-   * @param  string $priority The priority constant
+   * @param int $priority  The priority constant
    *
    * @return string The priority to use in log messages
    */
-  protected function getPriority($priority)
+  protected function getPriority(int $priority): string
   {
     return sfLogger::getPriorityName($priority);
   }
@@ -113,10 +114,9 @@ class sfFileLogger extends sfLogger
   /**
    * Executes the shutdown method.
    */
-  public function shutdown()
+  public function shutdown(): void
   {
-    if (is_resource($this->fp))
-    {
+    if (is_resource($this->fp)) {
       fclose($this->fp);
     }
   }

--- a/lib/log/sfLogger.class.php
+++ b/lib/log/sfLogger.class.php
@@ -40,11 +40,13 @@ abstract class sfLogger extends sfAbstractLogger implements sfLoggerInterface
   ];
 
   /** @var sfEventDispatcher */
-  protected $dispatcher;
+  protected sfEventDispatcher $dispatcher;
+
   /** @var array */
-  protected $options;
+  protected array $options;
+
   /** @var int */
-  protected $level = self::INFO;
+  protected int $level = self::INFO;
 
   /**
    * Class constructor.
@@ -53,18 +55,17 @@ abstract class sfLogger extends sfAbstractLogger implements sfLoggerInterface
    *
    * - level: The log level.
    *
-   * @param  sfEventDispatcher $dispatcher  A sfEventDispatcher instance
-   * @param  array             $options     An array of options.
+   * @param sfEventDispatcher $dispatcher  A sfEventDispatcher instance
+   * @param array             $options     An array of options.
    *
    * @throws sfInitializationException If an error occurs while initializing this sfLogger.
    */
   public function __construct(sfEventDispatcher $dispatcher, array $options = [])
   {
     $this->dispatcher = $dispatcher;
-    $this->options = $options;
+    $this->options    = $options;
 
-    if (isset($this->options['level']))
-    {
+    if (isset($this->options['level'])) {
       try {
         $this->level = self::parseLogLevel($this->options['level']);
       } catch (sfException $exception) {
@@ -72,11 +73,10 @@ abstract class sfLogger extends sfAbstractLogger implements sfLoggerInterface
       }
     }
 
-    $dispatcher->connect('application.log', array($this, 'listenToLogEvent'));
+    $dispatcher->connect('application.log', [$this, 'listenToLogEvent']);
 
-    if (!isset($options['auto_shutdown']) || $options['auto_shutdown'])
-    {
-      register_shutdown_function(array($this, 'shutdown'));
+    if ( ! isset($options['auto_shutdown']) || $options['auto_shutdown']) {
+      register_shutdown_function([$this, 'shutdown']);
     }
   }
 
@@ -85,12 +85,11 @@ abstract class sfLogger extends sfAbstractLogger implements sfLoggerInterface
    *
    * @param string $message   Message
    * @param int    $priority  Message priority
-   * @return void|bool
+   * @return void
    */
   public function log(string $message, int $priority = self::INFO): void
   {
-    if ($this->level >= $priority)
-    {
+    if ($this->level >= $priority) {
       $this->doLog($message, $priority);
     }
   }
@@ -106,18 +105,16 @@ abstract class sfLogger extends sfAbstractLogger implements sfLoggerInterface
   /**
    * Listens to application.log events.
    *
-   * @param sfEvent $event An sfEvent instance
+   * @param sfEvent $event  An sfEvent instance
    */
-  public function listenToLogEvent(sfEvent $event)
+  public function listenToLogEvent(sfEvent $event): void
   {
-    $priority = $event->getParameter('priority') ??  self::INFO;
+    $priority = $event->getParameter('priority') ?? self::INFO;
 
-    $subject  = $event->getSubject();
-    $subject  = is_object($subject) ? get_class($subject) : (is_string($subject) ? $subject : 'main');
-    foreach ($event->getParameters() as $key => $message)
-    {
-      if ('priority' === $key)
-      {
+    $subject = $event->getSubject();
+    $subject = is_object($subject) ? get_class($subject) : (is_string($subject) ? $subject : 'main');
+    foreach ($event->getParameters() as $key => $message) {
+      if ('priority' === $key) {
         continue;
       }
 
@@ -130,20 +127,20 @@ abstract class sfLogger extends sfAbstractLogger implements sfLoggerInterface
    *
    * Cleans up the current logger instance.
    */
-  public function shutdown()
+  public function shutdown(): void
   {
   }
 
   /**
    * Coverts a given priority name, or level, to a known log level.
    *
-   * @param  int|string $priority Priority name or log level
+   * @param int|string $priority  Priority name or log level
    *
    * @return int        The priority constant value
    *
    * @throws sfException if the priority level does not exist
    */
-  static public function parseLogLevel($priority): int
+  static public function parseLogLevel(int | string $priority): int
   {
     foreach (self::LEVELS as $level => $name) {
       if ($level === $priority || $name === $priority) {
@@ -156,16 +153,15 @@ abstract class sfLogger extends sfAbstractLogger implements sfLoggerInterface
   /**
    * Returns the priority name given a priority class constant
    *
-   * @param  integer $priority A priority class constant
+   * @param integer $priority  A priority class constant
    *
    * @return string  The priority name
    *
    * @throws sfException if the priority level does not exist
    */
-  static public function getPriorityName($priority)
+  static public function getPriorityName(int $priority): string
   {
-    if (!isset(self::LEVELS[$priority]))
-    {
+    if ( ! isset(self::LEVELS[$priority])) {
       throw new sfException(sprintf('The priority level "%s" does not exist.', $priority));
     }
 

--- a/lib/log/sfPsrLoggerAdapter.class.php
+++ b/lib/log/sfPsrLoggerAdapter.class.php
@@ -7,10 +7,12 @@
  * file that was distributed with this source code.
  */
 
+use Psr\Log\LoggerInterface;
+
 /**
  * sfPsrLoggerAdapter is meant to be able to use a Prs compliant logger in symfony 1.
  *
- * @see https://github.com/php-fig/log
+ * @see        https://github.com/php-fig/log
  *
  * @package    symfony
  * @subpackage service
@@ -23,21 +25,21 @@ class sfPsrLoggerAdapter extends sfLogger
    *
    * @var array
    */
-  private $buffer = [];
+  private array $buffer = [];
 
   /**
    * The logger that will the log will be forward to
    *
-   * @var \Psr\Log\LoggerInterface
+   * @var LoggerInterface
    */
-  private $logger;
+  private LoggerInterface $logger;
 
   /**
    * The service id that will be use as the psr logger
    *
    * @var string
    */
-  private $loggerServiceId = 'logger.psr';
+  private string $loggerServiceId = 'logger.psr';
 
   /**
    * Class constructor.
@@ -48,19 +50,17 @@ class sfPsrLoggerAdapter extends sfLogger
    * - auto_connect: If we must connect automatically to the context.load_factories to set the logger. Default: true
    *
    * @param sfEventDispatcher $dispatcher
-   * @param array $options
+   * @param array             $options
    *
    * @throws sfInitializationException
    */
   public function __construct(sfEventDispatcher $dispatcher, array $options = [])
   {
-    if (isset($options['logger_service_id']))
-    {
+    if (isset($options['logger_service_id'])) {
       $this->loggerServiceId = $options['logger_service_id'];
     }
 
-    if (!isset($options['auto_connect']) || $options['auto_connect'])
-    {
+    if ( ! isset($options['auto_connect']) || $options['auto_connect']) {
       $dispatcher->connect('context.load_factories', [$this, 'listenContextLoadFactoriesEvent']);
     }
 
@@ -74,24 +74,25 @@ class sfPsrLoggerAdapter extends sfLogger
    *
    * @return void
    */
-  public function listenContextLoadFactoriesEvent(sfEvent $event)
+  public function listenContextLoadFactoriesEvent(sfEvent $event): void
   {
     /* @var $context sfContext */
     $context = $event->getSubject();
-    /** @var $logger \Psr\Log\LoggerInterface */
+    /** @var $logger LoggerInterface */
     $logger = $context->getService($this->loggerServiceId);
     $this->setLogger($logger);
-    $this->dispatcher->disconnect('context.load_factories', array($this, 'listenContextLoadFactoriesEvent'));
+    $this->dispatcher->disconnect('context.load_factories', [$this, 'listenContextLoadFactoriesEvent']);
   }
 
   /**
    * Set the logger
    *
-   * @param \Psr\Log\LoggerInterface $logger
+   * @param LoggerInterface $logger
    */
-  public function setLogger(\Psr\Log\LoggerInterface $logger)
+  public function setLogger(LoggerInterface $logger): void
   {
     $this->logger = $logger;
+
     $this->flushBuffer();
   }
 
@@ -100,16 +101,14 @@ class sfPsrLoggerAdapter extends sfLogger
    *
    * @return void
    */
-  public function flushBuffer()
+  public function flushBuffer(): void
   {
-    if (!$this->logger)
-    {
+    if ( ! $this->logger) {
       $this->buffer = [];
       return;
     }
 
-    foreach ($this->buffer as $log)
-    {
+    foreach ($this->buffer as $log) {
       $this->log($log['message'], $log['priority']);
     }
 
@@ -119,21 +118,19 @@ class sfPsrLoggerAdapter extends sfLogger
   /**
    * Logs a message.
    *
-   * @param string $message Message
-   * @param int    $priority Message priority
+   * @param string $message   Message
+   * @param int    $priority  Message priority
    *
    * @return void
    */
   protected function doLog(string $message, int $priority): void
   {
-    if (!$this->logger)
-    {
+    if ( ! $this->logger) {
       $this->buffer[] = compact('message', 'priority');
       return;
     }
 
-    switch ($priority)
-    {
+    switch ($priority) {
       case sfLogger::EMERG:
         $this->logger->emergency($message);
         break;

--- a/lib/log/sfStreamLogger.class.php
+++ b/lib/log/sfStreamLogger.class.php
@@ -58,7 +58,7 @@ class sfStreamLogger extends sfLogger
    *
    * @param resource $stream A php stream
    */
-  public function setStream($stream)
+  public function setStream($stream): void
   {
     $this->stream = $stream;
   }

--- a/lib/log/sfVarLogger.class.php
+++ b/lib/log/sfVarLogger.class.php
@@ -19,9 +19,10 @@
 class sfVarLogger extends sfLogger
 {
   /** @var array[] */
-  protected $logs = [];
+  protected array $logs = [];
+
   /** @var bool */
-  protected $xdebugLogging = false;
+  protected bool $xdebugLogging = false;
 
   /**
    * Class constructor.
@@ -30,18 +31,17 @@ class sfVarLogger extends sfLogger
    *
    * - xdebug_logging: Whether to add xdebug trace to the logs (false by default).
    *
-   * @param  sfEventDispatcher $dispatcher  A sfEventDispatcher instance
-   * @param  array             $options     An array of options.
+   * @param sfEventDispatcher $dispatcher  A sfEventDispatcher instance
+   * @param array             $options     An array of options.
    *
    * @throws sfInitializationException
    */
   public function __construct(sfEventDispatcher $dispatcher, array $options = [])
   {
-    $this->xdebugLogging = isset($options['xdebug_logging']) ? $options['xdebug_logging'] : false;
+    $this->xdebugLogging = $options['xdebug_logging'] ?? false;
 
     // disable xdebug when an HTTP debug session exists (crashes Apache, see #2438)
-    if (isset($_GET['XDEBUG_SESSION_START']) || isset($_COOKIE['XDEBUG_SESSION']))
-    {
+    if (isset($_GET['XDEBUG_SESSION_START']) || isset($_COOKIE['XDEBUG_SESSION'])) {
       $this->xdebugLogging = false;
     }
 
@@ -54,14 +54,15 @@ class sfVarLogger extends sfLogger
    * Each log entry has the following attributes:
    *
    *  * priority
+   *  * priority_name
    *  * time
    *  * message
    *  * type
-   *  * debugStack
+   *  * debug_backtrace
    *
-   * @return array An array of logs
+   * @return array<{"priority":int,'priority_name':string,"time":int,"message":string,"type":string,"debug_backtrace":array}> An array of logs
    */
-  public function getLogs()
+  public function getLogs(): array
   {
     return $this->logs;
   }
@@ -69,15 +70,14 @@ class sfVarLogger extends sfLogger
   /**
    * Returns all the types in the logs.
    *
-   * @return array An array of types
+   * @return string[] An array of types
    */
-  public function getTypes()
+  public function getTypes(): array
   {
-    $types = array();
-    foreach ($this->logs as $log)
-    {
-      if (!in_array($log['type'], $types))
-      {
+    $types = [];
+
+    foreach ($this->logs as $log) {
+      if ( ! in_array($log['type'], $types)) {
         $types[] = $log['type'];
       }
     }
@@ -90,15 +90,13 @@ class sfVarLogger extends sfLogger
   /**
    * Returns all the priorities in the logs.
    *
-   * @return array An array of priorities
+   * @return string[] An array of priorities
    */
-  public function getPriorities()
+  public function getPriorities(): array
   {
-    $priorities = array();
-    foreach ($this->logs as $log)
-    {
-      if (!in_array($log['priority'], $priorities))
-      {
+    $priorities = [];
+    foreach ($this->logs as $log) {
+      if ( ! in_array($log['priority'], $priorities)) {
         $priorities[] = $log['priority'];
       }
     }
@@ -111,15 +109,13 @@ class sfVarLogger extends sfLogger
   /**
    * Returns the highest priority in the logs.
    *
-   * @return integer The highest priority
+   * @return int The highest priority
    */
-  public function getHighestPriority()
+  public function getHighestPriority(): int
   {
     $priority = 1000;
-    foreach ($this->logs as $log)
-    {
-      if ($log['priority'] < $priority)
-      {
+    foreach ($this->logs as $log) {
+      if ($log['priority'] < $priority) {
         $priority = $log['priority'];
       }
     }
@@ -137,20 +133,19 @@ class sfVarLogger extends sfLogger
   {
     // get log type in {}
     $type = 'sfOther';
-    if (preg_match('/^\s*{([^}]+)}\s*(.+?)$/s', $message, $matches))
-    {
+    if (preg_match('/^\s*{([^}]+)}\s*(.+?)$/s', $message, $matches)) {
       $type    = $matches[1];
       $message = $matches[2];
     }
 
-    $this->logs[] = array(
+    $this->logs[] = [
       'priority'        => $priority,
       'priority_name'   => $this->getPriorityName($priority),
       'time'            => time(),
       'message'         => $message,
       'type'            => $type,
       'debug_backtrace' => $this->getDebugBacktrace(),
-    );
+    ];
   }
 
   /**
@@ -160,29 +155,28 @@ class sfVarLogger extends sfLogger
    *
    * @see debug_backtrace()
    */
-  protected function getDebugBacktrace()
+  protected function getDebugBacktrace(): array
   {
     // if we have xdebug and dev has not disabled the feature, add some stack information
-    if (!$this->xdebugLogging || !function_exists('debug_backtrace'))
-    {
-      return array();
+    if ( ! $this->xdebugLogging || ! function_exists('debug_backtrace')) {
+      return [];
     }
 
     $traces = debug_backtrace();
 
     // remove sfLogger and sfEventDispatcher from the top of the trace
-    foreach ($traces as $i => $trace)
-    {
-      $class = isset($trace['class']) ? $trace['class'] : substr($file = basename($trace['file']), 0, strpos($file, '.'));
+    foreach ($traces as $i => $trace) {
+      $class = $trace['class'] ?? substr($file = basename($trace['file']), 0, strpos($file, '.'));
 
       if (
-        !class_exists($class)
-        ||
-        (!in_array($class, array('sfLogger', 'sfEventDispatcher')) && !is_subclass_of($class, 'sfLogger') && !is_subclass_of($class, 'sfEventDispatcher'))
-      )
-      {
-        $traces = array_slice($traces, $i);
-        break;
+        ! class_exists($class)
+        || (
+          ! in_array($class, [sfLogger::class, sfEventDispatcher::class])
+          && ! is_subclass_of($class, sfLogger::class)
+          && ! is_subclass_of($class, sfEventDispatcher::class)
+        )
+      ) {
+        return array_slice($traces, $i);
       }
     }
 

--- a/lib/log/sfWebDebugLogger.class.php
+++ b/lib/log/sfWebDebugLogger.class.php
@@ -92,9 +92,6 @@ class sfWebDebugLogger extends sfVarLogger
 
     $message = sprintf(' %%s at %s on line %s (%s)', $errfile, $errline, str_replace('%', '%%', $errstr));
     switch ($errno) {
-      case E_STRICT:
-        $this->dispatcher->notify(new sfEvent($this, 'application.log', ['priority' => sfLogger::ERR, sprintf($message, 'Strict notice')]));
-        break;
       case E_NOTICE:
         $this->dispatcher->notify(new sfEvent($this, 'application.log', ['priority' => sfLogger::NOTICE, sprintf($message, 'Notice')]));
         break;

--- a/lib/log/sfWebDebugLogger.class.php
+++ b/lib/log/sfWebDebugLogger.class.php
@@ -19,11 +19,13 @@
 class sfWebDebugLogger extends sfVarLogger
 {
   /** @var sfContext */
-  protected $context;
-  /** @var string */
-  protected $webDebugClass;
+  protected sfContext $context;
+
+  /** @var class-string */
+  protected string $webDebugClass;
+
   /** @var sfWebDebug */
-  protected $webDebug;
+  protected sfWebDebug $webDebug;
 
   /**
    * Class constructor.
@@ -32,8 +34,8 @@ class sfWebDebugLogger extends sfVarLogger
    *
    *  * web_debug_class: The web debug class (sfWebDebug by default)
    *
-   * @param sfEventDispatcher $dispatcher A sfEventDispatcher instance
-   * @param array             $options    An array of options.
+   * @param sfEventDispatcher $dispatcher  A sfEventDispatcher instance
+   * @param array             $options     An array of options.
    *
    * @throws sfInitializationException
    *
@@ -47,12 +49,11 @@ class sfWebDebugLogger extends sfVarLogger
       throw new sfInitializationException($exception->getMessage(), 0, $exception);
     }
 
-    $this->webDebugClass = isset($options['web_debug_class']) ? $options['web_debug_class'] : 'sfWebDebug';
+    $this->webDebugClass = $options['web_debug_class'] ?? sfWebDebug::class;
 
-    if (sfConfig::get('sf_web_debug'))
-    {
-      $dispatcher->connect('context.load_factories', array($this, 'listenForLoadFactories'));
-      $dispatcher->connect('response.filter_content', array($this, 'filterResponseContent'));
+    if (sfConfig::get('sf_web_debug')) {
+      $dispatcher->connect('context.load_factories', [$this, 'listenForLoadFactories']);
+      $dispatcher->connect('response.filter_content', [$this, 'filterResponseContent']);
     }
 
     $this->registerErrorHandler();
@@ -63,9 +64,9 @@ class sfWebDebugLogger extends sfVarLogger
   /**
    * Registers logger with PHP error handler.
    */
-  protected function registerErrorHandler()
+  protected function registerErrorHandler(): void
   {
-    set_error_handler(array($this,'handlePhpError'));
+    set_error_handler([$this, 'handlePhpError']);
   }
 
   /**
@@ -75,35 +76,33 @@ class sfWebDebugLogger extends sfVarLogger
    * E_CORE_ERROR, E_CORE_WARNING, E_COMPILE_ERROR, E_COMPILE_WARNING,
    * and most of E_STRICT.
    *
-   * @param string $errno      The level of the error raised, as an integer.
-   * @param string $errstr     The error message, as a string.
-   * @param string $errfile    The filename that the error was raised in, as a string.
-   * @param string $errline    The line number the error was raised at, as an integer.
-   * @param array  $errcontext An array that points to the active symbol table at the point the error occurred.
+   * @param string $errno       The level of the error raised, as an integer.
+   * @param string $errstr      The error message, as a string.
+   * @param string $errfile     The filename that the error was raised in, as a string.
+   * @param string $errline     The line number the error was raised at, as an integer.
+   * @param array  $errcontext  An array that points to the active symbol table at the point the error occurred.
    *
    * @return bool
    */
-  public function handlePhpError($errno, $errstr, $errfile, $errline, $errcontext = array())
+  public function handlePhpError($errno, $errstr, $errfile, $errline, $errcontext = [])
   {
-    if (($errno & error_reporting()) == 0)
-    {
+    if (($errno & error_reporting()) == 0) {
       return false;
     }
 
     $message = sprintf(' %%s at %s on line %s (%s)', $errfile, $errline, str_replace('%', '%%', $errstr));
-    switch ($errno)
-    {
+    switch ($errno) {
       case E_STRICT:
-        $this->dispatcher->notify(new sfEvent($this, 'application.log', array('priority' => sfLogger::ERR, sprintf($message, 'Strict notice'))));
+        $this->dispatcher->notify(new sfEvent($this, 'application.log', ['priority' => sfLogger::ERR, sprintf($message, 'Strict notice')]));
         break;
       case E_NOTICE:
-        $this->dispatcher->notify(new sfEvent($this, 'application.log', array('priority' => sfLogger::NOTICE, sprintf($message, 'Notice'))));
+        $this->dispatcher->notify(new sfEvent($this, 'application.log', ['priority' => sfLogger::NOTICE, sprintf($message, 'Notice')]));
         break;
       case E_WARNING:
-        $this->dispatcher->notify(new sfEvent($this, 'application.log', array('priority' => sfLogger::WARNING, sprintf($message, 'Warning'))));
+        $this->dispatcher->notify(new sfEvent($this, 'application.log', ['priority' => sfLogger::WARNING, sprintf($message, 'Warning')]));
         break;
       case E_RECOVERABLE_ERROR:
-        $this->dispatcher->notify(new sfEvent($this, 'application.log', array('priority' => sfLogger::ERR, sprintf($message, 'Error'))));
+        $this->dispatcher->notify(new sfEvent($this, 'application.log', ['priority' => sfLogger::ERR, sprintf($message, 'Error')]));
         break;
     }
 
@@ -115,36 +114,34 @@ class sfWebDebugLogger extends sfVarLogger
    *
    * @param sfEvent $event
    */
-  public function listenForLoadFactories(sfEvent $event)
+  public function listenForLoadFactories(sfEvent $event): void
   {
     $path = sprintf('%s/%s/images', $event->getSubject()->getRequest()->getRelativeUrlRoot(), sfConfig::get('sf_web_debug_web_dir'));
     $path = str_replace('//', '/', $path);
 
-    $this->webDebug = new $this->webDebugClass($this->dispatcher, $this, array(
+    $this->webDebug = new $this->webDebugClass($this->dispatcher, $this, [
       'image_root_path'    => $path,
       'request_parameters' => $event->getSubject()->getRequest()->getParameterHolder()->getAll(),
-    ));
+    ]);
   }
 
   /**
    * Listens to the response.filter_content event.
    *
-   * @param  sfEvent $event   The sfEvent instance
-   * @param  string  $content The response content
+   * @param sfEvent $event    The sfEvent instance
+   * @param string  $content  The response content
    *
    * @return string  The filtered response content
    */
-  public function filterResponseContent(sfEvent $event, $content)
+  public function filterResponseContent(sfEvent $event, string $content): string
   {
-    if (!sfConfig::get('sf_web_debug'))
-    {
+    if ( ! sfConfig::get('sf_web_debug')) {
       return $content;
     }
 
     // log timers information
-    $messages = array();
-    foreach (sfTimerManager::getTimers() as $name => $timer)
-    {
+    $messages = [];
+    foreach (sfTimerManager::getTimers() as $name => $timer) {
       $messages[] = sprintf('%s %.2f ms (%d)', $name, $timer->getElapsedTime() * 1000, $timer->getCalls());
     }
     $this->dispatcher->notify(new sfEvent($this, 'application.log', $messages));
@@ -154,29 +151,23 @@ class sfWebDebugLogger extends sfVarLogger
     // * if response status code is in the 3xx range
     // * if not rendering to the client
     // * if HTTP headers only
+
+    /** @var sfWebResponse $response */
     $response = $event->getSubject();
     /** @var sfWebRequest $request */
-    $request  = $this->context->getRequest();
+    $request = $this->context->getRequest();
+
     if (
       null === $this->webDebug
-      ||
-      !$this->context->has('request')
-      ||
-      !$this->context->has('response')
-      ||
-      !$this->context->has('controller')
-      ||
-      $request->isXmlHttpRequest()
-      ||
-      strpos($response->getContentType(), 'html') === false
-      ||
-      '3' == substr($response->getStatusCode(), 0, 1)
-      ||
-      $this->context->getController()->getRenderMode() != sfView::RENDER_CLIENT
-      ||
-      $response->isHeaderOnly()
-    )
-    {
+      || ! $this->context->has('request')
+      || ! $this->context->has('response')
+      || ! $this->context->has('controller')
+      || $request->isXmlHttpRequest()
+      || ! str_contains($response->getContentType(), 'html')
+      || str_starts_with($response->getStatusCode(), '3')
+      || $this->context->getController()->getRenderMode() != sfView::RENDER_CLIENT
+      || $response->isHeaderOnly()
+    ) {
       return $content;
     }
 

--- a/lib/request/sfRequest.class.php
+++ b/lib/request/sfRequest.class.php
@@ -170,12 +170,12 @@ abstract class sfRequest
   /**
    * Retrieves an attribute from the current request.
    *
-   * @param  string $name     Attribute name
-   * @param  string $default  Default attribute value
+   * @param string     $name     Attribute name
+   * @param mixed|null $default  Default attribute value
    *
    * @return mixed An attribute value
    */
-  public function getAttribute(string $name, string $default = null)
+  public function getAttribute(string $name, mixed $default = null): mixed
   {
     return $this->attributeHolder->get($name, $default);
   }

--- a/lib/request/sfRequest.class.php
+++ b/lib/request/sfRequest.class.php
@@ -22,12 +22,12 @@
  */
 abstract class sfRequest
 {
-  public const GET    = 'GET';
-  public const POST   = 'POST';
-  public const PUT    = 'PUT';
-  public const PATCH  = 'PATCH';
-  public const DELETE = 'DELETE';
-  public const HEAD   = 'HEAD';
+  public const GET     = 'GET';
+  public const POST    = 'POST';
+  public const PUT     = 'PUT';
+  public const PATCH   = 'PATCH';
+  public const DELETE  = 'DELETE';
+  public const HEAD    = 'HEAD';
   public const OPTIONS = 'OPTIONS';
 
   public const METHODS = [
@@ -37,13 +37,13 @@ abstract class sfRequest
     self::PATCH,
     self::DELETE,
     self::HEAD,
-    self::OPTIONS
+    self::OPTIONS,
   ];
 
   protected sfEventDispatcher $dispatcher;
-  protected ?string $content = null;
-  protected ?string $method = null;
-  protected array $options = [];
+  protected ?string           $content = null;
+  protected ?string           $method  = null;
+  protected array             $options = [];
   protected sfParameterHolder $parameterHolder;
   protected sfParameterHolder $attributeHolder;
 
@@ -54,18 +54,17 @@ abstract class sfRequest
    *
    *  * logging: Whether to enable logging or not (false by default)
    *
-   * @param  sfEventDispatcher $dispatcher  An sfEventDispatcher instance
-   * @param  array             $parameters  An associative array of initialization parameters
-   * @param  array             $attributes  An associative array of initialization attributes
-   * @param  array             $options     An associative array of options
+   * @param sfEventDispatcher $dispatcher  An sfEventDispatcher instance
+   * @param array             $parameters  An associative array of initialization parameters
+   * @param array             $attributes  An associative array of initialization attributes
+   * @param array             $options     An associative array of options
    */
   public function __construct(sfEventDispatcher $dispatcher, array $parameters = [], array $attributes = [], array $options = [])
   {
     $this->dispatcher = $dispatcher;
-    $this->options = $options;
+    $this->options    = $options;
 
-    if (!isset($this->options['logging']))
-    {
+    if ( ! isset($this->options['logging'])) {
       $this->options['logging'] = false;
     }
 
@@ -77,11 +76,11 @@ abstract class sfRequest
   /**
    * Return an option value or null if option does not exist
    *
-   * @param string $name The option name.
+   * @param string $name  The option name.
    *
    * @return mixed The option value
    */
-  public function getOption(string $name)
+  public function getOption(string $name): mixed
   {
     return $this->options[$name] ?? null;
   }
@@ -99,7 +98,7 @@ abstract class sfRequest
   /**
    * Extracts parameter values from the request.
    *
-   * @param  array $names  An indexed array of parameter names to extract
+   * @param array $names  An indexed array of parameter names to extract
    *
    * @return array An associative array of parameters and their values. If
    *               a specified parameter doesn't exist an empty string will
@@ -107,13 +106,11 @@ abstract class sfRequest
    */
   public function extractParameters(array $names): array
   {
-    $array = array();
+    $array = [];
 
     $parameters = $this->parameterHolder->getAll();
-    foreach ($parameters as $key => $value)
-    {
-      if (in_array($key, $names))
-      {
+    foreach ($parameters as $key => $value) {
+      if (in_array($key, $names)) {
         $array[$key] = $value;
       }
     }
@@ -140,7 +137,7 @@ abstract class sfRequest
    */
   public function setMethod(string $method): void
   {
-    if (!in_array(strtoupper($method), self::METHODS)) {
+    if ( ! in_array(strtoupper($method), self::METHODS)) {
       throw new sfException(sprintf('Invalid request method: %s.', $method));
     }
 
@@ -183,7 +180,7 @@ abstract class sfRequest
   /**
    * Indicates whether or not an attribute exist for the current request.
    *
-   * @param  string $name  Attribute name
+   * @param string $name  Attribute name
    *
    * @return bool true, if the attribute exists otherwise false
    */
@@ -196,10 +193,10 @@ abstract class sfRequest
    * Sets an attribute for the request.
    *
    * @param string $name   Attribute name
-   * @param mixed $value  Value for the attribute
+   * @param mixed  $value  Value for the attribute
    *
    */
-  public function setAttribute(string $name, $value): void
+  public function setAttribute(string $name, mixed $value): void
   {
     $this->attributeHolder->set($name, $value);
   }
@@ -207,12 +204,12 @@ abstract class sfRequest
   /**
    * Retrieves a parameter for the current request.
    *
-   * @param string $name    Parameter name
-   * @param mixed $default Parameter default value
+   * @param string $name     Parameter name
+   * @param mixed  $default  Parameter default value
    *
    * @return mixed
    */
-  public function getParameter(string $name, $default = null)
+  public function getParameter(string $name, mixed $default = null)
   {
     return $this->parameterHolder->get($name, $default);
   }
@@ -220,7 +217,7 @@ abstract class sfRequest
   /**
    * Indicates whether or not a parameter exist for the current request.
    *
-   * @param  string $name  Parameter name
+   * @param string $name  Parameter name
    *
    * @return bool true, if the parameter exists otherwise false
    */
@@ -233,10 +230,10 @@ abstract class sfRequest
    * Sets a parameter for the current request.
    *
    * @param string $name   Parameter name
-   * @param mixed $value  Parameter value
+   * @param mixed  $value  Parameter value
    *
    */
-  public function setParameter(string $name, $value): void
+  public function setParameter(string $name, mixed $value): void
   {
     $this->parameterHolder->set($name, $value);
   }
@@ -246,10 +243,9 @@ abstract class sfRequest
    *
    * @return string|false The content or false if none is available
    */
-  public function getContent()
+  public function getContent(): string | false
   {
-    if (null === $this->content && '' === trim($this->content = file_get_contents('php://input')))
-    {
+    if (null === $this->content && '' === trim($this->content = file_get_contents('php://input'))) {
       $this->content = false;
     }
 

--- a/lib/request/sfWebRequest.class.php
+++ b/lib/request/sfWebRequest.class.php
@@ -446,21 +446,19 @@ class sfWebRequest extends sfRequest
   /**
    * Returns the preferred culture for the current request.
    *
-   * @param  array  $cultures  An array of ordered cultures available
+   * @param string[]|null $cultures  An array of ordered cultures available
    *
    * @return string|null The preferred culture
    */
-  public function getPreferredCulture(array $cultures = null): ?string
+  public function getPreferredCulture(array | null $cultures = null): ?string
   {
     $preferredCultures = $this->getLanguages();
 
-    if (null === $cultures)
-    {
+    if (null === $cultures) {
       return $preferredCultures[0] ?? null;
     }
 
-    if (!$preferredCultures)
-    {
+    if ( ! $preferredCultures) {
       return $cultures[0];
     }
 
@@ -828,10 +826,9 @@ class sfWebRequest extends sfRequest
    *
    * @return array  An associative array of files
    */
-  public function getFiles(string $key = null): array
+  public function getFiles(string | null $key = null): array
   {
-    if (null === $this->fixedFileArray)
-    {
+    if (null === $this->fixedFileArray) {
       $this->fixedFileArray = self::convertFileInformation($_FILES);
     }
 

--- a/lib/request/sfWebRequest.class.php
+++ b/lib/request/sfWebRequest.class.php
@@ -22,8 +22,8 @@
  */
 class sfWebRequest extends sfRequest
 {
-  const PORT_HTTP  = 80;
-  const PORT_HTTPS = 443;
+  public const PORT_HTTP  = 80;
+  public const PORT_HTTPS = 443;
 
   /** @var string[]|null */
   protected ?array $languages = null;
@@ -610,7 +610,7 @@ class sfWebRequest extends sfRequest
    *
    * @return mixed The cookie value
    */
-  public function getCookie(string $name, $defaultValue = null)
+  public function getCookie(string $name, mixed $defaultValue = null): mixed
   {
     $retval = $defaultValue;
 
@@ -783,7 +783,7 @@ class sfWebRequest extends sfRequest
    * @param string       $format     The format
    * @param string|array $mimeTypes  The associated mime types (the preferred one must be the first as it will be used as the content type)
    */
-  public function setFormat(string $format, $mimeTypes): void
+  public function setFormat(string $format, array | string $mimeTypes): void
   {
     $this->formats[$format] = is_array($mimeTypes) ? $mimeTypes : [$mimeTypes];
   }
@@ -900,7 +900,7 @@ class sfWebRequest extends sfRequest
    *
    * @return mixed The GET parameter value
    */
-  public function getGetParameter(string $name, $default = null)
+  public function getGetParameter(string $name, mixed $default = null): mixed
   {
     return $this->getParameters[$name] ?? sfToolkit::getArrayValueForPath($this->getParameters, $name, $default);
   }
@@ -913,7 +913,7 @@ class sfWebRequest extends sfRequest
    *
    * @return mixed The POST parameter value
    */
-  public function getPostParameter(string $name, $default = null)
+  public function getPostParameter(string $name, mixed $default = null): mixed
   {
     return $this->postParameters[$name] ?? sfToolkit::getArrayValueForPath($this->postParameters, $name, $default);
   }
@@ -926,7 +926,7 @@ class sfWebRequest extends sfRequest
    *
    * @return mixed The parameter value
    */
-  public function getUrlParameter(string $name, $default = null)
+  public function getUrlParameter(string $name, mixed $default = null): mixed
   {
     return $this->requestParameters[$name] ?? sfToolkit::getArrayValueForPath($this->requestParameters, $name, $default);
   }

--- a/lib/response/sfCookie.class.php
+++ b/lib/response/sfCookie.class.php
@@ -3,50 +3,56 @@
 class sfCookie
 {
   /** @var string */
-  private $name;
+  private string $name;
+
   /** @var string|null */
-  private $value;
+  private string | null $value;
+
   /** @var \DateTimeInterface|null */
-  private $expires;
+  private DateTimeInterface | null $expires;
+
   /** @var string|null */
-  private $domain;
+  private string | null $domain;
+
   /** @var string */
-  private $path;
+  private string $path;
+
   /** @var bool */
-  private $httpOnly;
+  private bool $httpOnly;
+
   /** @var bool */
-  private $secure;
+  private bool $secure;
+
   /** @var string */
-  private $sameSite;
+  private string $sameSite;
 
   /**
-   * @param  string                             $name
-   * @param  string|null                        $value
-   * @param  DateTimeInterface|string|int|null  $expires
-   * @param  string|null                        $domain
-   * @param  string                             $path
-   * @param  bool                               $httpOnly
-   * @param  bool                               $secure
-   * @param  string                             $sameSite
+   * @param string                            $name
+   * @param string|null                       $value
+   * @param DateTimeInterface|string|int|null $expires
+   * @param string|null                       $domain
+   * @param string                            $path
+   * @param bool                              $httpOnly
+   * @param bool                              $secure
+   * @param string                            $sameSite
    */
   public function __construct(
-    string $name,
-    ?string $value,
-    $expires = null,
-    string $path = '/',
-    ?string $domain = null,
-    bool $httpOnly = false,
-    bool $secure = false,
-    string $sameSite = 'Lax'
-  )
-  {
-    $this->name = $name;
-    $this->value = $value;
-    $this->expires = $this->parseExpires($expires);
-    $this->path = $path;
-    $this->domain = $domain;
+    string                                  $name,
+    ?string                                 $value,
+    DateTimeInterface | string | int | null $expires = null,
+    string                                  $path = '/',
+    string | null                           $domain = null,
+    bool                                    $httpOnly = false,
+    bool                                    $secure = false,
+    string                                  $sameSite = 'Lax'
+  ) {
+    $this->name     = $name;
+    $this->value    = $value;
+    $this->expires  = $this->parseExpires($expires);
+    $this->path     = $path;
+    $this->domain   = $domain;
     $this->httpOnly = $httpOnly;
-    $this->secure = $secure;
+    $this->secure   = $secure;
     $this->sameSite = $sameSite;
   }
 
@@ -71,11 +77,11 @@ class sfCookie
   }
 
   /**
-   * @param  \DateTimeInterface|string|int|null  $expires
+   * @param \DateTimeInterface|string|int|null $expires
    * @return \DateTimeInterface|null
    * @throws \InvalidArgumentException
    */
-  private function parseExpires($expires): ?DateTimeInterface
+  private function parseExpires(DateTimeInterface | string | int | null $expires): ?DateTimeInterface
   {
     if ($expires === null) {
       return null;
@@ -86,7 +92,7 @@ class sfCookie
     }
 
     try {
-      if (is_string($expires) && !is_numeric($expires)) {
+      if (is_string($expires) && ! is_numeric($expires)) {
         return new DateTime($expires);
       }
       return DateTime::createFromFormat('U', $expires);

--- a/lib/response/sfResponse.class.php
+++ b/lib/response/sfResponse.class.php
@@ -19,12 +19,11 @@
  */
 abstract class sfResponse
 {
-  /** @var array */
-  protected $options = [];
-  /** @var sfEventDispatcher */
-  protected $dispatcher;
-  /** @var string */
-  protected $content = '';
+  protected array $options = [];
+
+  protected sfEventDispatcher $dispatcher;
+
+  protected string $content = '';
 
   /**
    * Class constructor.

--- a/lib/response/sfWebResponse.class.php
+++ b/lib/response/sfWebResponse.class.php
@@ -199,10 +199,10 @@ class sfWebResponse extends sfResponse
    * @param string $name  HTTP status text
    *
    */
-  public function setStatusCode(string $code, string $name = null): void
+  public function setStatusCode(string $code, string | null $name = null): void
   {
     $this->statusCode = $code;
-    $this->statusText = null !== $name ? $name : self::$statusTexts[$code];
+    $this->statusText = $name ?? self::$statusTexts[$code];
   }
 
   /**
@@ -271,7 +271,7 @@ class sfWebResponse extends sfResponse
    *
    * @return string|null
    */
-  public function getHttpHeader(string $name, string $default = null): ?string
+  public function getHttpHeader(string $name, string | null $default = null): string | null
   {
     $name = $this->normalizeHeaderName($name);
 
@@ -475,26 +475,23 @@ class sfWebResponse extends sfResponse
    * Adds an control cache http header.
    *
    * @param string $name   HTTP header
-   * @param string $value  Value for the http header
+   * @param string|null $value  Value for the http header
    */
-  public function addCacheControlHttpHeader(string $name, string $value = null): void
+  public function addCacheControlHttpHeader(string $name, string | null $value = null): void
   {
-    $cacheControl = $this->getHttpHeader('Cache-Control');
-    $currentHeaders = array();
-    if ($cacheControl)
-    {
-      foreach (preg_split('/\s*,\s*/', $cacheControl) as $tmp)
-      {
-        $tmp = explode('=', $tmp);
+    $cacheControl   = $this->getHttpHeader('Cache-Control');
+    $currentHeaders = [];
+    if ($cacheControl) {
+      foreach (preg_split('/\s*,\s*/', $cacheControl) as $tmp) {
+        $tmp                     = explode('=', $tmp);
         $currentHeaders[$tmp[0]] = $tmp[1] ?? null;
       }
     }
     $currentHeaders[str_replace('_', '-', strtolower($name))] = $value;
 
-    $headers = array();
-    foreach ($currentHeaders as $key => $value)
-    {
-      $headers[] = $key.(null !== $value ? '='.$value : '');
+    $headers = [];
+    foreach ($currentHeaders as $key => $value) {
+      $headers[] = $key . (null !== $value ? '=' . $value : '');
     }
 
     $this->setHttpHeader('Cache-Control', implode(', ', $headers));

--- a/lib/routing/sfPatternRouting.class.php
+++ b/lib/routing/sfPatternRouting.class.php
@@ -46,29 +46,27 @@ class sfPatternRouting extends sfRouting
    * @see sfRouting
    * @inheritdoc
    */
-  public function __construct(sfEventDispatcher $dispatcher, sfCache $cache = null, array $options = [])
+  public function __construct(sfEventDispatcher $dispatcher, sfCache | null $cache = null, array $options = [])
   {
-    $options = array_merge(array(
-      'variable_prefixes'                => array(':'),
-      'segment_separators'               => array('/', '.'),
+    $options = array_merge([
+      'variable_prefixes'                => [':'],
+      'segment_separators'               => ['/', '.'],
       'variable_regex'                   => '[\w\d_]+',
       'load_configuration'               => false,
       'suffix'                           => '',
       'generate_shortest_url'            => true,
       'extra_parameters_as_query_string' => true,
       'lookup_cache_dedicated_keys'      => false,
-    ), $options);
+    ], $options);
 
     // for BC
-    if ('.' == $options['suffix'])
-    {
+    if ('.' == $options['suffix']) {
       $options['suffix'] = '';
     }
 
     parent::__construct($dispatcher, $cache, $options);
 
-    if (null !== $this->cache && !$options['lookup_cache_dedicated_keys'] && $cacheData = $this->cache->get('symfony.routing.data'))
-    {
+    if (null !== $this->cache && ! $options['lookup_cache_dedicated_keys'] && $cacheData = $this->cache->get('symfony.routing.data')) {
       $this->cacheData = unserialize($cacheData);
     }
   }

--- a/lib/routing/sfRouting.class.php
+++ b/lib/routing/sfRouting.class.php
@@ -37,10 +37,10 @@ abstract class sfRouting
    *  * context:        An array of context variables to help URL matching and generation
    *
    * @param sfEventDispatcher $dispatcher  An sfEventDispatcher instance
-   * @param sfCache           $cache       An sfCache instance
+   * @param sfCache|null      $cache       An sfCache instance
    * @param array             $options     An associative array of initialization options.
    */
-  public function __construct(sfEventDispatcher $dispatcher, sfCache $cache = null, array $options = [])
+  public function __construct(sfEventDispatcher $dispatcher, sfCache | null $cache = null, array $options = [])
   {
     $this->dispatcher = $dispatcher;
 

--- a/lib/service/sfServiceContainerLoader.class.php
+++ b/lib/service/sfServiceContainerLoader.class.php
@@ -21,11 +21,9 @@ abstract class sfServiceContainerLoader implements sfServiceContainerLoaderInter
   protected $container;
 
   /**
-   * Constructor.
-   *
-   * @param sfServiceContainerBuilder $container A sfServiceContainerBuilder instance
+   * @param sfServiceContainerBuilder|null $container A sfServiceContainerBuilder instance
    */
-  public function __construct(sfServiceContainerBuilder $container = null)
+  public function __construct(sfServiceContainerBuilder | null $container = null)
   {
     $this->container = $container;
   }

--- a/lib/storage/sfDatabaseSessionStorage.class.php
+++ b/lib/storage/sfDatabaseSessionStorage.class.php
@@ -34,7 +34,7 @@ abstract class sfDatabaseSessionStorage extends sfSessionStorage
    *   * db_data_col: The database column in which the session data will be stored (sess_data by default)
    *   * db_time_col: The database column in which the session timestamp will be stored (sess_time by default)
    *
-   * @param  array $options An associative array of options
+   * @param array $options  An associative array of options
    *
    * @throws sfInitializationException
    *
@@ -42,11 +42,11 @@ abstract class sfDatabaseSessionStorage extends sfSessionStorage
    */
   public function __construct(array $options = [])
   {
-    $options = array_merge(array(
+    $options = array_merge([
       'db_id_col'   => 'sess_id',
       'db_data_col' => 'sess_data',
       'db_time_col' => 'sess_time',
-    ), $options);
+    ], $options);
 
     // disable auto_start
     $options['auto_start'] = false;
@@ -54,13 +54,11 @@ abstract class sfDatabaseSessionStorage extends sfSessionStorage
     // initialize the parent
     parent::__construct($options);
 
-    if (!isset($this->options['db_table']))
-    {
+    if ( ! isset($this->options['db_table'])) {
       throw new sfInitializationException('You must provide a "db_table" option to sfDatabaseSessionStorage.');
     }
 
-    if (!isset($this->options['database']))
-    {
+    if ( ! isset($this->options['database'])) {
       throw new sfInitializationException('You must provide a "database" option to sfDatabaseSessionStorage.');
     }
 
@@ -92,8 +90,8 @@ abstract class sfDatabaseSessionStorage extends sfSessionStorage
   /**
    * Opens a session.
    *
-   * @param  string $path  (ignored)
-   * @param  string $name  (ignored)
+   * @param string $path  (ignored)
+   * @param string $name  (ignored)
    *
    * @return boolean true, if the session was opened, otherwise an exception is thrown
    *
@@ -107,23 +105,17 @@ abstract class sfDatabaseSessionStorage extends sfSessionStorage
 
     // get the database and connection
     $databaseClass = get_class($database);
-    if ($databaseClass == 'sfPropelDatabase')
-    {
+    if ($databaseClass == 'sfPropelDatabase') {
       $this->db = Propel::getConnection($database->getParameter('name'));
-    }
-    elseif($databaseClass == 'sfDoctrineDatabase')
-    {
+    } elseif ($databaseClass == 'sfDoctrineDatabase') {
       $this->db = $database->getConnection();
-    }
-    else
-    {
+    } else {
       $this->db = $database->getResource();
     }
 
     $this->con = $database->getConnection();
 
-    if (null === $this->db && null === $this->con)
-    {
+    if (null === $this->db && null === $this->con) {
       throw new sfDatabaseException('Database connection does not exist. Unable to open session.');
     }
 
@@ -133,7 +125,7 @@ abstract class sfDatabaseSessionStorage extends sfSessionStorage
   /**
    * Destroys a session.
    *
-   * @param  string $id  A session ID
+   * @param string $id  A session ID
    *
    * @return bool true, if the session was destroyed, otherwise an exception is thrown
    *
@@ -144,7 +136,7 @@ abstract class sfDatabaseSessionStorage extends sfSessionStorage
   /**
    * Cleans up old sessions.
    *
-   * @param  int $lifetime  The lifetime of a session
+   * @param int $lifetime  The lifetime of a session
    *
    * @return bool true, if old sessions have been cleaned, otherwise an exception is thrown
    *
@@ -155,7 +147,7 @@ abstract class sfDatabaseSessionStorage extends sfSessionStorage
   /**
    * Reads a session.
    *
-   * @param  string $id  A session ID
+   * @param string $id  A session ID
    *
    * @return string      The session data if the session was read or created, otherwise an exception is thrown
    *
@@ -166,8 +158,8 @@ abstract class sfDatabaseSessionStorage extends sfSessionStorage
   /**
    * Writes session data.
    *
-   * @param  string $id    A session ID
-   * @param  string $data  A serialized chunk of session data
+   * @param string $id    A session ID
+   * @param string $data  A serialized chunk of session data
    *
    * @return bool true, if the session was written, otherwise an exception is thrown
    *
@@ -178,15 +170,14 @@ abstract class sfDatabaseSessionStorage extends sfSessionStorage
   /**
    * Regenerates id that represents this storage.
    *
-   * @param  boolean $destroy Destroy session when regenerating?
+   * @param boolean $destroy  Destroy session when regenerating?
    *
    * @return boolean|void True if session regenerated, false if error
    *
    */
   public function regenerate(bool $destroy = false): void
   {
-    if (self::$sessionIdRegenerated)
-    {
+    if (self::$sessionIdRegenerated) {
       return;
     }
 

--- a/lib/storage/sfNoStorage.class.php
+++ b/lib/storage/sfNoStorage.class.php
@@ -34,7 +34,7 @@ class sfNoStorage extends sfStorage
    *
    * @throws <b>sfStorageException</b> If an error occurs while reading data from this storage
    */
-  public function read(string $key)
+  public function read(string $key): mixed
   {
     return null;
   }
@@ -50,7 +50,7 @@ class sfNoStorage extends sfStorage
    *
    * @throws <b>sfStorageException</b> If an error occurs while removing data from this storage
    */
-  public function remove(string $key)
+  public function remove(string $key): mixed
   {
     return null;
   }
@@ -65,7 +65,7 @@ class sfNoStorage extends sfStorage
    *
    * @throws <b>sfStorageException</b> If an error occurs while writing to this storage
    */
-  public function write(string $key, $data): void
+  public function write(string $key, mixed $data): void
   {
   }
 

--- a/lib/storage/sfSessionStorage.class.php
+++ b/lib/storage/sfSessionStorage.class.php
@@ -25,8 +25,8 @@
  */
 class sfSessionStorage extends sfStorage
 {
-  static protected $sessionIdRegenerated = false;
-  static protected $sessionStarted       = false;
+  static protected bool $sessionIdRegenerated = false;
+  static protected bool $sessionStarted       = false;
 
   /**
    * Available options:
@@ -107,16 +107,9 @@ class sfSessionStorage extends sfStorage
    *
    * @return mixed Data associated with the key
    */
-  public function read(string $key)
+  public function read(string $key): mixed
   {
-    $retval = null;
-
-    if (isset($_SESSION[$key]))
-    {
-      $retval = $_SESSION[$key];
-    }
-
-    return $retval;
+    return $_SESSION[$key] ?? null;
   }
 
   /**
@@ -128,17 +121,17 @@ class sfSessionStorage extends sfStorage
    *
    * @return mixed Data associated with the key
    */
-  public function remove(string $key)
+  public function remove(string $key): mixed
   {
-    $retval = null;
+    if (isset($_SESSION[$key])) {
+      $value = $_SESSION[$key];
 
-    if (isset($_SESSION[$key]))
-    {
-      $retval = $_SESSION[$key];
       unset($_SESSION[$key]);
+
+      return $value;
     }
 
-    return $retval;
+    return null;
   }
 
   /**
@@ -150,7 +143,7 @@ class sfSessionStorage extends sfStorage
    * @param mixed  $data  Data associated with your key
    *
    */
-  public function write(string $key, $data): void
+  public function write(string $key, mixed $data): void
   {
     $_SESSION[$key] = $data;
   }
@@ -162,8 +155,7 @@ class sfSessionStorage extends sfStorage
    */
   public function regenerate(bool $destroy = false): void
   {
-    if (self::$sessionIdRegenerated)
-    {
+    if (self::$sessionIdRegenerated) {
       return;
     }
 

--- a/lib/storage/sfStorage.class.php
+++ b/lib/storage/sfStorage.class.php
@@ -21,7 +21,7 @@
 abstract class sfStorage
 {
   /** @var array */
-  protected $options = [];
+  protected array $options = [];
 
   /**
    * Class constructor.
@@ -34,7 +34,7 @@ abstract class sfStorage
    *
    * @throws sfInitializationException If an error occurs while initializing this sfStorage
    */
-  public function __construct($options = [])
+  public function __construct(array $options = [])
   {
     $this->options = array_merge(
       ['auto_shutdown' => true],
@@ -68,7 +68,7 @@ abstract class sfStorage
    *
    * @throws <b>sfStorageException</b> If an error occurs while reading data from this storage
    */
-  abstract public function read(string $key);
+  abstract public function read(string $key): mixed;
 
   /**
    * Regenerates id that represents this storage.
@@ -90,7 +90,7 @@ abstract class sfStorage
    *
    * @throws <b>sfStorageException</b> If an error occurs while removing data from this storage
    */
-  abstract public function remove(string $key);
+  abstract public function remove(string $key): mixed;
 
   /**
    * Executes the shutdown procedure.
@@ -109,5 +109,5 @@ abstract class sfStorage
    *
    * @throws <b>sfStorageException</b> If an error occurs while writing to this storage
    */
-  abstract public function write(string $key, $data): void;
+  abstract public function write(string $key, mixed $data): void;
 }

--- a/lib/task/app/sfAppRoutesTask.class.php
+++ b/lib/task/app/sfAppRoutesTask.class.php
@@ -18,133 +18,150 @@
  */
 class sfAppRoutesTask extends sfBaseTask
 {
-  protected
-    $routes = array();
-
   /**
    * @see sfTask
    */
-  protected function configure()
+  protected function configure(): void
   {
-    $this->addArguments(array(
+    $this->addArguments([
       new sfCommandArgument('application', sfCommandArgument::REQUIRED, 'The application name'),
       new sfCommandArgument('name', sfCommandArgument::OPTIONAL, 'A route name'),
-    ));
+    ]);
 
     $this->namespace = 'app';
     $this->name = 'routes';
     $this->briefDescription = 'Displays current routes for an application';
 
     $this->detailedDescription = <<<EOF
-The [app:routes|INFO] displays the current routes for a given application:
+      The [app:routes|INFO] displays the current routes for a given application:
 
-  [./symfony app:routes frontend|INFO]
-EOF;
+        [./symfony app:routes frontend|INFO]
+      EOF;
   }
 
   /**
    * @see sfTask
    */
-  protected function execute($arguments = array(), $options = array())
+  protected function execute(array $arguments = [], array $options = []): int
   {
-    $this->routes = $this->getRouting()->getRoutes();
+    $routes = $this->getRouting()->getRoutes();
 
     // display
-    $arguments['name'] ? $this->outputRoute($arguments['application'], $arguments['name']) : $this->outputRoutes($arguments['application']);
+    if ($arguments['name']) {
+      $this->outputRoute($arguments['application'], $routes, $arguments['name']);
+    } else {
+      $this->outputRoutes($arguments['application'], $routes);
+    }
+
+    return 0;
   }
 
-  protected function outputRoutes($application)
+  /**
+   * @param string                $application
+   * @param array<string,sfRoute> $routes
+   */
+  protected function outputRoutes(string $application, array $routes): void
   {
     $this->logSection('app', sprintf('Current routes for application "%s"', $application));
 
     $maxName = 4;
     $maxMethod = 6;
-    foreach ($this->routes as $name => $route)
-    {
-      $requirements = $route->getRequirements();
-      $method = isset($requirements['sf_method']) ? strtoupper(is_array($requirements['sf_method']) ? implode(', ', $requirements['sf_method']) : $requirements['sf_method']) : 'ANY';
 
-      if (strlen($name) > $maxName)
-      {
+    foreach ($routes as $name => $route) {
+      $requirements = $route->getRequirements();
+
+      $method = strtoupper(
+        implode(', ', (array)($requirements['sf_method'] ?? 'ANY')),
+      );
+
+      if (strlen($name) > $maxName) {
         $maxName = strlen($name);
       }
 
-      if (strlen($method) > $maxMethod)
-      {
+      if (strlen($method) > $maxMethod) {
         $maxMethod = strlen($method);
       }
     }
-    $format  = '%-'.$maxName.'s %-'.$maxMethod.'s %s';
+    $format = '%-' . $maxName . 's %-' . $maxMethod . 's %s';
 
     // displays the generated routes
-    $format1  = '%-'.($maxName + 9).'s %-'.($maxMethod + 9).'s %s';
+    $format1 = '%-' . ($maxName + 9) . 's %-' . ($maxMethod + 9) . 's %s';
     $this->log(sprintf($format1, $this->formatter->format('Name', 'COMMENT'), $this->formatter->format('Method', 'COMMENT'), $this->formatter->format('Pattern', 'COMMENT')));
-    foreach ($this->routes as $name => $route)
-    {
+
+    foreach ($this->routes as $name => $route) {
       $requirements = $route->getRequirements();
-      $method = isset($requirements['sf_method']) ? strtoupper(is_array($requirements['sf_method']) ? implode(', ', $requirements['sf_method']) : $requirements['sf_method']) : 'ANY';
+      $method = strtoupper(
+        implode(', ', (array)($requirements['sf_method'] ?? 'ANY')),
+      );
       $this->log(sprintf($format, $name, $method, $route->getPattern()));
     }
   }
 
-  protected function outputRoute($application, $name)
+  /**
+   * @param string $application
+   * @param array<string,sfRoute>  $routes
+   * @param string $name
+   *
+   * @throws sfCommandException
+   */
+  protected function outputRoute(string $application, array $routes, string $name): void
   {
     $this->logSection('app', sprintf('Route "%s" for application "%s"', $name, $application));
 
-    if (!isset($this->routes[$name]))
-    {
+    if ( ! isset($routes[$name])) {
       throw new sfCommandException(sprintf('The route "%s" does not exist.', $name));
     }
 
-    $route = $this->routes[$name];
+    $route = $routes[$name];
+
     $this->log(sprintf('%s         %s', $this->formatter->format('Name', 'COMMENT'), $name));
     $this->log(sprintf('%s      %s', $this->formatter->format('Pattern', 'COMMENT'), $route->getPattern()));
     $this->log(sprintf('%s        %s', $this->formatter->format('Class', 'COMMENT'), get_class($route)));
 
     $defaults = '';
-    $d = $route->getDefaults();
+    $d        = $route->getDefaults();
     ksort($d);
-    foreach ($d as $name => $value)
-    {
-      $defaults .= ($defaults ? "\n".str_repeat(' ', 13) : '').$name.': '.$this->formatValue($value);
+    foreach ($d as $name => $value) {
+      $defaults .= ($defaults ? "\n" . str_repeat(' ', 13) : '') . $name . ': ' . $this->formatValue($value);
     }
     $this->log(sprintf('%s     %s', $this->formatter->format('Defaults', 'COMMENT'), $defaults));
 
     $requirements = '';
     $r = $route->getRequirements();
     ksort($r);
-    foreach ($r as $name => $value)
-    {
-      $requirements .= ($requirements ? "\n".str_repeat(' ', 13) : '').$name.': '.$this->formatValue($value);
+    foreach ($r as $name => $value) {
+      $requirements .= ($requirements ? "\n" . str_repeat(' ', 13) : '') . $name . ': ' . $this->formatValue($value);
     }
     $this->log(sprintf('%s %s', $this->formatter->format('Requirements', 'COMMENT'), $requirements));
 
     $options = '';
-    $o = $route->getOptions();
+    $o       = $route->getOptions();
     ksort($o);
-    foreach ($o as $name => $value)
-    {
-      $options .= ($options ? "\n".str_repeat(' ', 13) : '').$name.': '.$this->formatValue($value);
+    foreach ($o as $name => $value) {
+      $options .= ($options ? "\n" . str_repeat(' ', 13) : '') . $name . ': ' . $this->formatValue($value);
     }
     $this->log(sprintf('%s      %s', $this->formatter->format('Options', 'COMMENT'), $options));
-    $this->log(sprintf('%s        %s', $this->formatter->format('Regex', 'COMMENT'), preg_replace('/^             /', '', preg_replace('/^/m', '             ', $route->getRegex()))));
+    $this->log(sprintf('%s        %s',
+        $this->formatter->format('Regex', 'COMMENT'),
+        preg_replace('/^             /', '',
+          preg_replace('/^/m', '             ', $route->getRegex()),
+        ),
+      ),
+    );
 
     $tokens = '';
-    foreach ($route->getTokens() as $token)
-    {
-      if (!$tokens)
-      {
+
+    foreach ($route->getTokens() as $token) {
+      if ( ! $tokens) {
         $tokens = $this->displayToken($token);
-      }
-      else
-      {
-        $tokens .= "\n".str_repeat(' ', 13).$this->displayToken($token);
+      } else {
+        $tokens .= "\n" . str_repeat(' ', 13) . $this->displayToken($token);
       }
     }
     $this->log(sprintf('%s       %s', $this->formatter->format('Tokens', 'COMMENT'), $tokens));
   }
 
-  protected function displayToken($token)
+  protected function displayToken(array $token): string
   {
     $type = array_shift($token);
     array_shift($token);
@@ -152,14 +169,11 @@ EOF;
     return sprintf('%-10s %s', $type, $this->formatValue($token));
   }
 
-  protected function formatValue($value)
+  protected function formatValue(object | string $value): string
   {
-    if (is_object($value))
-    {
+    if (is_object($value)) {
       return sprintf('object(%s)', get_class($value));
-    }
-    else
-    {
+    } else {
       return preg_replace("/\n\s*/s", '', var_export($value, true));
     }
   }

--- a/lib/task/configure/sfConfigureAuthorTask.class.php
+++ b/lib/task/configure/sfConfigureAuthorTask.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -21,53 +21,52 @@ class sfConfigureAuthorTask extends sfBaseTask
   /**
    * @see sfTask
    */
-  protected function configure()
+  protected function configure(): void
   {
-    $this->addArguments(array(
+    $this->addArguments([
       new sfCommandArgument('author', sfCommandArgument::REQUIRED, 'The project author'),
-    ));
+    ]);
 
     $this->namespace = 'configure';
-    $this->name = 'author';
+    $this->name      = 'author';
 
     $this->briefDescription = 'Configure project author';
 
     $this->detailedDescription = <<<EOF
-The [configure:author|INFO] task configures the author for a project:
+      The [configure:author|INFO] task configures the author for a project:
 
-  [./symfony configure:author "Fabien Potencier <fabien.potencier@symfony-project.com>"|INFO]
+        [./symfony configure:author "Fabien Potencier <fabien.potencier@symfony-project.com>"|INFO]
 
-The author is used by the generates to pre-configure the PHPDoc header for each generated file.
+      The author is used by the generates to pre-configure the PHPDoc header for each generated file.
 
-The value is stored in [config/properties.ini].
-EOF;
+      The value is stored in [config/properties.ini].
+      EOF;
   }
 
   /**
    * @see sfTask
    */
-  protected function execute($arguments = array(), $options = array())
+  protected function execute(array $arguments = [], array $options = []): int
   {
-    $file = sfConfig::get('sf_config_dir').'/properties.ini';
+    $file    = sfConfig::get('sf_config_dir') . '/properties.ini';
     $content = parse_ini_file($file, true);
 
-    if (!isset($content['symfony']))
-    {
-      $content['symfony'] = array();
+    if ( ! isset($content['symfony'])) {
+      $content['symfony'] = [];
     }
 
     $content['symfony']['author'] = $arguments['author'];
 
     $ini = '';
-    foreach ($content as $section => $values)
-    {
+    foreach ($content as $section => $values) {
       $ini .= sprintf("[%s]\n", $section);
-      foreach ($values as $key => $value)
-      {
+      foreach ($values as $key => $value) {
         $ini .= sprintf("  %s=%s\n", $key, $value);
       }
     }
 
     file_put_contents($file, $ini);
+
+    return 0;
   }
 }

--- a/lib/task/generator/sfGenerateAppTask.class.php
+++ b/lib/task/generator/sfGenerateAppTask.class.php
@@ -10,7 +10,7 @@
 
 use Symfony\Component\Yaml\Yaml;
 
-require_once(__DIR__.'/sfGeneratorBaseTask.class.php');
+require_once(__DIR__ . '/sfGeneratorBaseTask.class.php');
 
 /**
  * Generates a new application.
@@ -25,141 +25,134 @@ class sfGenerateAppTask extends sfGeneratorBaseTask
   /**
    * @see sfTask
    */
-  protected function configure()
+  protected function configure(): void
   {
-    $this->addArguments(array(
+    $this->addArguments([
       new sfCommandArgument('app', sfCommandArgument::REQUIRED, 'The application name'),
-    ));
+    ]);
 
-    $this->addOptions(array(
+    $this->addOptions([
       new sfCommandOption('escaping-strategy', null, sfCommandOption::PARAMETER_REQUIRED, 'Output escaping strategy', true),
       new sfCommandOption('csrf-secret', null, sfCommandOption::PARAMETER_REQUIRED, 'Secret to use for CSRF protection', true),
-    ));
+    ]);
 
     $this->namespace = 'generate';
-    $this->name = 'app';
+    $this->name      = 'app';
 
     $this->briefDescription = 'Generates a new application';
 
     $this->detailedDescription = <<<EOF
-The [generate:app|INFO] task creates the basic directory structure
-for a new application in the current project:
+      The [generate:app|INFO] task creates the basic directory structure
+      for a new application in the current project:
 
-  [./symfony generate:app frontend|INFO]
+        [./symfony generate:app frontend|INFO]
 
-This task also creates two front controller scripts in the
-[web/|COMMENT] directory:
+      This task also creates two front controller scripts in the
+      [web/|COMMENT] directory:
 
-  [web/%application%.php|INFO]     for the production environment
-  [web/%application%_dev.php|INFO] for the development environment
+        [web/%application%.php|INFO]     for the production environment
+        [web/%application%_dev.php|INFO] for the development environment
 
-For the first application, the production environment script is named
-[index.php|COMMENT].
+      For the first application, the production environment script is named
+      [index.php|COMMENT].
 
-If an application with the same name already exists,
-it throws a [sfCommandException|COMMENT].
+      If an application with the same name already exists,
+      it throws a [sfCommandException|COMMENT].
 
-By default, the output escaping is enabled (to prevent XSS), and a random
-secret is also generated to prevent CSRF.
+      By default, the output escaping is enabled (to prevent XSS), and a random
+      secret is also generated to prevent CSRF.
 
-You can disable output escaping by using the [escaping-strategy|COMMENT]
-option:
+      You can disable output escaping by using the [escaping-strategy|COMMENT]
+      option:
 
-  [./symfony generate:app frontend --escaping-strategy=false|INFO]
+        [./symfony generate:app frontend --escaping-strategy=false|INFO]
 
-You can enable session token in forms (to prevent CSRF) by defining
-a secret with the [csrf-secret|COMMENT] option:
+      You can enable session token in forms (to prevent CSRF) by defining
+      a secret with the [csrf-secret|COMMENT] option:
 
-  [./symfony generate:app frontend --csrf-secret=UniqueSecret|INFO]
+        [./symfony generate:app frontend --csrf-secret=UniqueSecret|INFO]
 
-You can customize the default skeleton used by the task by creating a
-[%sf_data_dir%/skeleton/app|COMMENT] directory.
-EOF;
+      You can customize the default skeleton used by the task by creating a
+      [%sf_data_dir%/skeleton/app|COMMENT] directory.
+      EOF;
   }
 
   /**
    * @see sfTask
    */
-  protected function execute($arguments = array(), $options = array())
+  protected function execute(array $arguments = [], array $options = []): int
   {
-    $app = $arguments['app'];
+    $app          = $arguments['app'];
     $appUserClass = lcfirst(sfInflector::camelize($app)) . 'User';
 
     // Validate the application name
-    if (!preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $app))
-    {
+    if ( ! preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $app)) {
       throw new sfCommandException(sprintf('The application name "%s" is invalid.', $app));
     }
 
-    $appDir = sfConfig::get('sf_apps_dir').'/'.$app;
+    $appDir = sfConfig::get('sf_apps_dir') . '/' . $app;
 
-    if (is_dir($appDir))
-    {
+    if (is_dir($appDir)) {
       throw new sfCommandException(sprintf('The application "%s" already exists.', $appDir));
     }
 
-    if (is_readable(sfConfig::get('sf_data_dir').'/skeleton/app'))
-    {
-      $skeletonDir = sfConfig::get('sf_data_dir').'/skeleton/app';
-    }
-    else
-    {
-      $skeletonDir = __DIR__.'/skeleton/app';
+    if (is_readable(sfConfig::get('sf_data_dir') . '/skeleton/app')) {
+      $skeletonDir = sfConfig::get('sf_data_dir') . '/skeleton/app';
+    } else {
+      $skeletonDir = __DIR__ . '/skeleton/app';
     }
 
     // Create basic application structure
     $finder = sfFinder::type('any')->discard('.sf');
-    $this->getFilesystem()->mirror($skeletonDir.'/app', $appDir, $finder);
+    $this->getFilesystem()->mirror($skeletonDir . '/app', $appDir, $finder);
 
     // Create $app.php or index.php if it is our first app
     $indexName = 'index';
-    $firstApp = !file_exists(sfConfig::get('sf_web_dir').'/index.php');
-    if (!$firstApp)
-    {
+    $firstApp  = ! file_exists(sfConfig::get('sf_web_dir') . '/index.php');
+    if ( ! $firstApp) {
       $indexName = $app;
     }
 
-    if (true === $options['csrf-secret'])
-    {
-      $options['csrf-secret'] = sha1(mt_rand(11111111, 99999999).getmypid());
+    if (true === $options['csrf-secret']) {
+      $options['csrf-secret'] = sha1(mt_rand(11111111, 99999999) . getmypid());
     }
 
     // Set no_script_name value in settings.yml for production environment
-    $files = sfFinder::type('file')->in([$appDir.'/config', $appDir.'/lib']);
-    $this->getFilesystem()->replaceTokens($files, '##', '##', array(
+    $files = sfFinder::type('file')->in([$appDir . '/config', $appDir . '/lib']);
+    $this->getFilesystem()->replaceTokens($files, '##', '##', [
       'APP_NAME'          => $app,
       'NO_SCRIPT_NAME'    => $firstApp ? 'true' : 'false',
       'CSRF_SECRET'       => Yaml::dump(Yaml::parse($options['csrf-secret']), 0),
-      'ESCAPING_STRATEGY' => Yaml::dump((boolean) Yaml::parse($options['escaping-strategy']), 0),
+      'ESCAPING_STRATEGY' => Yaml::dump((boolean)Yaml::parse($options['escaping-strategy']), 0),
       'USE_DATABASE'      => sfConfig::has('sf_orm') ? 'true' : 'false',
       'APP_USER_CLASS'    => $appUserClass,
-    ));
+    ]);
 
-    $this->getFilesystem()->copy($skeletonDir.'/web/index.php', sfConfig::get('sf_web_dir').'/'.$indexName.'.php');
-    $this->getFilesystem()->copy($skeletonDir.'/web/index.php', sfConfig::get('sf_web_dir').'/'.$app.'_dev.php');
+    $this->getFilesystem()->copy($skeletonDir . '/web/index.php', sfConfig::get('sf_web_dir') . '/' . $indexName . '.php');
+    $this->getFilesystem()->copy($skeletonDir . '/web/index.php', sfConfig::get('sf_web_dir') . '/' . $app . '_dev.php');
 
-    $this->getFilesystem()->replaceTokens(sfConfig::get('sf_web_dir').'/'.$indexName.'.php', '##', '##', array(
+    $this->getFilesystem()->replaceTokens(sfConfig::get('sf_web_dir') . '/' . $indexName . '.php', '##', '##', [
       'APP_NAME'    => $app,
       'ENVIRONMENT' => 'prod',
       'IS_DEBUG'    => 'false',
       'IP_CHECK'    => '',
-    ));
+    ]);
 
-    $this->getFilesystem()->replaceTokens(sfConfig::get('sf_web_dir').'/'.$app.'_dev.php', '##', '##', array(
+    $this->getFilesystem()->replaceTokens(sfConfig::get('sf_web_dir') . '/' . $app . '_dev.php', '##', '##', [
       'APP_NAME'    => $app,
       'ENVIRONMENT' => 'dev',
       'IS_DEBUG'    => 'true',
-      'IP_CHECK'    => '// this check prevents access to debug front controllers that are deployed by accident to production servers.'.PHP_EOL.
-                       '// feel free to remove this, extend it or make something more sophisticated.'.PHP_EOL.
-                       'if (!in_array(@$_SERVER[\'REMOTE_ADDR\'], array(\'127.0.0.1\', \'::1\')))'.PHP_EOL.
-                       '{'.PHP_EOL.
-                       '  die(\'You are not allowed to access this file. Check \'.basename(__FILE__).\' for more information.\');'.PHP_EOL.
-                       '}'.PHP_EOL,
-    ));
+      'IP_CHECK'    => '// this check prevents access to debug front controllers that are deployed by accident to production servers.' . PHP_EOL .
+                       '// feel free to remove this, extend it or make something more sophisticated.' . PHP_EOL .
+                       'if (!in_array(@$_SERVER[\'REMOTE_ADDR\'], array(\'127.0.0.1\', \'::1\')))' . PHP_EOL .
+                       '{' . PHP_EOL .
+                       '  die(\'You are not allowed to access this file. Check \'.basename(__FILE__).\' for more information.\');' . PHP_EOL .
+                       '}' . PHP_EOL,
+    ]);
 
 
-    $this->getFilesystem()->rename($appDir.'/lib/myUser.class.php', $appDir.'/lib/'.$appUserClass.'.class.php');
-    $this->getFilesystem()->rename($appDir.'/config/ApplicationConfiguration.class.php', $appDir.'/config/'.$app.'Configuration.class.php');
+    $this->getFilesystem()->rename($appDir . '/lib/myUser.class.php', $appDir . '/lib/' . $appUserClass . '.class.php');
+    $this->getFilesystem()->rename($appDir . '/config/ApplicationConfiguration.class.php', $appDir . '/config/' . $app . 'Configuration.class.php');
 
     $fixPerms = new sfProjectPermissionsTask($this->dispatcher, $this->formatter);
     $fixPerms->setCommandApplication($this->commandApplication);
@@ -167,6 +160,8 @@ EOF;
     $fixPerms->run();
 
     // Create test dir
-    $this->getFilesystem()->mkdirs(sfConfig::get('sf_test_dir').'/functional/'.$app);
+    $this->getFilesystem()->mkdirs(sfConfig::get('sf_test_dir') . '/functional/' . $app);
+
+    return 0;
   }
 }

--- a/lib/task/generator/sfGenerateModuleTask.class.php
+++ b/lib/task/generator/sfGenerateModuleTask.class.php
@@ -3,12 +3,12 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-require_once(__DIR__.'/sfGeneratorBaseTask.class.php');
+require_once(__DIR__ . '/sfGeneratorBaseTask.class.php');
 
 /**
  * Generates a new module.
@@ -23,94 +23,91 @@ class sfGenerateModuleTask extends sfGeneratorBaseTask
   /**
    * @see sfTask
    */
-  protected function configure()
+  protected function configure(): void
   {
-    $this->addArguments(array(
+    $this->addArguments([
       new sfCommandArgument('application', sfCommandArgument::REQUIRED, 'The application name'),
       new sfCommandArgument('module', sfCommandArgument::REQUIRED, 'The module name'),
-    ));
+    ]);
 
     $this->namespace = 'generate';
-    $this->name = 'module';
+    $this->name      = 'module';
 
     $this->briefDescription = 'Generates a new module';
 
     $this->detailedDescription = <<<EOF
-The [generate:module|INFO] task creates the basic directory structure
-for a new module in an existing application:
+      The [generate:module|INFO] task creates the basic directory structure
+      for a new module in an existing application:
 
-  [./symfony generate:module frontend article|INFO]
+        [./symfony generate:module frontend article|INFO]
 
-The task can also change the author name found in the [actions.class.php|COMMENT]
-if you have configure it in [config/properties.ini|COMMENT]:
+      The task can also change the author name found in the [actions.class.php|COMMENT]
+      if you have configure it in [config/properties.ini|COMMENT]:
 
-  [[symfony]
-    name=blog
-    author=Fabien Potencier <fabien.potencier@sensio.com>|INFO]
+        [[symfony]
+          name=blog
+          author=Fabien Potencier <fabien.potencier@sensio.com>|INFO]
 
-You can customize the default skeleton used by the task by creating a
-[%sf_data_dir%/skeleton/module|COMMENT] directory.
+      You can customize the default skeleton used by the task by creating a
+      [%sf_data_dir%/skeleton/module|COMMENT] directory.
 
-The task also creates a functional test stub named
-[%sf_test_dir%/functional/%application%/%module%ActionsTest.class.php|COMMENT]
-that does not pass by default.
+      The task also creates a functional test stub named
+      [%sf_test_dir%/functional/%application%/%module%ActionsTest.class.php|COMMENT]
+      that does not pass by default.
 
-If a module with the same name already exists in the application,
-it throws a [sfCommandException|COMMENT].
-EOF;
+      If a module with the same name already exists in the application,
+      it throws a [sfCommandException|COMMENT].
+      EOF;
   }
 
   /**
    * @see sfTask
    */
-  protected function execute($arguments = array(), $options = array())
+  protected function execute(array $arguments = [], array $options = []): int
   {
     $app    = $arguments['application'];
     $module = $arguments['module'];
 
     // Validate the module name
-    if (!preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $module))
-    {
+    if ( ! preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $module)) {
       throw new sfCommandException(sprintf('The module name "%s" is invalid.', $module));
     }
 
-    $moduleDir = sfConfig::get('sf_app_module_dir').'/'.$module;
+    $moduleDir = sfConfig::get('sf_app_module_dir') . '/' . $module;
 
-    if (is_dir($moduleDir))
-    {
+    if (is_dir($moduleDir)) {
       throw new sfCommandException(sprintf('The module "%s" already exists in the "%s" application.', $moduleDir, $app));
     }
 
-    $properties = parse_ini_file(sfConfig::get('sf_config_dir').'/properties.ini', true);
+    $properties = parse_ini_file(sfConfig::get('sf_config_dir') . '/properties.ini', true);
 
-    $constants = array(
+    $constants = [
       'PROJECT_NAME' => isset($properties['symfony']['name']) ? $properties['symfony']['name'] : 'symfony',
       'APP_NAME'     => $app,
       'MODULE_NAME'  => $module,
       'AUTHOR_NAME'  => isset($properties['symfony']['author']) ? $properties['symfony']['author'] : 'Your name here',
-    );
+    ];
 
-    if (is_readable(sfConfig::get('sf_data_dir').'/skeleton/module'))
-    {
-      $skeletonDir = sfConfig::get('sf_data_dir').'/skeleton/module';
-    }
-    else
-    {
-      $skeletonDir = __DIR__.'/skeleton/module';
+    if (is_readable(sfConfig::get('sf_data_dir') . '/skeleton/module')) {
+      $skeletonDir = sfConfig::get('sf_data_dir') . '/skeleton/module';
+    } else {
+      $skeletonDir = __DIR__ . '/skeleton/module';
     }
 
     // create basic application structure
     $finder = sfFinder::type('any')->discard('.sf');
-    $this->getFilesystem()->mirror($skeletonDir.'/module', $moduleDir, $finder);
+    $this->getFilesystem()->mirror($skeletonDir . '/module', $moduleDir, $finder);
 
     // create basic test
-    $this->getFilesystem()->copy($skeletonDir.'/test/actionsTest.php', sfConfig::get('sf_test_dir').'/functional/'.$app.'/'.$module.'ActionsTest.php');
+    $this->getFilesystem()->copy($skeletonDir . '/test/actionsTest.php', sfConfig::get('sf_test_dir') . '/functional/' . $app . '/' . $module . 'ActionsTest.php');
 
     // customize test file
-    $this->getFilesystem()->replaceTokens(sfConfig::get('sf_test_dir').'/functional/'.$app.DIRECTORY_SEPARATOR.$module.'ActionsTest.php', '##', '##', $constants);
+    $this->getFilesystem()->replaceTokens(sfConfig::get('sf_test_dir') . '/functional/' . $app . DIRECTORY_SEPARATOR . $module . 'ActionsTest.php', '##', '##', $constants);
 
     // customize php and yml files
     $finder = sfFinder::type('file')->name('*.php', '*.yml');
     $this->getFilesystem()->replaceTokens($finder->in($moduleDir), '##', '##', $constants);
+
+    return 0;
   }
 }

--- a/lib/task/generator/sfGenerateProjectTask.class.php
+++ b/lib/task/generator/sfGenerateProjectTask.class.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(__DIR__.'/sfGeneratorBaseTask.class.php');
+require_once(__DIR__ . '/sfGeneratorBaseTask.class.php');
 
 /**
  * Generates a new project.
@@ -23,7 +23,7 @@ class sfGenerateProjectTask extends sfGeneratorBaseTask
   /**
    * @see sfTask
    */
-  protected function doRun(sfCommandManager $commandManager, $options)
+  protected function doRun(sfCommandManager $commandManager, array | string | null $options): int
   {
     $this->process($commandManager, $options);
 
@@ -33,81 +33,77 @@ class sfGenerateProjectTask extends sfGeneratorBaseTask
   /**
    * @see sfTask
    */
-  protected function configure()
+  protected function configure(): void
   {
-    $this->addArguments(array(
+    $this->addArguments([
       new sfCommandArgument('name', sfCommandArgument::REQUIRED, 'The project name'),
       new sfCommandArgument('author', sfCommandArgument::OPTIONAL, 'The project author', 'Your name here'),
-    ));
+    ]);
 
-    $this->addOptions(array(
+    $this->addOptions([
       new sfCommandOption('installer', null, sfCommandOption::PARAMETER_REQUIRED, 'An installer script to execute', null),
-    ));
+    ]);
 
     $this->namespace = 'generate';
-    $this->name = 'project';
+    $this->name      = 'project';
 
     $this->briefDescription = 'Generates a new project';
 
     $this->detailedDescription = <<<EOF
-The [generate:project|INFO] task creates the basic directory structure
-for a new project in the current directory:
+      The [generate:project|INFO] task creates the basic directory structure
+      for a new project in the current directory:
 
-  [./symfony generate:project blog|INFO]
+        [./symfony generate:project blog|INFO]
 
-If the current directory already contains a symfony project,
-it throws a [sfCommandException|COMMENT].
+      If the current directory already contains a symfony project,
+      it throws a [sfCommandException|COMMENT].
 
-You can also pass the [--installer|COMMENT] option to further customize the
-project:
+      You can also pass the [--installer|COMMENT] option to further customize the
+      project:
 
-  [./symfony generate:project blog --installer=./installer.php|INFO]
+        [./symfony generate:project blog --installer=./installer.php|INFO]
 
-You can optionally include a second [author|COMMENT] argument to specify what name to
-use as author when symfony generates new classes:
+      You can optionally include a second [author|COMMENT] argument to specify what name to
+      use as author when symfony generates new classes:
 
-  [./symfony generate:project blog "Jack Doe"|INFO]
-EOF;
+        [./symfony generate:project blog "Jack Doe"|INFO]
+      EOF;
   }
 
   /**
    * @see sfTask
    */
-  protected function execute($arguments = array(), $options = array())
+  protected function execute(array $arguments = [], array $options = []): int
   {
-    if (file_exists('symfony'))
-    {
+    if (file_exists('symfony')) {
       throw new sfCommandException(sprintf('A symfony project already exists in this directory (%s).', getcwd()));
     }
 
-    if ($options['installer'] && $this->commandApplication && !file_exists($options['installer']))
-    {
+    if ($options['installer'] && $this->commandApplication && ! file_exists($options['installer'])) {
       throw new InvalidArgumentException(sprintf('The installer "%s" does not exist.', $options['installer']));
     }
 
     $this->arguments = $arguments;
-    $this->options = $options;
+    $this->options   = $options;
 
     // create basic project structure
-    $this->installDir(__DIR__.'/skeleton/project');
+    $this->installDir(__DIR__ . '/skeleton/project');
 
     // try to locate vendor/autoload.php
     $composerAutoload = $this->locateComposerAutoloadFile();
 
-    $this->tokens = array(
+    $this->tokens = [
       'PROJECT_NAME'      => $this->arguments['name'],
       'AUTHOR_NAME'       => $this->arguments['author'],
       'PROJECT_DIR'       => sfConfig::get('sf_root_dir'),
       'COMPOSER_AUTOLOAD' => var_export(str_replace('\\', '/', $composerAutoload), true),
-    );
+    ];
 
     $this->replaceTokens();
 
     // execute a custom installer
-    if ($options['installer'] && $this->commandApplication)
-    {
-      if ($this->canRunInstaller($options['installer']))
-      {
+    if ($options['installer'] && $this->commandApplication) {
+      if ($this->canRunInstaller($options['installer'])) {
         $this->reloadTasks();
         include $options['installer'];
       }
@@ -120,18 +116,17 @@ EOF;
     $fixPerms->run();
 
     $this->replaceTokens();
+
+    return 0;
   }
 
-  protected function canRunInstaller($installer)
+  protected function canRunInstaller(string $installer): bool
   {
-    if (preg_match('#^(https?|ftps?)://#', $installer))
-    {
-      if (ini_get('allow_url_fopen') === false)
-      {
+    if (preg_match('#^(https?|ftps?)://#', $installer)) {
+      if (ini_get('allow_url_fopen') === false) {
         $this->logSection('generate', sprintf('Cannot run remote installer "%s" because "allow_url_fopen" is off', $installer));
       }
-      if (ini_get('allow_url_include') === false)
-      {
+      if (ini_get('allow_url_include') === false) {
         $this->logSection('generate', sprintf('Cannot run remote installer "%s" because "allow_url_include" is off', $installer));
       }
       return ini_get('allow_url_fopen') && ini_get('allow_url_include');
@@ -139,7 +134,7 @@ EOF;
     return true;
   }
 
-  private function locateComposerAutoloadFile()
+  private function locateComposerAutoloadFile(): string
   {
     $locations = [
       __DIR__ . '/../../../vendor/autoload.php',

--- a/lib/task/generator/sfGenerateTaskTask.class.php
+++ b/lib/task/generator/sfGenerateTaskTask.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -20,171 +20,169 @@ class sfGenerateTaskTask extends sfBaseTask
   /**
    * @see sfTask
    */
-  protected function configure()
+  protected function configure(): void
   {
-    $this->addArguments(array(
+    $this->addArguments([
       new sfCommandArgument('task_name', sfCommandArgument::REQUIRED, 'The task name (can contain namespace)'),
-    ));
+    ]);
 
-    $this->addOptions(array(
+    $this->addOptions([
       new sfCommandOption('dir', null, sfCommandOption::PARAMETER_REQUIRED, 'The directory to create the task in', 'lib/task'),
       new sfCommandOption('use-database', null, sfCommandOption::PARAMETER_REQUIRED, 'Whether the task needs model initialization to access database', sfConfig::get('sf_orm')),
       new sfCommandOption('brief-description', null, sfCommandOption::PARAMETER_REQUIRED, 'A brief task description (appears in task list)'),
-    ));
+    ]);
 
-    $this->namespace = 'generate';
-    $this->name = 'task';
+    $this->namespace        = 'generate';
+    $this->name             = 'task';
     $this->briefDescription = 'Creates a skeleton class for a new task';
 
     $this->detailedDescription = <<<EOF
-The [generate:task|INFO] creates a new sfTask class based on the name passed as
-argument:
+      The [generate:task|INFO] creates a new sfTask class based on the name passed as
+      argument:
 
-  [./symfony generate:task namespace:name|INFO]
+        [./symfony generate:task namespace:name|INFO]
 
-The [namespaceNameTask.class.php|COMMENT] skeleton task is created under the [lib/task/|COMMENT]
-directory. Note that the namespace is optional.
+      The [namespaceNameTask.class.php|COMMENT] skeleton task is created under the [lib/task/|COMMENT]
+      directory. Note that the namespace is optional.
 
-If you want to create the file in another directory (relative to the project
-root folder), pass it in the [--dir|COMMENT] option. This directory will be created
-if it does not already exist.
+      If you want to create the file in another directory (relative to the project
+      root folder), pass it in the [--dir|COMMENT] option. This directory will be created
+      if it does not already exist.
 
-  [./symfony generate:task namespace:name --dir=plugins/myPlugin/lib/task|INFO]
+        [./symfony generate:task namespace:name --dir=plugins/myPlugin/lib/task|INFO]
 
-If you want the task to default to a connection other than default, provide
-the name of this connection with the [--use-database|COMMENT] option:
+      If you want the task to default to a connection other than default, provide
+      the name of this connection with the [--use-database|COMMENT] option:
 
-  [./symfony generate:task namespace:name --use-database=main|INFO]
+        [./symfony generate:task namespace:name --use-database=main|INFO]
 
-The [--use-database|COMMENT] option can also be used to disable database
-initialization in the generated task:
+      The [--use-database|COMMENT] option can also be used to disable database
+      initialization in the generated task:
 
-  [./symfony generate:task namespace:name --use-database=false|INFO]
+        [./symfony generate:task namespace:name --use-database=false|INFO]
 
-You can also specify a description:
+      You can also specify a description:
 
-  [./symfony generate:task namespace:name --brief-description="Does interesting things"|INFO]
-EOF;
+        [./symfony generate:task namespace:name --brief-description="Does interesting things"|INFO]
+      EOF;
   }
 
   /**
    * @see sfTask
    */
-  protected function execute($arguments = array(), $options = array())
+  protected function execute(array $arguments = [], array $options = []): int
   {
-    $taskName = $arguments['task_name'];
+    $taskName           = $arguments['task_name'];
     $taskNameComponents = explode(':', $taskName);
-    $namespace = isset($taskNameComponents[1]) ? $taskNameComponents[0] : '';
-    $name = isset($taskNameComponents[1]) ? $taskNameComponents[1] : $taskNameComponents[0];
-    $taskClassName = str_replace('-', '', ($namespace ? $namespace.ucfirst($name) : $name)).'Task';
+    $namespace          = isset($taskNameComponents[1]) ? $taskNameComponents[0] : '';
+    $name               = isset($taskNameComponents[1]) ? $taskNameComponents[1] : $taskNameComponents[0];
+    $taskClassName      = str_replace('-', '', ($namespace ? $namespace . ucfirst($name) : $name)) . 'Task';
 
     // Validate the class name
-    if (!preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $taskClassName))
-    {
+    if ( ! preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $taskClassName)) {
       throw new sfCommandException(sprintf('The task class name "%s" is invalid.', $taskClassName));
     }
 
-    $briefDescription = $options['brief-description'];
+    $briefDescription    = $options['brief-description'];
     $detailedDescription = <<<HED
-The [$taskName|INFO] task does things.
-Call it with:
+      The [$taskName|INFO] task does things.
+      Call it with:
 
-  [php symfony $taskName|INFO]
-HED;
+        [php symfony $taskName|INFO]
+      HED;
 
-    $useDatabase = sfToolkit::literalize($options['use-database']);
+    $useDatabase       = sfToolkit::literalize($options['use-database']);
     $defaultConnection = is_string($useDatabase) ? $useDatabase : sfConfig::get('sf_orm');
 
-    if ($useDatabase)
-    {
+    if ($useDatabase) {
       $content = <<<HED
-<?php
+        <?php
 
-class $taskClassName extends sfBaseTask
-{
-  protected function configure()
-  {
-    // // add your own arguments here
-    // \$this->addArguments(array(
-    //   new sfCommandArgument('my_arg', sfCommandArgument::REQUIRED, 'My argument'),
-    // ));
+        class $taskClassName extends sfBaseTask
+        {
+          protected function configure()
+          {
+            // // add your own arguments here
+            // \$this->addArguments(array(
+            //   new sfCommandArgument('my_arg', sfCommandArgument::REQUIRED, 'My argument'),
+            // ));
 
-    \$this->addOptions(array(
-      new sfCommandOption('application', null, sfCommandOption::PARAMETER_REQUIRED, 'The application name'),
-      new sfCommandOption('env', null, sfCommandOption::PARAMETER_REQUIRED, 'The environment', 'dev'),
-      new sfCommandOption('connection', null, sfCommandOption::PARAMETER_REQUIRED, 'The connection name', '$defaultConnection'),
-      // add your own options here
-    ));
+            \$this->addOptions(array(
+              new sfCommandOption('application', null, sfCommandOption::PARAMETER_REQUIRED, 'The application name'),
+              new sfCommandOption('env', null, sfCommandOption::PARAMETER_REQUIRED, 'The environment', 'dev'),
+              new sfCommandOption('connection', null, sfCommandOption::PARAMETER_REQUIRED, 'The connection name', '$defaultConnection'),
+              // add your own options here
+            ));
 
-    \$this->namespace        = '$namespace';
-    \$this->name             = '$name';
-    \$this->briefDescription = '$briefDescription';
-    \$this->detailedDescription = <<<EOF
-$detailedDescription
-EOF;
-  }
+            \$this->namespace        = '$namespace';
+            \$this->name             = '$name';
+            \$this->briefDescription = '$briefDescription';
+            \$this->detailedDescription = <<<EOF
+        $detailedDescription
+        EOF;
+          }
 
-  protected function execute(\$arguments = array(), \$options = array())
-  {
-    // initialize the database connection
-    \$databaseManager = new sfDatabaseManager(\$this->configuration);
-    \$connection = \$databaseManager->getDatabase(\$options['connection'])->getConnection();
+          protected function execute(\$arguments = array(), \$options = array())
+          {
+            // initialize the database connection
+            \$databaseManager = new sfDatabaseManager(\$this->configuration);
+            \$connection = \$databaseManager->getDatabase(\$options['connection'])->getConnection();
 
-    // add your code here
-  }
-}
+            // add your code here
+          }
+        }
 
-HED;
-    }
-    else
-    {
+        HED;
+    } else {
       $content = <<<HED
-<?php
+        <?php
 
-class $taskClassName extends sfBaseTask
-{
-  protected function configure()
-  {
-    // // add your own arguments here
-    // \$this->addArguments(array(
-    //   new sfCommandArgument('my_arg', sfCommandArgument::REQUIRED, 'My argument'),
-    // ));
+        class $taskClassName extends sfBaseTask
+        {
+          protected function configure()
+          {
+            // // add your own arguments here
+            // \$this->addArguments(array(
+            //   new sfCommandArgument('my_arg', sfCommandArgument::REQUIRED, 'My argument'),
+            // ));
 
-    // // add your own options here
-    // \$this->addOptions(array(
-    //   new sfCommandOption('my_option', null, sfCommandOption::PARAMETER_REQUIRED, 'My option'),
-    // ));
+            // // add your own options here
+            // \$this->addOptions(array(
+            //   new sfCommandOption('my_option', null, sfCommandOption::PARAMETER_REQUIRED, 'My option'),
+            // ));
 
-    \$this->namespace        = '$namespace';
-    \$this->name             = '$name';
-    \$this->briefDescription = '$briefDescription';
-    \$this->detailedDescription = <<<EOF
-$detailedDescription
-EOF;
-  }
+            \$this->namespace        = '$namespace';
+            \$this->name             = '$name';
+            \$this->briefDescription = '$briefDescription';
+            \$this->detailedDescription = <<<EOF
+        $detailedDescription
+        EOF;
+          }
 
-  protected function execute(\$arguments = array(), \$options = array())
-  {
-    // add your code here
-  }
-}
+          protected function execute(array \$arguments = [], array \$options = []): int
+          {
+            // add your code here
 
-HED;
+            return 0;
+          }
+        }
+
+        HED;
     }
 
     // check that the task directory exists and that the task file doesn't exist
-    if (!is_readable(sfConfig::get('sf_root_dir').'/'.$options['dir']))
-    {
+    if ( ! is_readable(sfConfig::get('sf_root_dir') . '/' . $options['dir'])) {
       $this->getFilesystem()->mkdirs($options['dir']);
     }
 
-    $taskFile = sfConfig::get('sf_root_dir').'/'.$options['dir'].'/'.$taskClassName.'.class.php';
-    if (is_readable($taskFile))
-    {
+    $taskFile = sfConfig::get('sf_root_dir') . '/' . $options['dir'] . '/' . $taskClassName . '.class.php';
+    if (is_readable($taskFile)) {
       throw new sfCommandException(sprintf('A "%s" task already exists in "%s".', $taskName, $taskFile));
     }
 
     $this->logSection('task', sprintf('Creating "%s" task file', $taskFile));
     file_put_contents($taskFile, $content);
+
+    return 0;
   }
 }

--- a/lib/task/help/sfHelpTask.class.php
+++ b/lib/task/help/sfHelpTask.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -21,112 +21,117 @@ class sfHelpTask extends sfCommandApplicationTask
   /**
    * @see sfTask
    */
-  protected function configure()
+  protected function configure(): void
   {
-    $this->addArguments(array(
+    $this->addArguments([
       new sfCommandArgument('task_name', sfCommandArgument::OPTIONAL, 'The task name', 'help'),
-    ));
+    ]);
 
-    $this->addOptions(array(
+    $this->addOptions([
       new sfCommandOption('xml', null, sfCommandOption::PARAMETER_NONE, 'To output help as XML'),
-    ));
+    ]);
 
     $this->briefDescription = 'Displays help for a task';
 
     $this->detailedDescription = <<<EOF
-The [help|INFO] task displays help for a given task:
+      The [help|INFO] task displays help for a given task:
 
-  [./symfony help test:all|INFO]
+        [./symfony help test:all|INFO]
 
-You can also output the help as XML by using the [--xml|COMMENT] option:
+      You can also output the help as XML by using the [--xml|COMMENT] option:
 
-  [./symfony help test:all --xml|INFO]
-EOF;
+        [./symfony help test:all --xml|INFO]
+      EOF;
   }
 
   /**
    * @see sfTask
    */
-  protected function execute($arguments = array(), $options = array())
+  protected function execute(array $arguments = [], array $options = []): int
   {
-    if (!isset($this->commandApplication))
-    {
+    if ( ! isset($this->commandApplication)) {
       throw new sfCommandException('You can only launch this task from the command line.');
     }
 
     $task = $this->commandApplication->getTask($arguments['task_name']);
 
-    if ($options['xml'])
-    {
+    if ($options['xml']) {
       $this->outputAsXml($task);
-    }
-    else
-    {
+    } else {
       $this->outputAsText($task);
     }
+
+    return 0;
   }
 
-  protected function outputAsText(sfTask $task)
+  protected function outputAsText(sfTask $task): void
   {
-    $messages = array();
+    $messages = [];
 
     $messages[] = $this->formatter->format('Usage:', 'COMMENT');
-    $messages[] = $this->formatter->format(sprintf(' '.$task->getSynopsis(), null === $this->commandApplication ? '' : $this->commandApplication->getName()))."\n";
+    $messages[] = $this->formatter->format(sprintf(' ' . $task->getSynopsis(), null === $this->commandApplication ? '' : $this->commandApplication->getName())) . "\n";
 
     // find the largest option or argument name
     $max = 0;
-    foreach ($task->getOptions() as $option)
-    {
+    foreach ($task->getOptions() as $option) {
       $max = strlen($option->getName()) + 2 > $max ? strlen($option->getName()) + 2 : $max;
     }
-    foreach ($task->getArguments() as $argument)
-    {
+    foreach ($task->getArguments() as $argument) {
       $max = strlen($argument->getName()) > $max ? strlen($argument->getName()) : $max;
     }
     $max += strlen($this->formatter->format(' ', 'INFO'));
 
-    if ($task->getAliases())
-    {
-      $messages[] = $this->formatter->format('Aliases:', 'COMMENT').' '.$this->formatter->format(implode(', ', $task->getAliases()), 'INFO')."\n";
+    if ($task->getAliases()) {
+      $messages[] = $this->formatter->format('Aliases:', 'COMMENT') . ' ' . $this->formatter->format(implode(', ', $task->getAliases()), 'INFO') . "\n";
     }
 
-    if ($task->getArguments())
-    {
+    if ($task->getArguments()) {
       $messages[] = $this->formatter->format('Arguments:', 'COMMENT');
-      foreach ($task->getArguments() as $argument)
-      {
-        $default = null !== $argument->getDefault() && (!is_array($argument->getDefault()) || count($argument->getDefault())) ? $this->formatter->format(sprintf(' (default: %s)', is_array($argument->getDefault()) ? str_replace("\n", '', print_r($argument->getDefault(), true)): $argument->getDefault()), 'COMMENT') : '';
+      foreach ($task->getArguments() as $argument) {
+        $default    = null !== $argument->getDefault() && ( ! is_array($argument->getDefault()) || count($argument->getDefault())) ? $this->formatter->format(
+          sprintf(' (default: %s)', is_array($argument->getDefault()) ? str_replace("\n", '', print_r($argument->getDefault(), true)) : $argument->getDefault()),
+          'COMMENT'
+        ) : '';
         $messages[] = sprintf(" %-{$max}s %s%s", $this->formatter->format($argument->getName(), 'INFO'), $argument->getHelp(), $default);
       }
 
       $messages[] = '';
     }
 
-    if ($task->getOptions())
-    {
+    if ($task->getOptions()) {
       $messages[] = $this->formatter->format('Options:', 'COMMENT');
 
-      foreach ($task->getOptions() as $option)
-      {
-        $default = $option->acceptParameter() && null !== $option->getDefault() && (!is_array($option->getDefault()) || count($option->getDefault())) ? $this->formatter->format(sprintf(' (default: %s)', is_array($option->getDefault()) ? str_replace("\n", '', print_r($option->getDefault(), true)): $option->getDefault()), 'COMMENT') : '';
-        $multiple = $option->isArray() ? $this->formatter->format(' (multiple values allowed)', 'COMMENT') : '';
-        $messages[] = sprintf(' %-'.$max.'s %s%s%s%s', $this->formatter->format('--'.$option->getName(), 'INFO'), $option->getShortcut() ? sprintf('(-%s) ', $option->getShortcut()) : '', $option->getHelp(), $default, $multiple);
+      foreach ($task->getOptions() as $option) {
+        $default    = $option->acceptParameter() && null !== $option->getDefault() && ( ! is_array($option->getDefault()) || count(
+            $option->getDefault()
+          )) ? $this->formatter->format(
+          sprintf(' (default: %s)', is_array($option->getDefault()) ? str_replace("\n", '', print_r($option->getDefault(), true)) : $option->getDefault()),
+          'COMMENT'
+        ) : '';
+        $multiple   = $option->isArray() ? $this->formatter->format(' (multiple values allowed)', 'COMMENT') : '';
+        $messages[] = sprintf(
+          ' %-' . $max . 's %s%s%s%s',
+          $this->formatter->format('--' . $option->getName(), 'INFO'),
+          $option->getShortcut() ? sprintf('(-%s) ', $option->getShortcut()) : '',
+          $option->getHelp(),
+          $default,
+          $multiple
+        );
       }
 
       $messages[] = '';
     }
 
-    if ($detailedDescription = $task->getDetailedDescription())
-    {
+    if ($detailedDescription = $task->getDetailedDescription()) {
       $messages[] = $this->formatter->format('Description:', 'COMMENT');
 
-      $messages[] = ' '.implode("\n ", explode("\n", $detailedDescription))."\n";
+      $messages[] = ' ' . implode("\n ", explode("\n", $detailedDescription)) . "\n";
     }
 
     $this->log($messages);
   }
 
-  protected function outputAsXml(sfTask $task)
+  protected function outputAsXml(sfTask $task): void
   {
     echo $task->asXml();
   }

--- a/lib/task/log/sfLogClearTask.class.php
+++ b/lib/task/log/sfLogClearTask.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -21,25 +21,27 @@ class sfLogClearTask extends sfBaseTask
   /**
    * @see sfTask
    */
-  protected function configure()
+  protected function configure(): void
   {
     $this->namespace = 'log';
     $this->name = 'clear';
     $this->briefDescription = 'Clears log files';
 
     $this->detailedDescription = <<<EOF
-The [log:clear|INFO] task clears all symfony log files:
+      The [log:clear|INFO] task clears all symfony log files:
 
-  [./symfony log:clear|INFO]
-EOF;
+        [./symfony log:clear|INFO]
+      EOF;
   }
 
   /**
    * @see sfTask
    */
-  protected function execute($arguments = array(), $options = array())
+  protected function execute(array $arguments = [], array $options = []): int
   {
     $logs = sfFinder::type('file')->in(sfConfig::get('sf_log_dir'));
     $this->getFilesystem()->remove($logs);
+
+    return 0;
   }
 }

--- a/lib/task/plugin/sfPluginPublishAssetsTask.class.php
+++ b/lib/task/plugin/sfPluginPublishAssetsTask.class.php
@@ -21,87 +21,84 @@ class sfPluginPublishAssetsTask extends sfBaseTask
   /**
    * @see sfTask
    */
-  protected function configure()
+  protected function configure(): void
   {
-    $this->addArguments(array(
+    $this->addArguments([
       new sfCommandArgument('plugins', sfCommandArgument::OPTIONAL | sfCommandArgument::IS_ARRAY, 'Publish this plugin\'s assets'),
-    ));
+    ]);
 
-    $this->addOptions(array(
+    $this->addOptions([
       new sfCommandOption('core-only', '', sfCommandOption::PARAMETER_NONE, 'If set only core plugins will publish their assets'),
-    ));
+    ]);
 
-    $this->addOptions(array(
+    $this->addOptions([
       new sfCommandOption('relative', '', sfCommandOption::PARAMETER_NONE, 'If set symlinks will be relative'),
-    ));
+    ]);
 
     $this->namespace = 'plugin';
-    $this->name = 'publish-assets';
+    $this->name      = 'publish-assets';
 
     $this->briefDescription = 'Publishes web assets for all plugins';
 
     $this->detailedDescription = <<<EOF
-The [plugin:publish-assets|INFO] task will publish web assets from all plugins.
+      The [plugin:publish-assets|INFO] task will publish web assets from all plugins.
 
-  [./symfony plugin:publish-assets|INFO]
+        [./symfony plugin:publish-assets|INFO]
 
-In fact this will send the [plugin.post_install|INFO] event to each plugin.
+      In fact this will send the [plugin.post_install|INFO] event to each plugin.
 
-You can specify which plugin or plugins should install their assets by passing
-those plugins' names as arguments:
+      You can specify which plugin or plugins should install their assets by passing
+      those plugins' names as arguments:
 
-  [./symfony plugin:publish-assets sfDoctrinePlugin|INFO]
-EOF;
+        [./symfony plugin:publish-assets sfDoctrinePlugin|INFO]
+      EOF;
   }
 
   /**
    * @see sfTask
    */
-  protected function execute($arguments = array(), $options = array())
+  protected function execute(array $arguments = [], array $options = []): int
   {
     $enabledPlugins = $this->configuration->getPlugins();
 
-    if ($diff = array_diff($arguments['plugins'], $enabledPlugins))
-    {
-      throw new InvalidArgumentException('Plugin(s) not found: '.implode(', ', $diff));
+    if ($diff = array_diff($arguments['plugins'], $enabledPlugins)) {
+      throw new InvalidArgumentException('Plugin(s) not found: ' . implode(', ', $diff));
     }
 
-    if ($options['core-only'])
-    {
-      $corePlugins = sfFinder::type('dir')->relative()->maxdepth(0)->in($this->configuration->getSymfonyLibDir().'/plugins');
+    if ($options['core-only']) {
+      $corePlugins          = sfFinder::type('dir')->relative()->maxdepth(0)->in($this->configuration->getSymfonyLibDir() . '/plugins');
       $arguments['plugins'] = array_unique(array_merge($arguments['plugins'], array_intersect($enabledPlugins, $corePlugins)));
-    }
-    else if (!count($arguments['plugins']))
-    {
+    } elseif ( ! count($arguments['plugins'])) {
       $arguments['plugins'] = $enabledPlugins;
     }
 
-    foreach ($arguments['plugins'] as $plugin)
-    {
+    foreach ($arguments['plugins'] as $plugin) {
       $pluginConfiguration = $this->configuration->getPluginConfiguration($plugin);
 
-      $this->logSection('plugin', 'Configuring plugin - '.$plugin);
+      $this->logSection('plugin', 'Configuring plugin - ' . $plugin);
       $this->installPluginAssets($plugin, $pluginConfiguration->getRootDir(), $options['relative']);
     }
+
+    return 0;
   }
 
   /**
    * Installs web content for a plugin.
    *
-   * @param string $plugin The plugin name
-   * @param string $dir    The plugin directory
+   * @param string $plugin  The plugin name
+   * @param string $dir     The plugin directory
+   * @param bool   $relative
    */
-  protected function installPluginAssets($plugin, $dir, $relative)
+  protected function installPluginAssets(string $plugin, string $dir, bool $relative): void
   {
-    $webDir = $dir.DIRECTORY_SEPARATOR.'web';
+    $webDir = $dir . DIRECTORY_SEPARATOR . 'web';
 
-    if (is_dir($webDir))
-    {
-    	if($relative) {
-	      $this->getFilesystem()->relativeSymlink($webDir, sfConfig::get('sf_web_dir').DIRECTORY_SEPARATOR.$plugin, true);
-    	} else {
-	      $this->getFilesystem()->symlink($webDir, sfConfig::get('sf_web_dir').DIRECTORY_SEPARATOR.$plugin, true);
-    	}
+    if (is_dir($webDir)) {
+      if ($relative) {
+        $this->getFilesystem()->relativeSymlink($webDir, sfConfig::get('sf_web_dir') . DIRECTORY_SEPARATOR . $plugin, true);
+      } else {
+        $this->getFilesystem()->symlink($webDir, sfConfig::get('sf_web_dir') . DIRECTORY_SEPARATOR . $plugin, true);
+      }
     }
   }
 }

--- a/lib/task/project/sfProjectClearControllersTask.class.php
+++ b/lib/task/project/sfProjectClearControllersTask.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -21,58 +21,58 @@ class sfProjectClearControllersTask extends sfBaseTask
   /**
    * @see sfTask
    */
-  protected function configure()
+  protected function configure(): void
   {
-    $this->namespace = 'project';
-    $this->name = 'clear-controllers';
+    $this->namespace        = 'project';
+    $this->name             = 'clear-controllers';
     $this->briefDescription = 'Clears all non production environment controllers';
 
     $this->detailedDescription = <<<EOF
-The [project:clear-controllers|INFO] task clears all non production environment
-controllers:
+      The [project:clear-controllers|INFO] task clears all non production environment
+      controllers:
 
-  [./symfony project:clear-controllers|INFO]
+        [./symfony project:clear-controllers|INFO]
 
-You can use this task on a production server to remove all front
-controller scripts except the production ones.
+      You can use this task on a production server to remove all front
+      controller scripts except the production ones.
 
-If you have two applications named [frontend|COMMENT] and [backend|COMMENT],
-you have four default controller scripts in [web/|COMMENT]:
+      If you have two applications named [frontend|COMMENT] and [backend|COMMENT],
+      you have four default controller scripts in [web/|COMMENT]:
 
-  [index.php
-  frontend_dev.php
-  backend.php
-  backend_dev.php|INFO]
+        [index.php
+        frontend_dev.php
+        backend.php
+        backend_dev.php|INFO]
 
-After executing the [project:clear-controllers|COMMENT] task, two front
-controller scripts are left in [web/|COMMENT]:
+      After executing the [project:clear-controllers|COMMENT] task, two front
+      controller scripts are left in [web/|COMMENT]:
 
-  [index.php
-  backend.php|INFO]
+        [index.php
+        backend.php|INFO]
 
-Those two controllers are safe because debug mode and the web debug
-toolbar are disabled.
-EOF;
+      Those two controllers are safe because debug mode and the web debug
+      toolbar are disabled.
+      EOF;
   }
 
   /**
    * @see sfTask
    */
-  protected function execute($arguments = array(), $options = array())
+  protected function execute(array $arguments = [], array $options = []): int
   {
     $finder = sfFinder::type('file')->maxdepth(1)->name('*.php');
-    foreach ($finder->in(sfConfig::get('sf_web_dir')) as $controller)
-    {
+
+    foreach ($finder->in(sfConfig::get('sf_web_dir')) as $controller) {
       $content = file_get_contents($controller);
 
-      if (preg_match('/ProjectConfiguration::getApplicationConfiguration\(\'(.*?)\', \'(.*?)\'/', $content, $match))
-      {
+      if (preg_match('/ProjectConfiguration::getApplicationConfiguration\(\'(.*?)\', \'(.*?)\'/', $content, $match)) {
         // Remove file if it has found an application and the environment is not production
-        if ($match[2] != 'prod')
-        {
+        if ($match[2] != 'prod') {
           $this->getFilesystem()->remove($controller);
         }
       }
     }
+
+    return 0;
   }
 }

--- a/lib/task/project/sfProjectDeployTask.class.php
+++ b/lib/task/project/sfProjectDeployTask.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -18,192 +18,173 @@
  */
 class sfProjectDeployTask extends sfBaseTask
 {
-  protected
-    $outputBuffer = '',
-    $errorBuffer = '';
+  protected string $outputBuffer = '';
+  protected string $errorBuffer  = '';
 
   /**
    * @see sfTask
    */
-  protected function configure()
+  protected function configure(): void
   {
-    $this->addArguments(array(
+    $this->addArguments([
       new sfCommandArgument('server', sfCommandArgument::REQUIRED, 'The server name'),
-    ));
+    ]);
 
-    $this->addOptions(array(
+    $this->addOptions([
       new sfCommandOption('go', null, sfCommandOption::PARAMETER_NONE, 'Do the deployment'),
       new sfCommandOption('rsync-dir', null, sfCommandOption::PARAMETER_REQUIRED, 'The directory where to look for rsync*.txt files', 'config'),
       new sfCommandOption('rsync-options', null, sfCommandOption::PARAMETER_OPTIONAL, 'To options to pass to the rsync executable', '-azC --force --delete --progress'),
-    ));
+    ]);
 
-    $this->namespace = 'project';
-    $this->name = 'deploy';
+    $this->namespace        = 'project';
+    $this->name             = 'deploy';
     $this->briefDescription = 'Deploys a project to another server';
 
     $this->detailedDescription = <<<EOF
-The [project:deploy|INFO] task deploys a project on a server:
+      The [project:deploy|INFO] task deploys a project on a server:
 
-  [./symfony project:deploy production|INFO]
+        [./symfony project:deploy production|INFO]
 
-The server must be configured in [config/properties.ini|COMMENT]:
+      The server must be configured in [config/properties.ini|COMMENT]:
 
-  [[production]
-    host=www.example.com
-    port=22
-    user=fabien
-    dir=/var/www/sfblog/
-    type=rsync|INFO]
+        [[production]
+          host=www.example.com
+          port=22
+          user=fabien
+          dir=/var/www/sfblog/
+          type=rsync|INFO]
 
-To automate the deployment, the task uses rsync over SSH.
-You must configure SSH access with a key or configure the password
-in [config/properties.ini|COMMENT].
+      To automate the deployment, the task uses rsync over SSH.
+      You must configure SSH access with a key or configure the password
+      in [config/properties.ini|COMMENT].
 
-By default, the task is in dry-mode. To do a real deployment, you
-must pass the [--go|COMMENT] option:
+      By default, the task is in dry-mode. To do a real deployment, you
+      must pass the [--go|COMMENT] option:
 
-  [./symfony project:deploy --go production|INFO]
+        [./symfony project:deploy --go production|INFO]
 
-Files and directories configured in [config/rsync_exclude.txt|COMMENT] are
-not deployed:
+      Files and directories configured in [config/rsync_exclude.txt|COMMENT] are
+      not deployed:
 
-  [.svn
-  /web/uploads/*
-  /cache/*
-  /log/*|INFO]
+        [.svn
+        /web/uploads/*
+        /cache/*
+        /log/*|INFO]
 
-You can also create a [rsync.txt|COMMENT] and [rsync_include.txt|COMMENT] files.
+      You can also create a [rsync.txt|COMMENT] and [rsync_include.txt|COMMENT] files.
 
-If you need to customize the [rsync*.txt|COMMENT] files based on the server,
-you can pass a [rsync-dir|COMMENT] option:
+      If you need to customize the [rsync*.txt|COMMENT] files based on the server,
+      you can pass a [rsync-dir|COMMENT] option:
 
-  [./symfony project:deploy --go --rsync-dir=config/production production|INFO]
+        [./symfony project:deploy --go --rsync-dir=config/production production|INFO]
 
-Last, you can specify the options passed to the rsync executable, using the
-[rsync-options|INFO] option (defaults are [-azC --force --delete --progress|INFO]):
+      Last, you can specify the options passed to the rsync executable, using the
+      [rsync-options|INFO] option (defaults are [-azC --force --delete --progress|INFO]):
 
-  [./symfony project:deploy --go --rsync-options=-avz|INFO]
-EOF;
+        [./symfony project:deploy --go --rsync-options=-avz|INFO]
+      EOF;
   }
 
   /**
    * @see sfTask
    */
-  protected function execute($arguments = array(), $options = array())
+  protected function execute(array $arguments = [], array $options = []): int
   {
     $env = $arguments['server'];
 
-    $ini = sfConfig::get('sf_config_dir').'/properties.ini';
-    if (!file_exists($ini))
-    {
+    $ini = sfConfig::get('sf_config_dir') . '/properties.ini';
+    if ( ! file_exists($ini)) {
       throw new sfCommandException('You must create a config/properties.ini file');
     }
 
     $properties = parse_ini_file($ini, true);
 
-    if (!isset($properties[$env]))
-    {
+    if ( ! isset($properties[$env])) {
       throw new sfCommandException(sprintf('You must define the configuration for server "%s" in config/properties.ini', $env));
     }
 
     $properties = $properties[$env];
 
-    if (!isset($properties['host']))
-    {
+    if ( ! isset($properties['host'])) {
       throw new sfCommandException('You must define a "host" entry.');
     }
 
-    if (!isset($properties['dir']))
-    {
+    if ( ! isset($properties['dir'])) {
       throw new sfCommandException('You must define a "dir" entry.');
     }
 
     $host = $properties['host'];
     $dir  = $properties['dir'];
-    $user = isset($properties['user']) ? $properties['user'].'@' : '';
+    $user = isset($properties['user']) ? $properties['user'] . '@' : '';
 
-    if (substr($dir, -1) != '/')
-    {
+    if (substr($dir, -1) != '/') {
       $dir .= '/';
     }
 
     $ssh = 'ssh';
 
-    if (isset($properties['port']))
-    {
+    if (isset($properties['port'])) {
       $port = $properties['port'];
-      $ssh = '"ssh -p'.$port.'"';
+      $ssh  = '"ssh -p' . $port . '"';
     }
 
-    if (isset($properties['parameters']))
-    {
+    if (isset($properties['parameters'])) {
       $parameters = $properties['parameters'];
-    }
-    else
-    {
+    } else {
       $parameters = $options['rsync-options'];
-      if (file_exists($options['rsync-dir'].'/rsync_include.txt'))
-      {
+      if (file_exists($options['rsync-dir'] . '/rsync_include.txt')) {
         $parameters .= sprintf(' --include-from=%s/rsync_include.txt', $options['rsync-dir']);
       }
 
-      if (file_exists($options['rsync-dir'].'/rsync_exclude.txt'))
-      {
+      if (file_exists($options['rsync-dir'] . '/rsync_exclude.txt')) {
         $parameters .= sprintf(' --exclude-from=%s/rsync_exclude.txt', $options['rsync-dir']);
       }
 
-      if (file_exists($options['rsync-dir'].'/rsync.txt'))
-      {
+      if (file_exists($options['rsync-dir'] . '/rsync.txt')) {
         $parameters .= sprintf(' --files-from=%s/rsync.txt', $options['rsync-dir']);
       }
     }
 
-    $dryRun = $options['go'] ? '' : '--dry-run';
+    $dryRun  = $options['go'] ? '' : '--dry-run';
     $command = "rsync $dryRun $parameters -e $ssh ./ $user$host:$dir";
 
-    $this->getFilesystem()->execute($command, $options['trace'] ? array($this, 'logOutput') : null, array($this, 'logErrors'));
+    $this->getFilesystem()->execute($command, $options['trace'] ? [$this, 'logOutput'] : null, [$this, 'logErrors']);
 
-    $this->clearBuffers();
+    $this->flushBuffers();
+
+    return 0;
   }
 
-  public function logOutput($output)
+  public function logOutput(string $output): void
   {
-    if (false !== $pos = strpos($output, "\n"))
-    {
+    if (false !== $pos = strpos($output, "\n")) {
       $this->outputBuffer .= substr($output, 0, $pos);
       $this->log($this->outputBuffer);
       $this->outputBuffer = substr($output, $pos + 1);
-    }
-    else
-    {
+    } else {
       $this->outputBuffer .= $output;
     }
   }
 
-  public function logErrors($output)
+  public function logErrors(string $output): void
   {
-    if (false !== $pos = strpos($output, "\n"))
-    {
+    if (false !== $pos = strpos($output, "\n")) {
       $this->errorBuffer .= substr($output, 0, $pos);
       $this->log($this->formatter->format($this->errorBuffer, 'ERROR'));
       $this->errorBuffer = substr($output, $pos + 1);
-    }
-    else
-    {
+    } else {
       $this->errorBuffer .= $output;
     }
   }
 
-  protected function clearBuffers()
+  protected function flushBuffers(): void
   {
-    if ($this->outputBuffer)
-    {
+    if ($this->outputBuffer) {
       $this->log($this->outputBuffer);
       $this->outputBuffer = '';
     }
 
-    if ($this->errorBuffer)
-    {
+    if ($this->errorBuffer) {
       $this->log($this->formatter->format($this->errorBuffer, 'ERROR'));
       $this->errorBuffer = '';
     }

--- a/lib/task/project/sfProjectDisableTask.class.php
+++ b/lib/task/project/sfProjectDisableTask.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -21,59 +21,54 @@ class sfProjectDisableTask extends sfBaseTask
   /**
    * @see sfTask
    */
-  protected function configure()
+  protected function configure(): void
   {
-    $this->addArguments(array(
+    $this->addArguments([
       new sfCommandArgument('env', sfCommandArgument::REQUIRED, 'The environment name'),
       new sfCommandArgument('app', sfCommandArgument::OPTIONAL | sfCommandArgument::IS_ARRAY, 'The application name'),
-    ));
+    ]);
 
-    $this->namespace = 'project';
-    $this->name = 'disable';
+    $this->namespace        = 'project';
+    $this->name             = 'disable';
     $this->briefDescription = 'Disables an application in a given environment';
 
     $this->detailedDescription = <<<EOF
-The [project:disable|INFO] task disables an environment:
+      The [project:disable|INFO] task disables an environment:
 
-  [./symfony project:disable prod|INFO]
+        [./symfony project:disable prod|INFO]
 
-You can also specify individual applications to be disabled in that
-environment:
+      You can also specify individual applications to be disabled in that
+      environment:
 
-  [./symfony project:disable prod frontend backend|INFO]
-EOF;
+        [./symfony project:disable prod frontend backend|INFO]
+      EOF;
   }
 
   /**
    * @see sfTask
    */
-  protected function execute($arguments = array(), $options = array())
+  protected function execute(array $arguments = [], array $options = []): int
   {
-    if (1 == count($arguments['app']) && !file_exists(sfConfig::get('sf_apps_dir').'/'.$arguments['app'][0]))
-    {
+    if (1 == count($arguments['app']) && ! file_exists(sfConfig::get('sf_apps_dir') . '/' . $arguments['app'][0])) {
       // support previous task signature
-      $applications = array($arguments['env']);
-      $env = $arguments['app'][0];
-    }
-    else
-    {
+      $applications = [$arguments['env']];
+      $env          = $arguments['app'][0];
+    } else {
       $applications = count($arguments['app']) ? $arguments['app'] : sfFinder::type('dir')->relative()->maxdepth(0)->in(sfConfig::get('sf_apps_dir'));
-      $env = $arguments['env'];
+      $env          = $arguments['env'];
     }
 
-    foreach ($applications as $app)
-    {
-      $lockFile = sfConfig::get('sf_data_dir').'/'.$app.'_'.$env.'.lck';
-      if (file_exists($lockFile))
-      {
+    foreach ($applications as $app) {
+      $lockFile = sfConfig::get('sf_data_dir') . '/' . $app . '_' . $env . '.lck';
+      if (file_exists($lockFile)) {
         $this->logSection('enable', sprintf('%s [%s] is currently DISABLED', $app, $env));
-      }
-      else
-      {
+      } else {
         $this->getFilesystem()->touch($lockFile);
 
         $this->logSection('enable', sprintf('%s [%s] has been DISABLED', $app, $env));
       }
     }
+
+    return 0;
   }
 }

--- a/lib/task/project/sfProjectEnableTask.class.php
+++ b/lib/task/project/sfProjectEnableTask.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -21,64 +21,59 @@ class sfProjectEnableTask extends sfBaseTask
   /**
    * @see sfTask
    */
-  protected function configure()
+  protected function configure(): void
   {
-    $this->addArguments(array(
+    $this->addArguments([
       new sfCommandArgument('env', sfCommandArgument::REQUIRED, 'The environment name'),
       new sfCommandArgument('app', sfCommandArgument::OPTIONAL | sfCommandArgument::IS_ARRAY, 'The application name'),
-    ));
+    ]);
 
-    $this->namespace = 'project';
-    $this->name = 'enable';
+    $this->namespace        = 'project';
+    $this->name             = 'enable';
     $this->briefDescription = 'Enables an application in a given environment';
 
     $this->detailedDescription = <<<EOF
-The [project:enable|INFO] task enables a specific environment:
+      The [project:enable|INFO] task enables a specific environment:
 
-  [./symfony project:enable frontend prod|INFO]
+        [./symfony project:enable frontend prod|INFO]
 
-You can also specify individual applications to be enabled in that
-environment:
+      You can also specify individual applications to be enabled in that
+      environment:
 
-  [./symfony project:enable prod frontend backend|INFO]
-EOF;
+        [./symfony project:enable prod frontend backend|INFO]
+      EOF;
   }
 
   /**
    * @see sfTask
    */
-  protected function execute($arguments = array(), $options = array())
+  protected function execute(array $arguments = [], array $options = []): int
   {
-    if (1 == count($arguments['app']) && !file_exists(sfConfig::get('sf_apps_dir').'/'.$arguments['app'][0]))
-    {
+    if (1 == count($arguments['app']) && ! file_exists(sfConfig::get('sf_apps_dir') . '/' . $arguments['app'][0])) {
       // support previous task signature
-      $applications = array($arguments['env']);
-      $env = $arguments['app'][0];
-    }
-    else
-    {
+      $applications = [$arguments['env']];
+      $env          = $arguments['app'][0];
+    } else {
       $applications = count($arguments['app']) ? $arguments['app'] : sfFinder::type('dir')->relative()->maxdepth(0)->in(sfConfig::get('sf_apps_dir'));
-      $env = $arguments['env'];
+      $env          = $arguments['env'];
     }
 
-    foreach ($applications as $app)
-    {
-      $lockFile = sfConfig::get('sf_data_dir').'/'.$app.'_'.$env.'.lck';
-      if (!file_exists($lockFile))
-      {
+    foreach ($applications as $app) {
+      $lockFile = sfConfig::get('sf_data_dir') . '/' . $app . '_' . $env . '.lck';
+      if ( ! file_exists($lockFile)) {
         $this->logSection('enable', sprintf('%s [%s] is currently ENABLED', $app, $env));
-      }
-      else
-      {
+      } else {
         $this->getFilesystem()->remove($lockFile);
 
         $clearCache = new sfCacheClearTask($this->dispatcher, $this->formatter);
         $clearCache->setCommandApplication($this->commandApplication);
         $clearCache->setConfiguration($this->configuration);
-        $clearCache->run(array(), array('--app='.$app, '--env='.$env));
+        $clearCache->run([], ['--app=' . $app, '--env=' . $env]);
 
         $this->logSection('enable', sprintf('%s [%s] has been ENABLED', $app, $env));
       }
     }
+
+    return 0;
   }
 }

--- a/lib/task/project/sfProjectOptimizeTask.class.php
+++ b/lib/task/project/sfProjectOptimizeTask.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -21,42 +21,41 @@ class sfProjectOptimizeTask extends sfBaseTask
   /**
    * @see sfTask
    */
-  protected function configure()
+  protected function configure(): void
   {
-    $this->addArguments(array(
+    $this->addArguments([
       new sfCommandArgument('application', sfCommandArgument::REQUIRED, 'The application name'),
       new sfCommandArgument('env', sfCommandArgument::OPTIONAL, 'The environment name', 'prod'),
-    ));
+    ]);
 
-    $this->namespace = 'project';
-    $this->name = 'optimize';
+    $this->namespace        = 'project';
+    $this->name             = 'optimize';
     $this->briefDescription = 'Optimizes a project for better performance';
 
     $this->detailedDescription = <<<EOF
-The [project:optimize|INFO] optimizes a project for better performance:
+      The [project:optimize|INFO] optimizes a project for better performance:
 
-  [./symfony project:optimize frontend prod|INFO]
+        [./symfony project:optimize frontend prod|INFO]
 
-This task should only be used on a production server. Don't forget to re-run
-the task each time the project changes.
-EOF;
+      This task should only be used on a production server. Don't forget to re-run
+      the task each time the project changes.
+      EOF;
   }
 
   /**
    * @see sfTask
    */
-  protected function execute($arguments = array(), $options = array())
+  protected function execute(array $arguments = [], array $options = []): int
   {
-    $data = array();
+    $data    = [];
     $modules = $this->findModules();
-    $target = sfConfig::get('sf_cache_dir').'/'.$arguments['application'].'/'.$arguments['env'].'/config/configuration.php';
+    $target  = sfConfig::get('sf_cache_dir') . '/' . $arguments['application'] . '/' . $arguments['env'] . '/config/configuration.php';
 
     $current_umask = umask();
     umask(0000);
 
     // remove existing optimization file
-    if (file_exists($target))
-    {
+    if (file_exists($target)) {
       $this->getFilesystem()->remove($target);
     }
 
@@ -67,16 +66,12 @@ EOF;
     sfContext::createInstance($this->configuration);
 
     // force cache generation for generated modules
-    foreach ($modules as $module)
-    {
+    foreach ($modules as $module) {
       $this->logSection('module', $module);
 
-      try
-      {
-        $this->configuration->getConfigCache()->checkConfig('modules/'.$module.'/config/generator.yml',  true);
-      }
-      catch (Exception $e)
-      {
+      try {
+        $this->configuration->getConfigCache()->checkConfig('modules/' . $module . '/config/generator.yml', true);
+      } catch (Exception $e) {
         $this->dispatcher->notifyUntil(new sfEvent($e, 'application.throw_exception'));
 
         $this->logSection($module, $e->getMessage(), null, 'ERROR');
@@ -85,43 +80,49 @@ EOF;
 
     $templates = $this->findTemplates($modules);
 
-    $data['getTemplateDir'] = $this->optimizeGetTemplateDir($modules, $templates);
+    $data['getTemplateDir']    = $this->optimizeGetTemplateDir($modules, $templates);
     $data['getControllerDirs'] = $this->optimizeGetControllerDirs($modules);
-    $data['getPluginPaths'] = $this->configuration->getPluginPaths();
-    $data['loadHelpers'] = $this->optimizeLoadHelpers($modules);
+    $data['getPluginPaths']    = $this->configuration->getPluginPaths();
+    $data['loadHelpers']       = $this->optimizeLoadHelpers($modules);
 
-    if (!file_exists($directory = dirname($target)))
-    {
+    if ( ! file_exists($directory = dirname($target))) {
       $this->getFilesystem()->mkdirs($directory);
     }
 
     $this->logSection('file+', $target);
-    file_put_contents($target, '<?php return '.var_export($data, true).';');
+    file_put_contents($target, '<?php return ' . var_export($data, true) . ';');
 
     umask($current_umask);
+
+    return 0;
   }
 
-  protected function optimizeGetControllerDirs($modules)
+  /**
+   * @param array $modules
+   * @return array<string,array>
+   */
+  protected function optimizeGetControllerDirs(array $modules): array
   {
-    $data = array();
-    foreach ($modules as $module)
-    {
+    $data = [];
+    foreach ($modules as $module) {
       $data[$module] = $this->configuration->getControllerDirs($module);
     }
 
     return $data;
   }
 
-  protected function optimizeGetTemplateDir($modules, $templates)
+  /**
+   * @param string[] $modules
+   * @param string[] $templates
+   * @return array<string,array<string,string>>
+   */
+  protected function optimizeGetTemplateDir(array $modules, array $templates): array
   {
-    $data = array();
-    foreach ($modules as $module)
-    {
-      $data[$module] = array();
-      foreach ($templates[$module] as $template)
-      {
-        if (null !== $dir = $this->configuration->getTemplateDir($module, $template))
-        {
+    $data = [];
+    foreach ($modules as $module) {
+      $data[$module] = [];
+      foreach ($templates[$module] as $template) {
+        if (null !== $dir = $this->configuration->getTemplateDir($module, $template)) {
           $data[$module][$template] = $dir;
         }
       }
@@ -130,37 +131,35 @@ EOF;
     return $data;
   }
 
-  protected function optimizeLoadHelpers($modules)
+  /**
+   * @param string[] $modules
+   * @return array<string,string[]>
+   */
+  protected function optimizeLoadHelpers(array $modules): array
   {
-    $data = array();
+    $data = [];
 
     $finder = sfFinder::type('file')->name('*Helper.php');
 
     // module helpers
-    foreach ($modules as $module)
-    {
-      $helpers = array();
+    foreach ($modules as $module) {
+      $helpers = [];
 
       $dirs = $this->configuration->getHelperDirs($module);
-      foreach ($finder->in($dirs[0]) as $file)
-      {
+      foreach ($finder->in($dirs[0]) as $file) {
         $helpers[basename($file, 'Helper.php')] = $file;
       }
 
-      if (count($helpers))
-      {
+      if (count($helpers) > 0) {
         $data[$module] = $helpers;
       }
     }
 
     // all other helpers
-    foreach ($this->configuration->getHelperDirs() as $dir)
-    {
-      foreach ($finder->in($dir) as $file)
-      {
+    foreach ($this->configuration->getHelperDirs() as $dir) {
+      foreach ($finder->in($dir) as $file) {
         $helper = basename($file, 'Helper.php');
-        if (!isset($data[''][$helper]))
-        {
+        if ( ! isset($data[''][$helper])) {
           $data[''][$helper] = $file;
         }
       }
@@ -169,37 +168,46 @@ EOF;
     return $data;
   }
 
-  protected function findTemplates($modules)
+  /**
+   * @param string[] $modules
+   * @return string[]
+   */
+  protected function findTemplates(array $modules): array
   {
-    $files = array();
+    $files = [];
 
-    foreach ($modules as $module)
-    {
+    foreach ($modules as $module) {
       $files[$module] = sfFinder::type('file')->follow_link()->relative()->in($this->configuration->getTemplateDirs($module));
     }
 
     return $files;
   }
 
-  protected function findModules()
+  /**
+   * @return string[]
+   */
+  protected function findModules(): array
   {
     // application
-    $dirs = array(sfConfig::get('sf_app_module_dir'));
+    $dirs = [sfConfig::get('sf_app_module_dir')];
 
     // plugins
-    $pluginSubPaths = $this->configuration->getPluginSubPaths(DIRECTORY_SEPARATOR.'modules');
-    $modules = array();
-    foreach (sfFinder::type('dir')->maxdepth(0)->follow_link()->relative()->in($pluginSubPaths) as $module)
-    {
-        if (in_array($module, sfConfig::get('sf_enabled_modules')))
-        {
-          $modules[] = $module;
-        }
+    $pluginSubPaths = $this->configuration->getPluginSubPaths(DIRECTORY_SEPARATOR . 'modules');
+    $modules        = [];
+    foreach (sfFinder::type('dir')->maxdepth(0)->follow_link()->relative()->in($pluginSubPaths) as $module) {
+      if (in_array($module, sfConfig::get('sf_enabled_modules'))) {
+        $modules[] = $module;
+      }
     }
 
     // core modules
-    $dirs[] = sfConfig::get('sf_symfony_lib_dir').'/controller';
+    $dirs[] = sfConfig::get('sf_symfony_lib_dir') . '/controller';
 
-    return array_unique(array_merge(sfFinder::type('dir')->maxdepth(0)->follow_link()->relative()->in($dirs), $modules));
+    return array_unique(
+      array_merge(
+        sfFinder::type('dir')->maxdepth(0)->follow_link()->relative()->in($dirs),
+        $modules,
+      ),
+    );
   }
 }

--- a/lib/task/project/sfProjectPermissionsTask.class.php
+++ b/lib/task/project/sfProjectPermissionsTask.class.php
@@ -18,93 +18,94 @@
  */
 class sfProjectPermissionsTask extends sfBaseTask
 {
-  protected
-    $current = null,
-    $failed  = array();
+  protected string | null $current = null;
+
+  /**
+   * @var string[]
+   */
+  protected array $failed = [];
 
   /**
    * @see sfTask
    */
-  protected function configure()
+  protected function configure(): void
   {
-    $this->namespace = 'project';
-    $this->name = 'permissions';
+    $this->namespace        = 'project';
+    $this->name             = 'permissions';
     $this->briefDescription = 'Fixes symfony directory permissions';
 
     $this->detailedDescription = <<<EOF
-The [project:permissions|INFO] task fixes directory permissions:
+      The [project:permissions|INFO] task fixes directory permissions:
 
-  [./symfony project:permissions|INFO]
-EOF;
+        [./symfony project:permissions|INFO]
+      EOF;
   }
 
   /**
    * @see sfTask
    */
-  protected function execute($arguments = array(), $options = array())
+  protected function execute(array $arguments = [], array $options = []): int
   {
-    if (file_exists(sfConfig::get('sf_upload_dir')))
-    {
+    if (file_exists(sfConfig::get('sf_upload_dir'))) {
       $this->chmod(sfConfig::get('sf_upload_dir'), 0777);
     }
 
     $this->chmod(sfConfig::get('sf_cache_dir'), 0777);
     $this->chmod(sfConfig::get('sf_log_dir'), 0777);
-    $this->chmod(sfConfig::get('sf_root_dir').'/symfony', 0777);
+    $this->chmod(sfConfig::get('sf_root_dir') . '/symfony', 0777);
 
-    $dirs = array(
+    $dirs = [
       sfConfig::get('sf_cache_dir'),
       sfConfig::get('sf_log_dir'),
       sfConfig::get('sf_upload_dir'),
-    );
+    ];
 
-    $dirFinder = sfFinder::type('dir');
-    $fileFinder = sfFinder::type('file');
-
-    foreach ($dirs as $dir)
-    {
-      $this->chmod($dirFinder->in($dir), 0777);
-      $this->chmod($fileFinder->in($dir), 0666);
+    foreach ($dirs as $dir) {
+      $this->chmod(sfFinder::type('dir')->in($dir), 0777);
+      $this->chmod(sfFinder::type('file')->in($dir), 0666);
     }
 
     // note those files that failed
-    if (count($this->failed))
-    {
-      $this->logBlock(array_merge(
-        array('Permissions on the following file(s) could not be fixed:', ''),
-        array_map(function($f) { return ' - '.sfDebug::shortenFilePath($f); }, $this->failed)
-      ), 'ERROR_LARGE');
+    if (count($this->failed) > 0) {
+      $this->logBlock(
+        array_merge(
+          ['Permissions on the following file(s) could not be fixed:', ''],
+          array_map(function ($f) {
+            return ' - ' . sfDebug::shortenFilePath($f);
+          }, $this->failed)
+        ),
+        'ERROR_LARGE'
+      );
     }
+
+    return 0;
   }
 
   /**
    * Chmod and capture any failures.
    *
-   * @param string  $file
-   * @param integer $mode
-   * @param integer $umask
+   * @param string[]|string $file
+   * @param int             $mode
+   * @param int             $umask
    *
    * @see sfFilesystem
    */
-  protected function chmod($file, $mode, $umask = 0000)
+  protected function chmod(array | string $file, int $mode, int $umask = 0000): void
   {
-    if (is_array($file))
-    {
-      foreach ($file as $f)
-      {
+    if (is_array($file)) {
+      foreach ($file as $f) {
         $this->chmod($f, $mode, $umask);
       }
+      return;
     }
-    else
-    {
-      set_error_handler(array($this, 'handleError'));
 
-      $this->current = $file;
-      @$this->getFilesystem()->chmod($file, $mode, $umask);
-      $this->current = null;
+    set_error_handler([$this, 'handleError']);
 
-      restore_error_handler();
-    }
+    $this->current = $file;
+    @$this->getFilesystem()->chmod($file, $mode, $umask);
+    $this->current = null;
+
+    restore_error_handler();
   }
 
   /**
@@ -112,7 +113,7 @@ EOF;
    *
    * @see http://www.php.net/set_error_handler
    */
-  public function handleError($no, $string, $file, $line, $context = [])
+  public function handleError($no, $string, $file, $line, $context = []): void
   {
     $this->failed[] = $this->current;
   }

--- a/lib/task/project/sfProjectSendEmailsTask.class.php
+++ b/lib/task/project/sfProjectSendEmailsTask.class.php
@@ -21,36 +21,36 @@ class sfProjectSendEmailsTask extends sfBaseTask
   /**
    * @see sfTask
    */
-  protected function configure()
+  protected function configure(): void
   {
-    $this->addOptions(array(
+    $this->addOptions([
       new sfCommandOption('application', null, sfCommandOption::PARAMETER_OPTIONAL, 'The application name', true),
       new sfCommandOption('env', null, sfCommandOption::PARAMETER_REQUIRED, 'The environment', 'dev'),
       new sfCommandOption('message-limit', null, sfCommandOption::PARAMETER_OPTIONAL, 'The maximum number of messages to send', 0),
       new sfCommandOption('time-limit', null, sfCommandOption::PARAMETER_OPTIONAL, 'The time limit for sending messages (in seconds)', 0),
-    ));
+    ]);
 
     $this->namespace = 'project';
-    $this->name = 'send-emails';
+    $this->name      = 'send-emails';
 
     $this->briefDescription = 'Sends emails stored in a queue';
 
     $this->detailedDescription = <<<EOF
-The [project:send-emails|INFO] sends emails stored in a queue:
+      The [project:send-emails|INFO] sends emails stored in a queue:
 
-  [php symfony project:send-emails|INFO]
+        [php symfony project:send-emails|INFO]
 
-You can limit the number of messages to send:
+      You can limit the number of messages to send:
 
-  [php symfony project:send-emails --message-limit=10|INFO]
+        [php symfony project:send-emails --message-limit=10|INFO]
 
-Or limit to time (in seconds):
+      Or limit to time (in seconds):
 
-  [php symfony project:send-emails --time-limit=10|INFO]
-EOF;
+        [php symfony project:send-emails --time-limit=10|INFO]
+      EOF;
   }
 
-  protected function execute($arguments = array(), $options = array())
+  protected function execute(array $arguments = [], array $options = []): int
   {
     $databaseManager = new sfDatabaseManager($this->configuration);
 
@@ -61,5 +61,7 @@ EOF;
     $sent = $this->getMailer()->flushQueue();
 
     $this->logSection('project', sprintf('sent %s emails', $sent));
+
+    return 0;
   }
 }

--- a/lib/task/project/sfProjectValidateTask.class.php
+++ b/lib/task/project/sfProjectValidateTask.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -21,82 +21,83 @@ class sfValidateTask extends sfBaseTask
   /**
    * @see sfTask
    */
-  protected function configure()
+  protected function configure(): void
   {
-    $this->namespace = 'project';
-    $this->name = 'validate';
+    $this->namespace        = 'project';
+    $this->name             = 'validate';
     $this->briefDescription = 'Finds deprecated usage in a project';
 
     $this->detailedDescription = <<<EOF
-The [project:validate|INFO] task detects deprecated usage in your project.
+      The [project:validate|INFO] task detects deprecated usage in your project.
 
-  [./symfony project:validate|INFO]
+        [./symfony project:validate|INFO]
 
-The task lists all the files you need to change before switching to
-symfony 1.4.
-EOF;
+      The task lists all the files you need to change before switching to
+      symfony 1.4.
+      EOF;
   }
 
   /**
    * @see sfTask
    */
-  protected function execute($arguments = array(), $options = array())
+  protected function execute(array $arguments = [], array $options = []): int
   {
-    foreach ($this->getUpgradeClasses() as $i => $class)
-    {
+    foreach ($this->getUpgradeClasses() as $i => $class) {
       $v = new $class($this->dispatcher, $this->formatter);
+      assert($v instanceof sfValidation);
 
-      $this->logBlock(($i + 1).'. '.$v->getHeader(), 'QUESTION_LARGE');
+      $this->logBlock(($i + 1) . '. ' . $v->getHeader(), 'QUESTION_LARGE');
 
       $v->setCommandApplication($this->commandApplication);
       $v->setConfiguration($this->configuration);
+
       $files = $v->validate();
 
-      if (!$files)
-      {
-        $this->log('  '.$this->formatter->format(' OK ', 'INFO'));
+      if ( ! $files) {
+        $this->log('  ' . $this->formatter->format(' OK ', 'INFO'));
 
         continue;
       }
 
-      $this->log('  '.$this->formatter->format(' '.count($files).' file(s) need to be changed. ', 'ERROR'));
+      $this->log('  ' . $this->formatter->format(' ' . count($files) . ' file(s) need to be changed. ', 'ERROR'));
 
-      foreach ($files as $file => $value)
-      {
-        $this->log('  '.$this->formatter->format($this->formatFile($file), 'INFO'));
+      foreach ($files as $file => $value) {
+        $this->log('  ' . $this->formatter->format($this->formatFile($file), 'INFO'));
 
-        if (true !== $value)
-        {
-          $this->log('    '.$value);
+        if (true !== $value) {
+          $this->log('    ' . $value);
         }
       }
 
       $this->log($v->getExplanation());
     }
+
+    return 0;
   }
 
-  protected function formatFile($file)
+  protected function formatFile(string $file): string
   {
     return str_replace(realpath(sfConfig::get('sf_root_dir')), 'ROOT', realpath($file));
   }
 
-  protected function getUpgradeClasses()
+  /**
+   * @return class-string[]
+   */
+  protected function getUpgradeClasses(): array
   {
-    $baseDir = __DIR__.'/validation/';
-    $classes = array();
+    $baseDir = __DIR__ . '/validation/';
+    $classes = [];
 
-    foreach (glob($baseDir.'*.class.php') as $file)
-    {
-      $class = str_replace(array($baseDir, '.class.php'), '', $file);
+    foreach (glob($baseDir . '*.class.php') as $file) {
+      $class = str_replace([$baseDir, '.class.php'], '', $file);
 
-      if ('sfValidation' != $class)
-      {
+      if ($class !== sfValidation::class) {
         $classes[] = $class;
 
-        require_once $baseDir.$class.'.class.php';
+        require_once $baseDir . $class . '.class.php';
       }
     }
-  
+
     return $classes;
   }
 }

--- a/lib/task/project/validation/sfDeprecatedClassesValidation.class.php
+++ b/lib/task/project/validation/sfDeprecatedClassesValidation.class.php
@@ -18,72 +18,112 @@
  */
 class sfDeprecatedClassesValidation extends sfValidation
 {
-  public function getHeader()
+  public function getHeader(): string
   {
     return 'Checking usage of deprecated classes';
   }
 
-  public function getExplanation()
+  public function getExplanation(): array
   {
-    return array(
-          '',
-          '  The files above use deprecated classes',
-          '  that have been removed in symfony 1.4.',
-          '',
-          '  You can find a list of all deprecated classes under the',
-          '  "Classes" section of the DEPRECATED tutorial:',
-          '',
-          '  http://www.symfony-project.org/tutorial/1_4/en/deprecated',
-          '',
-    );
+    return [
+      '',
+      '  The files above use deprecated classes',
+      '  that have been removed in symfony 1.4.',
+      '',
+      '  You can find a list of all deprecated classes under the',
+      '  "Classes" section of the DEPRECATED tutorial:',
+      '',
+      '  http://www.symfony-project.org/tutorial/1_4/en/deprecated',
+      '',
+    ];
   }
 
-  public function validate()
+  public function validate(): array
   {
-    $classes = array(
-      'sfDoctrineLogger', 'sfNoRouting', 'sfPathInfoRouting', 'sfRichTextEditor',
-      'sfRichTextEditorFCK', 'sfRichTextEditorTinyMCE', 'sfCrudGenerator', 'sfAdminGenerator',
-      'sfPropelCrudGenerator', 'sfPropelAdminGenerator', 'sfPropelUniqueValidator', 'sfDoctrineUniqueValidator',
-      'sfLoader', 'sfConsoleRequest', 'sfConsoleResponse', 'sfConsoleController',
-      'sfDoctrineDataRetriever', 'sfPropelDataRetriever',
-      'sfWidgetFormI18nSelectLanguage', 'sfWidgetFormI18nSelectCurrency', 'sfWidgetFormI18nSelectCountry',
-      'sfWidgetFormChoiceMany', 'sfWidgetFormPropelChoiceMany', 'sfWidgetFormDoctrineChoiceMany',
-      'sfValidatorChoiceMany', 'sfValidatorPropelChoiceMany', 'sfValidatorPropelDoctrineMany',
-      'SfExtensionObjectBuilder', 'SfExtensionPeerBuilder', 'SfMultiExtendObjectBuilder',
-      'SfNestedSetBuilder', 'SfNestedSetPeerBuilder', 'SfObjectBuilder', 'SfPeerBuilder',
-      'sfWidgetFormPropelSelect', 'sfWidgetFormPropelSelectMany',
-      'sfWidgetFormDoctrineSelect', 'sfWidgetFormDoctrineSelectMany',
+    $classes = [
+      'sfDoctrineLogger',
+      'sfNoRouting',
+      'sfPathInfoRouting',
+      'sfRichTextEditor',
+      'sfRichTextEditorFCK',
+      'sfRichTextEditorTinyMCE',
+      'sfCrudGenerator',
+      'sfAdminGenerator',
+      'sfPropelCrudGenerator',
+      'sfPropelAdminGenerator',
+      'sfPropelUniqueValidator',
+      'sfDoctrineUniqueValidator',
+      'sfLoader',
+      'sfConsoleRequest',
+      'sfConsoleResponse',
+      'sfConsoleController',
+      'sfDoctrineDataRetriever',
+      'sfPropelDataRetriever',
+      'sfWidgetFormI18nSelectLanguage',
+      'sfWidgetFormI18nSelectCurrency',
+      'sfWidgetFormI18nSelectCountry',
+      'sfWidgetFormChoiceMany',
+      'sfWidgetFormPropelChoiceMany',
+      'sfWidgetFormDoctrineChoiceMany',
+      'sfValidatorChoiceMany',
+      'sfValidatorPropelChoiceMany',
+      'sfValidatorPropelDoctrineMany',
+      'SfExtensionObjectBuilder',
+      'SfExtensionPeerBuilder',
+      'SfMultiExtendObjectBuilder',
+      'SfNestedSetBuilder',
+      'SfNestedSetPeerBuilder',
+      'SfObjectBuilder',
+      'SfPeerBuilder',
+      'sfWidgetFormPropelSelect',
+      'sfWidgetFormPropelSelectMany',
+      'sfWidgetFormDoctrineSelect',
+      'sfWidgetFormDoctrineSelectMany',
 
       // classes from sfCompat10Plugin
-      'sfEzComponentsBridge', 'sfZendFrameworkBridge', 'sfProcessCache', 'sfValidatorConfigHandler',
-      'sfActionException', 'sfValidatorException', 'sfFillInFormFilter', 'sfValidationExecutionFilter',
-      'sfRequestCompat10', 'sfFillInForm', 'sfCallbackValidator', 'sfCompareValidator', 'sfDateValidator',
-      'sfEmailValidator', 'sfFileValidator', 'sfNumberValidator', 'sfRegexValidator', 'sfStringValidator',
-      'sfUrlValidator', 'sfValidator', 'sfValidatorManager', 'sfMailView', 'sfMail',
-    );
+      'sfEzComponentsBridge',
+      'sfZendFrameworkBridge',
+      'sfProcessCache',
+      'sfValidatorConfigHandler',
+      'sfActionException',
+      'sfValidatorException',
+      'sfFillInFormFilter',
+      'sfValidationExecutionFilter',
+      'sfRequestCompat10',
+      'sfFillInForm',
+      'sfCallbackValidator',
+      'sfCompareValidator',
+      'sfDateValidator',
+      'sfEmailValidator',
+      'sfFileValidator',
+      'sfNumberValidator',
+      'sfRegexValidator',
+      'sfStringValidator',
+      'sfUrlValidator',
+      'sfValidator',
+      'sfValidatorManager',
+      'sfMailView',
+      'sfMail',
+    ];
 
-    $found = array();
-    $files = sfFinder::type('file')->name('*.php')->prune('vendor')->in(array(
+    $found = [];
+    $files = sfFinder::type('file')->name('*.php')->prune('vendor')->in([
       sfConfig::get('sf_apps_dir'),
       sfConfig::get('sf_lib_dir'),
       sfConfig::get('sf_test_dir'),
       sfConfig::get('sf_plugins_dir'),
-    ));
-    foreach ($files as $file)
-    {
+    ]);
+    foreach ($files as $file) {
       $content = sfToolkit::stripComments(file_get_contents($file));
 
-      $matches = array();
-      foreach ($classes as $class)
-      {
-        if (preg_match('#\b'.preg_quote($class, '#').'\b#', $content))
-        {
+      $matches = [];
+      foreach ($classes as $class) {
+        if (preg_match('#\b' . preg_quote($class, '#') . '\b#', $content)) {
           $matches[] = $class;
         }
       }
 
-      if ($matches)
-      {
+      if ($matches) {
         $found[$file] = implode(', ', $matches);
       }
     }

--- a/lib/task/project/validation/sfDeprecatedConfigurationFilesValidation.class.php
+++ b/lib/task/project/validation/sfDeprecatedConfigurationFilesValidation.class.php
@@ -18,53 +18,51 @@
  */
 class sfDeprecatedConfigurationFilesValidation extends sfValidation
 {
-  public function getHeader()
+  public function getHeader(): string
   {
     return 'Checking usage of deprecated configuration files';
   }
 
-  public function getExplanation()
+  public function getExplanation(): array
   {
-    return array(
-          '',
-          '  The project uses deprecated configuration files',
-          '  that have been removed in symfony 1.4 (mailer.yml, validate/*.yml)',
-          '  or for which the format changed (generator.yml)',
-          '',
-    );
+    return [
+      '',
+      '  The project uses deprecated configuration files',
+      '  that have been removed in symfony 1.4 (mailer.yml, validate/*.yml)',
+      '  or for which the format changed (generator.yml)',
+      '',
+    ];
   }
 
-  public function validate()
+  public function validate(): array
   {
     // mailer.yml
     $files = sfFinder::type('file')->name('mailer.yml')->in($this->getProjectConfigDirectories());
-    $found = array();
-    foreach ($files as $file)
-    {
+    $found = [];
+    foreach ($files as $file) {
       $found[$file] = true;
     }
 
     // modules/*/validate/*.yml
-    $files = sfFinder::type('file')->name('*.yml')->in(array_merge(
-      glob(sfConfig::get('sf_apps_dir').'/*/modules/*/validate'),
-      glob(sfConfig::get('sf_plugins_dir').'/*/modules/*/validate')
-    ));
-    foreach ($files as $file)
-    {
+    $files = sfFinder::type('file')->name('*.yml')->in(
+      array_merge(
+        glob(sfConfig::get('sf_apps_dir') . '/*/modules/*/validate'),
+        glob(sfConfig::get('sf_plugins_dir') . '/*/modules/*/validate')
+      )
+    );
+    foreach ($files as $file) {
       $found[$file] = true;
     }
 
     // old generator.yml
-    $files = sfFinder::type('file')->name('generator.yml')->in(array(
+    $files = sfFinder::type('file')->name('generator.yml')->in([
       sfConfig::get('sf_apps_dir'),
       sfConfig::get('sf_plugins_dir'),
-    ));
-    foreach ($files as $file)
-    {
+    ]);
+    foreach ($files as $file) {
       $content = file_get_contents($file);
 
-      if (false !== strpos($content, 'sfPropelAdminGenerator'))
-      {
+      if (false !== strpos($content, 'sfPropelAdminGenerator')) {
         $found[$file] = true;
       }
     }

--- a/lib/task/project/validation/sfDeprecatedHelpersValidation.class.php
+++ b/lib/task/project/validation/sfDeprecatedHelpersValidation.class.php
@@ -18,67 +18,113 @@
  */
 class sfDeprecatedHelpersValidation extends sfValidation
 {
-  public function getHeader()
+  public function getHeader(): string
   {
     return 'Checking usage of deprecated helpers';
   }
 
-  public function getExplanation()
+  public function getExplanation(): array
   {
-    return array(
-          '',
-          '  The files above use deprecated helpers',
-          '  that have been removed in symfony 1.4.',
-          '',
-          '  You can find a list of all deprecated helpers under the',
-          '  "Helpers" section of the DEPRECATED tutorial:',
-          '',
-          '  http://www.symfony-project.org/tutorial/1_4/en/deprecated',
-          '',
-    );
+    return [
+      '',
+      '  The files above use deprecated helpers',
+      '  that have been removed in symfony 1.4.',
+      '',
+      '  You can find a list of all deprecated helpers under the',
+      '  "Helpers" section of the DEPRECATED tutorial:',
+      '',
+      '  http://www.symfony-project.org/tutorial/1_4/en/deprecated',
+      '',
+    ];
   }
 
-  public function validate()
+  public function validate(): array
   {
-    $helpers = array(
-      'select_day_tag', 'select_month_tag', 'select_year_tag', 'select_date_tag', 'select_second_tag',
-      'select_minute_tag', 'select_hour_tag', 'select_ampm_tag', 'select_time_tag', 'select_datetime_tag',
-      'select_number_tag', 'select_timezone_tag', 'options_for_select', 'select_tag', 'select_country_tag',
-      'select_language_tag', 'select_currency_tag', 'input_tag', 'input_hidden_tag', 'input_file_tag',
-      'input_password_tag', 'textarea_tag', 'checkbox_tag', 'radiobutton_tag', 'input_date_range_tag',
-      'input_date_tag', 'submit_tag', 'reset_tag', 'submit_image_tag', 'label_for',
-      'object_admin_input_file_tag', 'object_admin_double_list', 'object_admin_select_list',
-      'object_admin_check_list', 'object_input_date_tag', 'object_textarea_tag', 'objects_for_select',
-      'object_select_tag', 'object_select_country_tag', 'object_select_language_tag', 'object_input_hidden_tag',
-      'object_input_tag', 'object_checkbox_tag', 'form_has_error', 'form_error', 'get_callbacks',
-      'get_ajax_options', 'button_to_remote', 'link_to_remote', 'periodically_call_remote', 'form_remote_tag',
-      'submit_to_remote', 'submit_image_to_remote', 'update_element_function', 'evaluate_remote_response',
-      'remote_function', 'observe_field', 'observe_form', 'visual_effect', 'sortable_element',
-      'draggable_element', 'drop_receiving_element', 'input_auto_complete_tag', 'input_in_place_editor_tag',
-    );
+    $helpers = [
+      'select_day_tag',
+      'select_month_tag',
+      'select_year_tag',
+      'select_date_tag',
+      'select_second_tag',
+      'select_minute_tag',
+      'select_hour_tag',
+      'select_ampm_tag',
+      'select_time_tag',
+      'select_datetime_tag',
+      'select_number_tag',
+      'select_timezone_tag',
+      'options_for_select',
+      'select_tag',
+      'select_country_tag',
+      'select_language_tag',
+      'select_currency_tag',
+      'input_tag',
+      'input_hidden_tag',
+      'input_file_tag',
+      'input_password_tag',
+      'textarea_tag',
+      'checkbox_tag',
+      'radiobutton_tag',
+      'input_date_range_tag',
+      'input_date_tag',
+      'submit_tag',
+      'reset_tag',
+      'submit_image_tag',
+      'label_for',
+      'object_admin_input_file_tag',
+      'object_admin_double_list',
+      'object_admin_select_list',
+      'object_admin_check_list',
+      'object_input_date_tag',
+      'object_textarea_tag',
+      'objects_for_select',
+      'object_select_tag',
+      'object_select_country_tag',
+      'object_select_language_tag',
+      'object_input_hidden_tag',
+      'object_input_tag',
+      'object_checkbox_tag',
+      'form_has_error',
+      'form_error',
+      'get_callbacks',
+      'get_ajax_options',
+      'button_to_remote',
+      'link_to_remote',
+      'periodically_call_remote',
+      'form_remote_tag',
+      'submit_to_remote',
+      'submit_image_to_remote',
+      'update_element_function',
+      'evaluate_remote_response',
+      'remote_function',
+      'observe_field',
+      'observe_form',
+      'visual_effect',
+      'sortable_element',
+      'draggable_element',
+      'drop_receiving_element',
+      'input_auto_complete_tag',
+      'input_in_place_editor_tag',
+    ];
 
-    $found = array();
-    $files = sfFinder::type('file')->name('*.php')->prune('vendor')->in(array(
+    $found = [];
+    $files = sfFinder::type('file')->name('*.php')->prune('vendor')->in([
       sfConfig::get('sf_apps_dir'),
       sfConfig::get('sf_lib_dir'),
       sfConfig::get('sf_test_dir'),
       sfConfig::get('sf_plugins_dir'),
-    ));
-    foreach ($files as $file)
-    {
+    ]);
+    foreach ($files as $file) {
       $content = sfToolkit::stripComments(file_get_contents($file));
 
-      $matches = array();
-      foreach ($helpers as $helper)
-      {
-        if (preg_match('#\b'.preg_quote($helper, '#').'\b#', $content))
-        {
+      $matches = [];
+      foreach ($helpers as $helper) {
+        if (preg_match('#\b' . preg_quote($helper, '#') . '\b#', $content)) {
           $matches[] = $helper;
         }
       }
 
-      if ($matches)
-      {
+      if ($matches) {
         $found[$file] = implode(', ', $matches);
       }
     }

--- a/lib/task/project/validation/sfDeprecatedMethodsValidation.class.php
+++ b/lib/task/project/validation/sfDeprecatedMethodsValidation.class.php
@@ -18,30 +18,30 @@
  */
 class sfDeprecatedMethodsValidation extends sfValidation
 {
-  public function getHeader()
+  public function getHeader(): string
   {
     return 'Checking usage of deprecated methods';
   }
 
-  public function getExplanation()
+  public function getExplanation(): array
   {
-    return array(
-          '',
-          '  The files above use deprecated functions and/or methods',
-          '  that have been removed in symfony 1.4.',
-          '',
-          '  You can find a list of all deprecated methods under the',
-          '  "Methods and Functions" section of the DEPRECATED tutorial:',
-          '',
-          '  http://www.symfony-project.org/tutorial/1_4/en/deprecated',
-          '',
-    );
+    return [
+      '',
+      '  The files above use deprecated functions and/or methods',
+      '  that have been removed in symfony 1.4.',
+      '',
+      '  You can find a list of all deprecated methods under the',
+      '  "Methods and Functions" section of the DEPRECATED tutorial:',
+      '',
+      '  http://www.symfony-project.org/tutorial/1_4/en/deprecated',
+      '',
+    ];
   }
 
-  public function validate()
+  public function validate(): array
   {
     $found = array_merge(
-      $this->doValidate(array(
+      $this->doValidate([
         'sfToolkit::getTmpDir',
         'sfToolkit::removeArrayValueForPath',
         'sfToolkit::hasArrayValueForPath',
@@ -53,45 +53,55 @@ class sfDeprecatedMethodsValidation extends sfValidation
         'getXDebugStack',
         'checkSymfonyVersion',
         'sh',
-      ), array(
+      ], [
         sfConfig::get('sf_apps_dir'),
         sfConfig::get('sf_lib_dir'),
         sfConfig::get('sf_test_dir'),
         sfConfig::get('sf_plugins_dir'),
-      )),
+      ]),
 
-      $this->doValidate(array(
-        'contains', 'responseContains', 'isRequestParameter', 'isResponseHeader',
-        'isUserCulture', 'isRequestFormat', 'checkResponseElement',
-      ), sfConfig::get('sf_test_dir')),
+      $this->doValidate([
+        'contains',
+        'responseContains',
+        'isRequestParameter',
+        'isResponseHeader',
+        'isUserCulture',
+        'isRequestFormat',
+        'checkResponseElement',
+      ], sfConfig::get('sf_test_dir')),
 
-      $this->doValidate(array(
-        'getDefaultView', 'handleError', 'validate', 'debugMessage', 'getController()->sendEmail'
-      ), $this->getProjectActionDirectories())
+      $this->doValidate([
+        'getDefaultView',
+        'handleError',
+        'validate',
+        'debugMessage',
+        'getController()->sendEmail',
+      ], $this->getProjectActionDirectories())
     );
 
     return $found;
   }
 
-  public function doValidate($methods, $dir)
+  /**
+   * @param array           $methods
+   * @param string[]|string $dir
+   * @return string[]
+   */
+  public function doValidate(array $methods, array | string $dir): array
   {
-    $found = array();
+    $found = [];
     $files = sfFinder::type('file')->name('*.php')->prune('vendor')->in($dir);
-    foreach ($files as $file)
-    {
+    foreach ($files as $file) {
       $content = sfToolkit::stripComments(file_get_contents($file));
 
-      $matches = array();
-      foreach ($methods as $method)
-      {
-        if (preg_match('#\b'.preg_quote($method, '#').'\b#', $content))
-        {
+      $matches = [];
+      foreach ($methods as $method) {
+        if (preg_match('#\b' . preg_quote($method, '#') . '\b#', $content)) {
           $matches[] = $method;
         }
       }
 
-      if ($matches)
-      {
+      if ($matches) {
         $found[$file] = implode(', ', $matches);
       }
     }

--- a/lib/task/project/validation/sfDeprecatedPluginsValidation.class.php
+++ b/lib/task/project/validation/sfDeprecatedPluginsValidation.class.php
@@ -18,43 +18,39 @@
  */
 class sfDeprecatedPluginsValidation extends sfValidation
 {
-  public function getHeader()
+  public function getHeader(): string
   {
     return 'Checking usage of deprecated plugins';
   }
 
-  public function getExplanation()
+  public function getExplanation(): array
   {
-    return array(
-          '',
-          '  The files above use deprecated plugins',
-          '  that have been removed in symfony 1.4.',
-          '',
-          'You can probably remove those references safely.',
-          '',
-    );
+    return [
+      '',
+      '  The files above use deprecated plugins',
+      '  that have been removed in symfony 1.4.',
+      '',
+      'You can probably remove those references safely.',
+      '',
+    ];
   }
 
-  public function validate()
+  public function validate(): array
   {
-    $found = array();
+    $found = [];
     $files = sfFinder::type('file')->name('*Configuration.class.php')->in($this->getProjectConfigDirectories());
-    foreach ($files as $file)
-    {
+    foreach ($files as $file) {
       $content = sfToolkit::stripComments(file_get_contents($file));
 
-      $matches = array();
-      if (false !== strpos($content, 'sfCompat10Plugin'))
-      {
+      $matches = [];
+      if (false !== strpos($content, 'sfCompat10Plugin')) {
         $matches[] = 'sfCompat10Plugin';
       }
-      if (false !== strpos($content, 'sfProtoculousPlugin'))
-      {
+      if (false !== strpos($content, 'sfProtoculousPlugin')) {
         $matches[] = 'sfProtoculousPlugin';
       }
 
-      if ($matches)
-      {
+      if ($matches) {
         $found[$file] = implode(', ', $matches);
       }
     }

--- a/lib/task/project/validation/sfDeprecatedSettingsValidation.class.php
+++ b/lib/task/project/validation/sfDeprecatedSettingsValidation.class.php
@@ -18,57 +18,62 @@
  */
 class sfDeprecatedSettingsValidation extends sfValidation
 {
-  public function getHeader()
+  public function getHeader(): string
   {
     return 'Checking usage of deprecated settings';
   }
 
-  public function getExplanation()
+  public function getExplanation(): array
   {
-    return array(
-          '',
-          '  The files above use deprecated settings',
-          '  that have been removed in symfony 1.4.',
-          '',
-          '  You can find a list of all deprecated settings under the',
-          '  "Settings" section of the DEPRECATED tutorial:',
-          '',
-          '  http://www.symfony-project.org/tutorial/1_4/en/deprecated',
-          '',
-    );
+    return [
+      '',
+      '  The files above use deprecated settings',
+      '  that have been removed in symfony 1.4.',
+      '',
+      '  You can find a list of all deprecated settings under the',
+      '  "Settings" section of the DEPRECATED tutorial:',
+      '',
+      '  http://www.symfony-project.org/tutorial/1_4/en/deprecated',
+      '',
+    ];
   }
 
-  public function validate()
+  public function validate(): array
   {
-    $settings = array(
-      'sf_check_symfony_version', 'sf_max_forwards', 'sf_lazy_cache_key', 'sf_strip_comments',
-      'sf_lazy_routes_deserialize', 'sf_calendar_web_dir', 'sf_rich_text_js_dir', 'sf_validation_error_prefix',
-      'sf_validation_error_suffix', 'sf_validation_error_class', 'sf_validation_error_id_prefix',
-      '_is_internal', 'sf_doc_dir',
-    );
+    $settings = [
+      'sf_check_symfony_version',
+      'sf_max_forwards',
+      'sf_lazy_cache_key',
+      'sf_strip_comments',
+      'sf_lazy_routes_deserialize',
+      'sf_calendar_web_dir',
+      'sf_rich_text_js_dir',
+      'sf_validation_error_prefix',
+      'sf_validation_error_suffix',
+      'sf_validation_error_class',
+      'sf_validation_error_id_prefix',
+      '_is_internal',
+      'sf_doc_dir',
+    ];
 
-    $found = array();
-    $files = sfFinder::type('file')->name('*.php')->prune('vendor')->in(array(
+    $found = [];
+    $files = sfFinder::type('file')->name('*.php')->prune('vendor')->in([
       sfConfig::get('sf_apps_dir'),
       sfConfig::get('sf_lib_dir'),
       sfConfig::get('sf_test_dir'),
       sfConfig::get('sf_plugins_dir'),
-    ));
-    foreach ($files as $file)
-    {
+    ]);
+    foreach ($files as $file) {
       $content = sfToolkit::stripComments(file_get_contents($file));
 
-      $matches = array();
-      foreach ($settings as $setting)
-      {
-        if (false !== stripos($content, $setting))
-        {
+      $matches = [];
+      foreach ($settings as $setting) {
+        if (false !== stripos($content, $setting)) {
           $matches[] = $setting;
         }
       }
 
-      if ($matches)
-      {
+      if ($matches) {
         $found[$file] = implode(', ', $matches);
       }
     }

--- a/lib/task/project/validation/sfParameterHolderValidation.class.php
+++ b/lib/task/project/validation/sfParameterHolderValidation.class.php
@@ -18,44 +18,42 @@
  */
 class sfParameterHolderValidation extends sfValidation
 {
-  public function getHeader()
+  public function getHeader(): string
   {
     return 'Checking usage of array notation with a parameter holder';
   }
 
-  public function getExplanation()
+  public function getExplanation(): array
   {
-    return array(
-          '',
-          '  The files above use the array notation with a parameter holder,',
-          '  which is not supported anymore in symfony 1.4.',
-          '  For instance, you need to change this construct:',
-          '',
-          '    $foo = $request->getParameter(\'foo[bar]\')',
-          '',
-          '  to this one:',
-          '',
-          '    $params = $request->getParameter(\'foo\')',
-          '    $foo = $params[\'bar\'])',
-          '',
-    );
+    return [
+      '',
+      '  The files above use the array notation with a parameter holder,',
+      '  which is not supported anymore in symfony 1.4.',
+      '  For instance, you need to change this construct:',
+      '',
+      '    $foo = $request->getParameter(\'foo[bar]\')',
+      '',
+      '  to this one:',
+      '',
+      '    $params = $request->getParameter(\'foo\')',
+      '    $foo = $params[\'bar\'])',
+      '',
+    ];
   }
 
-  public function validate()
+  public function validate(): array
   {
-    $found = array();
-    $files = sfFinder::type('file')->name('*.php')->prune('vendor')->in(array(
+    $found = [];
+    $files = sfFinder::type('file')->name('*.php')->prune('vendor')->in([
       sfConfig::get('sf_apps_dir'),
       sfConfig::get('sf_lib_dir'),
       sfConfig::get('sf_test_dir'),
       sfConfig::get('sf_plugins_dir'),
-    ));
-    foreach ($files as $file)
-    {
+    ]);
+    foreach ($files as $file) {
       $content = sfToolkit::stripComments(file_get_contents($file));
 
-      if (preg_match('#\b(get|has|remove)(Request)*Parameter\(\s*[\'"][^\),]*?\[[^\),]#', $content))
-      {
+      if (preg_match('#\b(get|has|remove)(Request)*Parameter\(\s*[\'"][^\),]*?\[[^\),]#', $content)) {
         $found[$file] = true;
       }
     }

--- a/lib/task/project/validation/sfValidation.class.php
+++ b/lib/task/project/validation/sfValidation.class.php
@@ -18,17 +18,23 @@
  */
 abstract class sfValidation extends sfBaseTask
 {
-  protected
-    $task = null;
+  protected $task = null;
 
   /**
    * Validates the current project.
+   *
+   * @return string[] Files to be upgraded.
    */
-  abstract public function validate();
+  abstract public function validate(): array;
 
-  abstract public function getHeader();
+  abstract public function getHeader(): string;
 
-  public function execute($arguments = array(), $options = array())
+  /**
+   * @return string[]|string
+   */
+  abstract public function getExplanation(): array | string;
+
+  public function execute(array $arguments = [], array $options = []): int
   {
     throw new sfException('You can\'t execute this task.');
   }
@@ -36,19 +42,21 @@ abstract class sfValidation extends sfBaseTask
   /**
    * Returns a finder that exclude upgrade scripts from being upgraded!
    *
-   * @param  string $type String directory or file or any (for both file and directory)
+   * @param string $type  String directory or file or any (for both file and directory)
    *
    * @return sfFinder A sfFinder instance
    */
-  protected function getFinder($type)
+  protected function getFinder(string $type): sfFinder
   {
     return sfFinder::type($type)->prune('symfony')->discard('symfony');
   }
 
   /**
    * Returns all project directories where you can put PHP classes.
+   *
+   * @return string[]
    */
-  protected function getProjectClassDirectories()
+  protected function getProjectClassDirectories(): array
   {
     return array_merge(
       $this->getProjectLibDirectories(),
@@ -58,48 +66,56 @@ abstract class sfValidation extends sfBaseTask
 
   /**
    * Returns all project directories where you can put templates.
+   *
+   * @return string[]
    */
-  protected function getProjectTemplateDirectories()
+  protected function getProjectTemplateDirectories(): array
   {
     return array_merge(
-      glob(sfConfig::get('sf_apps_dir').'/*/modules/*/templates'),
-      glob(sfConfig::get('sf_apps_dir').'/*/templates')
+      glob(sfConfig::get('sf_apps_dir') . '/*/modules/*/templates'),
+      glob(sfConfig::get('sf_apps_dir') . '/*/templates')
     );
   }
 
   /**
    * Returns all project directories where you can put actions and components.
+   *
+   * @return string[]
    */
-  protected function getProjectActionDirectories()
+  protected function getProjectActionDirectories(): array
   {
-    return glob(sfConfig::get('sf_apps_dir').'/*/modules/*/actions');
+    return glob(sfConfig::get('sf_apps_dir') . '/*/modules/*/actions');
   }
 
   /**
    * Returns all project lib directories.
-   * 
-   * @param string $subdirectory A subdirectory within lib (i.e. "/form")
+   *
+   * @param string|null $subdirectory  A subdirectory within lib (i.e. "/form")
+   *
+   * @return string[]
    */
-  protected function getProjectLibDirectories($subdirectory = null)
+  protected function getProjectLibDirectories(string | null $subdirectory = null): array
   {
     return array_merge(
-      glob(sfConfig::get('sf_apps_dir').'/*/modules/*/lib'.$subdirectory),
-      glob(sfConfig::get('sf_apps_dir').'/*/lib'.$subdirectory),
-      array(
-        sfConfig::get('sf_apps_dir').'/lib'.$subdirectory,
-        sfConfig::get('sf_lib_dir').$subdirectory,
-      )
+      glob(sfConfig::get('sf_apps_dir') . '/*/modules/*/lib' . $subdirectory),
+      glob(sfConfig::get('sf_apps_dir') . '/*/lib' . $subdirectory),
+      [
+        sfConfig::get('sf_apps_dir') . '/lib' . $subdirectory,
+        sfConfig::get('sf_lib_dir') . $subdirectory,
+      ]
     );
   }
 
   /**
    * Returns all project config directories.
+   *
+   * @return string[]
    */
-  protected function getProjectConfigDirectories()
+  protected function getProjectConfigDirectories(): array
   {
     return array_merge(
-      glob(sfConfig::get('sf_apps_dir').'/*/modules/*/config'),
-      glob(sfConfig::get('sf_apps_dir').'/*/config'),
+      glob(sfConfig::get('sf_apps_dir') . '/*/modules/*/config'),
+      glob(sfConfig::get('sf_apps_dir') . '/*/config'),
       glob(sfConfig::get('sf_config_dir'))
     );
   }
@@ -107,9 +123,9 @@ abstract class sfValidation extends sfBaseTask
   /**
    * Returns all application names.
    *
-   * @return array An array of application names
+   * @return string[] An array of application names
    */
-  protected function getApplications()
+  protected function getApplications(): array
   {
     return sfFinder::type('dir')->maxdepth(0)->relative()->in(sfConfig::get('sf_apps_dir'));
   }

--- a/lib/task/sfBaseTask.class.php
+++ b/lib/task/sfBaseTask.class.php
@@ -18,43 +18,53 @@
  */
 abstract class sfBaseTask extends sfCommandApplicationTask
 {
-  /** @var \sfProjectConfiguration|\sfApplicationConfiguration */
-  protected $configuration   = null;
-  /** @var int|null */
-  protected $statusStartTime = null;
+  protected sfProjectConfiguration | sfApplicationConfiguration | null $configuration = null;
+
+  protected int | null $statusStartTime = null;
 
   /**
    * @see sfTask
    * @inheritdoc
    */
-  protected function doRun(sfCommandManager $commandManager, $options)
+  protected function doRun(sfCommandManager $commandManager, array | string | null $options): int
   {
-    $event = $this->dispatcher->filter(new sfEvent($this, 'command.filter_options', array('command_manager' => $commandManager)), $options);
+    $event   = $this->dispatcher->filter(
+      new sfEvent($this, 'command.filter_options', ['command_manager' => $commandManager]),
+      $options,
+    );
     $options = $event->getReturnValue();
 
     $this->process($commandManager, $options);
 
-    $event = new sfEvent($this, 'command.pre_command', array('arguments' => $commandManager->getArgumentValues(), 'options' => $commandManager->getOptionValues()));
+    $event = new sfEvent($this, 'command.pre_command', [
+      'arguments' => $commandManager->getArgumentValues(),
+      'options'   => $commandManager->getOptionValues(),
+    ]);
+
     $this->dispatcher->notifyUntil($event);
-    if ($event->isProcessed())
-    {
+
+    if ($event->isProcessed()) {
       return $event->getReturnValue();
     }
 
     $this->checkProjectExists();
 
-    $requiresApplication = $commandManager->getArgumentSet()->hasArgument('application') || $commandManager->getOptionSet()->hasOption('application');
-    if (null === $this->configuration || ($requiresApplication && !$this->configuration instanceof sfApplicationConfiguration))
-    {
-      $application = $commandManager->getArgumentSet()->hasArgument('application') ? $commandManager->getArgumentValue('application') : ($commandManager->getOptionSet()->hasOption('application') ? $commandManager->getOptionValue('application') : null);
-      $env = $commandManager->getOptionSet()->hasOption('env') ? $commandManager->getOptionValue('env') : 'test';
+    $requiresApplication = $commandManager->getArgumentSet()->hasArgument('application')
+                           || $commandManager->getOptionSet()->hasOption('application');
 
-      if (true === $application)
-      {
+    if (null === $this->configuration || ($requiresApplication && ! $this->configuration instanceof sfApplicationConfiguration)) {
+      $application = $commandManager->getArgumentSet()->hasArgument('application')
+        ? $commandManager->getArgumentValue('application')
+        : ($commandManager->getOptionSet()->hasOption('application')
+          ? $commandManager->getOptionValue('application')
+          : null);
+
+      $env = ($commandManager->getOptionSet()->hasOption('env') ? $commandManager->getOptionValue('env') : 'test') ?: 'test';
+
+      if (true === $application) {
         $application = $this->getFirstApplication();
 
-        if ($commandManager->getOptionSet()->hasOption('application'))
-        {
+        if ($commandManager->getOptionSet()->hasOption('application')) {
           $commandManager->setOption($commandManager->getOptionSet()->getOption('application'), $application);
         }
       }
@@ -62,8 +72,7 @@ abstract class sfBaseTask extends sfCommandApplicationTask
       $this->configuration = $this->createConfiguration($application, $env);
     }
 
-    if (!$this->withTrace())
-    {
+    if ( ! $this->withTrace()) {
       sfConfig::set('sf_logging_enabled', false);
     }
 
@@ -77,9 +86,9 @@ abstract class sfBaseTask extends sfCommandApplicationTask
   /**
    * Sets the current task's configuration.
    *
-   * @param sfProjectConfiguration $configuration
+   * @param sfProjectConfiguration | null $configuration
    */
-  public function setConfiguration(sfProjectConfiguration $configuration = null)
+  public function setConfiguration(sfProjectConfiguration | null $configuration = null): void
   {
     $this->configuration = $configuration;
   }
@@ -89,16 +98,12 @@ abstract class sfBaseTask extends sfCommandApplicationTask
    *
    * @return sfFilesystem A sfFilesystem instance
    */
-  public function getFilesystem()
+  public function getFilesystem(): sfFilesystem
   {
-    if (!isset($this->filesystem))
-    {
-      if ($this->isVerbose())
-      {
+    if ( ! isset($this->filesystem)) {
+      if ($this->isVerbose()) {
         $this->filesystem = new sfFilesystem($this->dispatcher, $this->formatter);
-      }
-      else
-      {
+      } else {
         $this->filesystem = new sfFilesystem();
       }
     }
@@ -109,14 +114,13 @@ abstract class sfBaseTask extends sfCommandApplicationTask
   /**
    * Checks if the current directory is a symfony project directory.
    *
-   * @return true if the current directory is a symfony project directory, false otherwise
+   * @return void If the current directory is a symfony project directory, throws otherwise
    *
    * @throws sfException
    */
-  public function checkProjectExists()
+  public function checkProjectExists(): void
   {
-    if (!file_exists('symfony'))
-    {
+    if ( ! file_exists('symfony')) {
       throw new sfException('You must be in a symfony project directory.');
     }
   }
@@ -124,16 +128,15 @@ abstract class sfBaseTask extends sfCommandApplicationTask
   /**
    * Checks if an application exists.
    *
-   * @param  string $app The application name
+   * @param string $app  The application name
    *
-   * @return bool true if the application exists, false otherwise
+   * @return void if the application exists, throws otherwise
    *
    * @throws sfException
    */
-  public function checkAppExists($app)
+  public function checkAppExists(string $app): void
   {
-    if (!is_dir(sfConfig::get('sf_apps_dir').'/'.$app))
-    {
+    if ( ! is_dir(sfConfig::get('sf_apps_dir') . '/' . $app)) {
       throw new sfException(sprintf('Application "%s" does not exist', $app));
     }
   }
@@ -141,17 +144,16 @@ abstract class sfBaseTask extends sfCommandApplicationTask
   /**
    * Checks if a module exists.
    *
-   * @param  string $app    The application name
-   * @param  string $module The module name
+   * @param string $app     The application name
+   * @param string $module  The module name
    *
-   * @return bool true if the module exists, false otherwise
+   * @return void if the module exists, throws otherwise
    *
    * @throws sfException
    */
-  public function checkModuleExists($app, $module)
+  public function checkModuleExists(string $app, string $module): void
   {
-    if (!is_dir(sfConfig::get('sf_apps_dir').'/'.$app.'/modules/'.$module))
-    {
+    if ( ! is_dir(sfConfig::get('sf_apps_dir') . '/' . $app . '/modules/' . $module)) {
       throw new sfException(sprintf('Module "%s/%s" does not exist.', $app, $module));
     }
   }
@@ -161,10 +163,9 @@ abstract class sfBaseTask extends sfCommandApplicationTask
    *
    * @return boolean
    */
-  protected function withTrace()
+  protected function withTrace(): bool
   {
-    if (null !== $this->commandApplication && !$this->commandApplication->withTrace())
-    {
+    if (null !== $this->commandApplication && ! $this->commandApplication->withTrace()) {
       return false;
     }
 
@@ -176,10 +177,9 @@ abstract class sfBaseTask extends sfCommandApplicationTask
    *
    * @return boolean
    */
-  protected function isVerbose()
+  protected function isVerbose(): bool
   {
-    if (null !== $this->commandApplication && !$this->commandApplication->isVerbose())
-    {
+    if (null !== $this->commandApplication && ! $this->commandApplication->isVerbose()) {
       return false;
     }
 
@@ -191,10 +191,9 @@ abstract class sfBaseTask extends sfCommandApplicationTask
    *
    * @return boolean
    */
-  protected function isDebug()
+  protected function isDebug(): bool
   {
-    if (null !== $this->commandApplication && !$this->commandApplication->isDebug())
-    {
+    if (null !== $this->commandApplication && ! $this->commandApplication->isDebug()) {
       return false;
     }
 
@@ -204,37 +203,30 @@ abstract class sfBaseTask extends sfCommandApplicationTask
   /**
    * Creates a configuration object.
    *
-   * @param string  $application The application name
-   * @param string  $env         The environment name
+   * @param string|null $application  The application name
+   * @param string      $env          The environment name
    *
    * @return sfProjectConfiguration A sfProjectConfiguration instance
    */
-  protected function createConfiguration($application, $env)
+  protected function createConfiguration(string | null $application, string $env): sfProjectConfiguration
   {
-    if (null !== $application)
-    {
+    if (null !== $application) {
       $this->checkAppExists($application);
 
-      require_once sfConfig::get('sf_config_dir').'/ProjectConfiguration.class.php';
+      require_once sfConfig::get('sf_config_dir') . '/ProjectConfiguration.class.php';
 
-      $configuration = ProjectConfiguration::getApplicationConfiguration($application, $env, $this->isDebug(), null, $this->dispatcher);
+      return ProjectConfiguration::getApplicationConfiguration($application, $env, $this->isDebug(), null, $this->dispatcher);
     }
-    else
-    {
-      if (file_exists(sfConfig::get('sf_config_dir').'/ProjectConfiguration.class.php'))
-      {
-        require_once sfConfig::get('sf_config_dir').'/ProjectConfiguration.class.php';
-        $configuration = new ProjectConfiguration(null, $this->dispatcher);
-      }
-      else
-      {
-        $configuration = new sfProjectConfiguration(getcwd(), $this->dispatcher);
-      }
 
-      if (null !== $env)
-      {
-        sfConfig::set('sf_environment', $env);
-      }
+    if (file_exists(sfConfig::get('sf_config_dir') . '/ProjectConfiguration.class.php')) {
+      require_once sfConfig::get('sf_config_dir') . '/ProjectConfiguration.class.php';
+      $configuration = new ProjectConfiguration(null, $this->dispatcher);
+    } else {
+      $configuration = new sfProjectConfiguration(getcwd(), $this->dispatcher);
+    }
+
+    if (null !== $env) {
+      sfConfig::set('sf_environment', $env);
     }
 
     return $configuration;
@@ -243,12 +235,11 @@ abstract class sfBaseTask extends sfCommandApplicationTask
   /**
    * Returns the first application in apps.
    *
-   * @return string The Application name
+   * @return string|null The Application name, if available
    */
-  protected function getFirstApplication()
+  protected function getFirstApplication(): string | null
   {
-    if (count($dirs = sfFinder::type('dir')->maxdepth(0)->follow_link()->relative()->in(sfConfig::get('sf_apps_dir'))))
-    {
+    if (count($dirs = sfFinder::type('dir')->maxdepth(0)->follow_link()->relative()->in(sfConfig::get('sf_apps_dir')))) {
       return $dirs[0];
     }
 
@@ -258,13 +249,12 @@ abstract class sfBaseTask extends sfCommandApplicationTask
   /**
    * Mirrors a directory structure inside the created project.
    *
-   * @param string   $dir    The directory to mirror
-   * @param sfFinder $finder A sfFinder instance to use for the mirroring
+   * @param string        $dir     The directory to mirror
+   * @param sfFinder|null $finder  A sfFinder instance to use for the mirroring
    */
-  protected function installDir($dir, $finder = null)
+  protected function installDir(string $dir, sfFinder | null $finder = null)
   {
-    if (null === $finder)
-    {
+    if (null === $finder) {
       $finder = sfFinder::type('any')->discard('.sf');
     }
 
@@ -278,17 +268,14 @@ abstract class sfBaseTask extends sfCommandApplicationTask
    *
    * You can define global tokens by defining the $this->tokens property.
    *
-   * @param array $dirs   An array of directory where to do the replacement
-   * @param array $tokens An array of tokens to use
+   * @param string[]             $dirs    An array of directory where to do the replacement
+   * @param array<string,string> $tokens  An array of tokens to use
    */
-  protected function replaceTokens($dirs = array(), $tokens = array())
+  protected function replaceTokens(array $dirs = [], array $tokens = [])
   {
-    if (!$dirs)
-    {
-      $dirs = array(sfConfig::get('sf_config_dir'), sfConfig::get('sf_lib_dir'));
-    }
+    $dirs = $dirs ?: [sfConfig::get('sf_config_dir'), sfConfig::get('sf_lib_dir')];
 
-    $tokens = array_merge(isset($this->tokens) ? $this->tokens : array(), $tokens);
+    $tokens = array_merge($this->tokens ?? [], $tokens);
 
     $this->getFilesystem()->replaceTokens(sfFinder::type('file')->prune('vendor')->in($dirs), '##', '##', $tokens);
   }
@@ -300,8 +287,7 @@ abstract class sfBaseTask extends sfCommandApplicationTask
    */
   protected function reloadTasks()
   {
-    if (null === $this->commandApplication)
-    {
+    if (null === $this->commandApplication) {
       return;
     }
 
@@ -311,12 +297,10 @@ abstract class sfBaseTask extends sfCommandApplicationTask
     $this->commandApplication->loadTasks($this->configuration);
 
     $disabledPluginsRegex = sprintf('#^(%s)#', implode('|', array_diff($this->configuration->getAllPluginPaths(), $this->configuration->getPluginPaths())));
-    $tasks = array();
-    foreach (get_declared_classes() as $class)
-    {
+    $tasks                = [];
+    foreach (get_declared_classes() as $class) {
       $r = new Reflectionclass($class);
-      if ($r->isSubclassOf('sfTask') && !$r->isAbstract() && !preg_match($disabledPluginsRegex, $r->getFileName()))
-      {
+      if ($r->isSubclassOf('sfTask') && ! $r->isAbstract() && ! preg_match($disabledPluginsRegex, $r->getFileName())) {
         $tasks[] = new $class($this->dispatcher, $this->formatter);
       }
     }
@@ -327,12 +311,11 @@ abstract class sfBaseTask extends sfCommandApplicationTask
   /**
    * @see sfCommandApplicationTask
    */
-  protected function createTask($name)
+  protected function createTask($name): sfCommandApplicationTask
   {
     $task = parent::createTask($name);
 
-    if ($task instanceof sfBaseTask)
-    {
+    if ($task instanceof sfBaseTask) {
       $task->setConfiguration($this->configuration);
     }
 
@@ -342,38 +325,33 @@ abstract class sfBaseTask extends sfCommandApplicationTask
   /**
    * Show status of task
    *
-   * @param integer $done
-   * @param integer $total
-   * @param integer $size
+   * @param int $done
+   * @param int $total
+   * @param int $size
    * @return void
    */
-  protected function showStatus($done, $total, $size = 30)
+  protected function showStatus(int $done, int $total, int $size = 30): void
   {
     // if we go over our bound, just ignore it
-    if ($done > $total)
-    {
+    if ($done > $total) {
       $this->statusStartTime = null;
       return;
     }
 
-    if (null === $this->statusStartTime)
-    {
+    if (null === $this->statusStartTime) {
       $this->statusStartTime = time();
     }
 
-    $now = time();
+    $now  = time();
     $perc = (double)($done / $total);
-    $bar = floor($perc * $size);
+    $bar  = floor($perc * $size);
 
     $statusBar = "\r[";
     $statusBar .= str_repeat('=', $bar);
-    if ($bar < $size)
-    {
+    if ($bar < $size) {
       $statusBar .= '>';
       $statusBar .= str_repeat(' ', $size - $bar);
-    }
-    else
-    {
+    } else {
       $statusBar .= "=";
     }
 
@@ -383,68 +361,58 @@ abstract class sfBaseTask extends sfCommandApplicationTask
 
     $rate = $done ? ($now - $this->statusStartTime) / $done : 0;
     $left = $total - $done;
-    $eta = round($rate * $left, 2);
+    $eta  = round($rate * $left, 2);
 
     $elapsed = $now - $this->statusStartTime;
 
-    $eta = $this->convertTime($eta);
+    $eta     = $this->convertTime($eta);
     $elapsed = $this->convertTime($elapsed);
 
     $memory = memory_get_usage(true);
-    if ($memory>1024*1024*1024*10)
-    {
-      $memory = sprintf('%.2fGB', $memory/1024/1024/1024);
-    }
-    elseif ($memory>1024*1024*10)
-    {
-      $memory = sprintf('%.2fMB', $memory/1024/1024);
-    }
-    elseif ($memory>1024*10)
-    {
-      $memory = sprintf('%.2fkB', $memory/1024);
-    }
-    else
-    {
+    if ($memory > 1024 * 1024 * 1024 * 10) {
+      $memory = sprintf('%.2fGB', $memory / 1024 / 1024 / 1024);
+    } elseif ($memory > 1024 * 1024 * 10) {
+      $memory = sprintf('%.2fMB', $memory / 1024 / 1024);
+    } elseif ($memory > 1024 * 10) {
+      $memory = sprintf('%.2fkB', $memory / 1024);
+    } else {
       $memory = sprintf('%.2fB', $memory);
     }
 
-    $statusBar .= ' [ remaining: '.$eta.' | elapsed: '.$elapsed.' ] (memory: '.$memory.')     ';
+    $statusBar .= ' [ remaining: ' . $eta . ' | elapsed: ' . $elapsed . ' ] (memory: ' . $memory . ')     ';
 
     echo $statusBar;
 
     // when done, send a newline
-    if ($done == $total)
-    {
+    if ($done == $total) {
       $this->statusStartTime = null;
       echo "\n";
     }
   }
 
   /**
-   * Convert time into humain format
+   * Convert time into human format
    *
-   * @param integer $time
+   * @param int $time
    * @return string
    */
-  private function convertTime($time)
+  private function convertTime(int $time): string
   {
     $string = '';
 
-    if ($time > 3600)
-    {
-      $h = (int) abs($time / 3600);
-      $time -= ($h * 3600);
-      $string .= $h. ' h ';
+    if ($time > 3600) {
+      $h      = (int)abs($time / 3600);
+      $time   -= ($h * 3600);
+      $string .= $h . ' h ';
     }
 
-    if ($time > 60)
-    {
-      $m = (int) abs($time / 60);
-      $time -= ($m * 60);
-      $string .= $m. ' min ';
+    if ($time > 60) {
+      $m      = (int)abs($time / 60);
+      $time   -= ($m * 60);
+      $string .= $m . ' min ';
     }
 
-    $string .= (int) $time.' sec';
+    $string .= (int)$time . ' sec';
 
     return $string;
   }

--- a/lib/task/sfFilesystem.class.php
+++ b/lib/task/sfFilesystem.class.php
@@ -18,21 +18,24 @@
  */
 class sfFilesystem
 {
-  /** @var \sfEventDispatcher|null */
-  protected $dispatcher = null;
-  /** @var \sfFormatter|null */
-  protected $formatter  = null;
+  /**
+   * @var sfEventDispatcher|null
+   */
+  protected sfEventDispatcher | null $dispatcher;
 
   /**
-   * Constructor.
-   *
-   * @param sfEventDispatcher $dispatcher  An sfEventDispatcher instance
-   * @param sfFormatter       $formatter   An sfFormatter instance
+   * @var sfFormatter|null
+   */
+  protected sfFormatter | null $formatter;
+
+  /**
+   * @param sfEventDispatcher|null $dispatcher  An sfEventDispatcher instance
+   * @param sfFormatter|null       $formatter   An sfFormatter instance
    */
   public function __construct(sfEventDispatcher $dispatcher = null, sfFormatter $formatter = null)
   {
     $this->dispatcher = $dispatcher;
-    $this->formatter = $formatter;
+    $this->formatter  = $formatter;
   }
 
   /**
@@ -50,29 +53,23 @@ class sfFilesystem
    *
    * @return bool
    */
-  public function copy($originFile, $targetFile, $options = array())
+  public function copy(string $originFile, string $targetFile, array $options = []): bool
   {
-    if (!array_key_exists('override', $options))
-    {
-      $options['override'] = false;
-    }
+    $override = $options['override'] ?? false;
 
     // we create target_dir if needed
-    if (!is_dir(dirname($targetFile)))
-    {
+    if ( ! is_dir(dirname($targetFile))) {
       $this->mkdirs(dirname($targetFile));
     }
 
     $mostRecent = false;
-    if (file_exists($targetFile))
-    {
-      $statTarget = stat($targetFile);
+    if (file_exists($targetFile)) {
+      $statTarget  = stat($targetFile);
       $stat_origin = stat($originFile);
-      $mostRecent = ($stat_origin['mtime'] > $statTarget['mtime']);
+      $mostRecent  = ($stat_origin['mtime'] > $statTarget['mtime']);
     }
 
-    if ($options['override'] || !file_exists($targetFile) || $mostRecent)
-    {
+    if ($override || ! file_exists($targetFile) || $mostRecent) {
       $this->logSection('file+', $targetFile);
 
       return copy($originFile, $targetFile);
@@ -84,15 +81,14 @@ class sfFilesystem
   /**
    * Creates a directory recursively.
    *
-   * @param  string $path  The directory path
-   * @param  int    $mode  The directory mode
+   * @param string $path  The directory path
+   * @param int    $mode  The directory mode
    *
    * @return bool true if the directory has been created, false otherwise
    */
-  public function mkdirs($path, $mode = 0777)
+  public function mkdirs(string $path, int $mode = 0777): bool
   {
-    if (is_dir($path))
-    {
+    if (is_dir($path)) {
       return true;
     }
 
@@ -104,17 +100,11 @@ class sfFilesystem
   /**
    * Creates empty files.
    *
-   * @param mixed $files  The filename, or an array of filenames
+   * @param string[]|string $files  The filename, or an array of filenames
    */
-  public function touch($files)
+  public function touch(array | string $files): void
   {
-    if (!is_array($files))
-    {
-      $files = array($files);
-    }
-
-    foreach ($files as $file)
-    {
+    foreach ((array)$files as $file) {
       $this->logSection('file+', $file);
 
       touch($file);
@@ -124,28 +114,19 @@ class sfFilesystem
   /**
    * Removes files or directories.
    *
-   * @param mixed $files  A filename or an array of files to remove
+   * @param string[]|string $files  A filename or an array of files to remove
    */
-  public function remove($files)
+  public function remove(array | string $files): void
   {
-    if (!is_array($files))
-    {
-      $files = array($files);
-    }
-
-    $files = array_reverse($files);
-    foreach ($files as $file)
-    {
-      if (is_dir($file) && !is_link($file))
-      {
+    foreach (array_reverse((array)$files) as $file) {
+      if (is_dir($file) && ! is_link($file)) {
         $this->logSection('dir-', $file);
-
         rmdir($file);
-      }
-      else
-      {
-        $this->logSection(is_link($file) ? 'link-' : 'file-', $file);
-
+      } elseif (is_link($file)) {
+        $this->logSection('link-', $file);
+        unlink($file);
+      } else {
+        $this->logSection('file-', $file);
         unlink($file);
       }
     }
@@ -154,22 +135,16 @@ class sfFilesystem
   /**
    * Change mode for an array of files or directories.
    *
-   * @param array   $files  An array of files or directories
-   * @param integer $mode   The new mode
-   * @param integer $umask  The mode mask (octal)
+   * @param string[]|string $files  An array of files or directories
+   * @param int             $mode   The new mode
+   * @param int             $umask  The mode mask (octal)
    */
-  public function chmod($files, $mode, $umask = 0000)
+  public function chmod(array | string $files, int $mode, int $umask = 0000): void
   {
     $currentUmask = umask();
     umask($umask);
 
-    if (!is_array($files))
-    {
-      $files = array($files);
-    }
-
-    foreach ($files as $file)
-    {
+    foreach ((array)$files as $file) {
       $this->logSection(sprintf('chmod %o', $mode), $file);
       chmod($file, $mode);
     }
@@ -187,15 +162,14 @@ class sfFilesystem
    *
    * @throws sfException
    */
-  public function rename($origin, $target)
+  public function rename(string $origin, string $target): bool
   {
     // we check that target does not exist
-    if (is_readable($target))
-    {
+    if (is_readable($target)) {
       throw new sfException(sprintf('Cannot rename because the target "%s" already exist.', $target));
     }
 
-    $this->logSection('rename', $origin.' > '.$target);
+    $this->logSection('rename', "{$origin} > {$target}");
 
     return rename($origin, $target);
   }
@@ -207,30 +181,23 @@ class sfFilesystem
    * @param string $targetDir      The symbolic link name
    * @param bool   $copyOnWindows  Whether to copy files if on windows
    */
-  public function symlink($originDir, $targetDir, $copyOnWindows = false)
+  public function symlink(string $originDir, string $targetDir, bool $copyOnWindows = false): void
   {
-    if ('\\' == DIRECTORY_SEPARATOR && $copyOnWindows)
-    {
-      $finder = sfFinder::type('any');
-      $this->mirror($originDir, $targetDir, $finder);
+    if ('\\' == DIRECTORY_SEPARATOR && $copyOnWindows) {
+      $this->mirror($originDir, $targetDir, sfFinder::type('any'));
       return;
     }
 
     $ok = false;
-    if (is_link($targetDir))
-    {
-      if (readlink($targetDir) != $originDir)
-      {
+    if (is_link($targetDir)) {
+      if (readlink($targetDir) != $originDir) {
         unlink($targetDir);
-      }
-      else
-      {
+      } else {
         $ok = true;
       }
     }
 
-    if (!$ok)
-    {
+    if ( ! $ok) {
       $this->logSection('link+', $targetDir);
       symlink($originDir, $targetDir);
     }
@@ -243,10 +210,9 @@ class sfFilesystem
    * @param string $targetDir      The symbolic link name
    * @param bool   $copyOnWindows  Whether to copy files if on windows
    */
-  public function relativeSymlink($originDir, $targetDir, $copyOnWindows = false)
+  public function relativeSymlink(string $originDir, string $targetDir, bool $copyOnWindows = false): void
   {
-    if ('\\' != DIRECTORY_SEPARATOR || !$copyOnWindows)
-    {
+    if ('\\' != DIRECTORY_SEPARATOR || ! $copyOnWindows) {
       $originDir = $this->calculateRelativeDir($targetDir, $originDir);
     }
 
@@ -263,24 +229,16 @@ class sfFilesystem
    *
    * @throws sfException
    */
-  public function mirror($originDir, $targetDir, $finder, $options = array())
+  public function mirror(string $originDir, string $targetDir, sfFinder $finder, array $options = []): void
   {
-    foreach ($finder->relative()->in($originDir) as $file)
-    {
-      if (is_dir($originDir.DIRECTORY_SEPARATOR.$file))
-      {
-        $this->mkdirs($targetDir.DIRECTORY_SEPARATOR.$file);
-      }
-      else if (is_file($originDir.DIRECTORY_SEPARATOR.$file))
-      {
-        $this->copy($originDir.DIRECTORY_SEPARATOR.$file, $targetDir.DIRECTORY_SEPARATOR.$file, $options);
-      }
-      else if (is_link($originDir.DIRECTORY_SEPARATOR.$file))
-      {
-        $this->symlink($originDir.DIRECTORY_SEPARATOR.$file, $targetDir.DIRECTORY_SEPARATOR.$file);
-      }
-      else
-      {
+    foreach ($finder->relative()->in($originDir) as $file) {
+      if (is_dir($originDir . DIRECTORY_SEPARATOR . $file)) {
+        $this->mkdirs($targetDir . DIRECTORY_SEPARATOR . $file);
+      } elseif (is_file($originDir . DIRECTORY_SEPARATOR . $file)) {
+        $this->copy($originDir . DIRECTORY_SEPARATOR . $file, $targetDir . DIRECTORY_SEPARATOR . $file, $options);
+      } elseif (is_link($originDir . DIRECTORY_SEPARATOR . $file)) {
+        $this->symlink($originDir . DIRECTORY_SEPARATOR . $file, $targetDir . DIRECTORY_SEPARATOR . $file);
+      } else {
         throw new sfException(sprintf('Unable to guess "%s" file type.', $file));
       }
     }
@@ -289,24 +247,23 @@ class sfFilesystem
   /**
    * Executes a shell command.
    *
-   * @param string $cmd            The command to execute on the shell
-   * @param array  $stdoutCallback A callback for stdout output
-   * @param array  $stderrCallback A callback for stderr output
+   * @param string        $cmd             The command to execute on the shell
+   * @param callable|null $stdoutCallback  A callback for stdout output
+   * @param callable|null $stderrCallback  A callback for stderr output
    *
-   * @return array An array composed of the content output and the error output
+   * @return string[] An array composed of the content output and the error output (exactly two items)
    */
-  public function execute($cmd, $stdoutCallback = null, $stderrCallback = null)
+  public function execute(string $cmd, callable $stdoutCallback = null, callable $stderrCallback = null): array
   {
     $this->logSection('exec ', $cmd);
 
-    $descriptorspec = array(
-      1 => array('pipe', 'w'), // stdout
-      2 => array('pipe', 'w'), // stderr
-    );
+    $descriptorSpec = [
+      1 => ['pipe', 'w'], // stdout
+      2 => ['pipe', 'w'], // stderr
+    ];
 
-    $process = proc_open($cmd, $descriptorspec, $pipes);
-    if (!is_resource($process))
-    {
+    $process = proc_open($cmd, $descriptorSpec, $pipes);
+    if ( ! is_resource($process)) {
       throw new RuntimeException('Unable to execute the command.');
     }
 
@@ -314,31 +271,23 @@ class sfFilesystem
     stream_set_blocking($pipes[2], false);
 
     $output = '';
-    $err = '';
-    while (!feof($pipes[1]) || !feof($pipes[2]))
-    {
-      foreach ($pipes as $key => $pipe)
-      {
-        if (!$line = fread($pipe, 128))
-        {
+    $err    = '';
+    while ( ! feof($pipes[1]) || ! feof($pipes[2])) {
+      foreach ($pipes as $key => $pipe) {
+        if ( ! $line = fread($pipe, 128)) {
           continue;
         }
 
-        if (1 == $key)
-        {
+        if (1 == $key) {
           // stdout
           $output .= $line;
-          if ($stdoutCallback)
-          {
+          if ($stdoutCallback) {
             call_user_func($stdoutCallback, $line);
           }
-        }
-        else
-        {
+        } else {
           // stderr
           $err .= $line;
-          if ($stderrCallback)
-          {
+          if ($stderrCallback) {
             call_user_func($stderrCallback, $line);
           }
         }
@@ -350,35 +299,27 @@ class sfFilesystem
     fclose($pipes[1]);
     fclose($pipes[2]);
 
-    if (($return = proc_close($process)) > 0)
-    {
+    if (($return = proc_close($process)) > 0) {
       throw new RuntimeException('Problem executing command.', $return);
     }
 
-    return array($output, $err);
+    return [$output, $err];
   }
 
   /**
    * Replaces tokens in an array of files.
    *
-   * @param array  $files       An array of filenames
-   * @param string $beginToken  The begin token delimiter
-   * @param string $endToken    The end token delimiter
-   * @param array  $tokens      An array of token/value pairs
+   * @param string[]|string      $files       An array of filenames
+   * @param string               $beginToken  The begin token delimiter
+   * @param string               $endToken    The end token delimiter
+   * @param array<string,string> $tokens      An array of token/value pairs
    */
-  public function replaceTokens($files, $beginToken, $endToken, $tokens)
+  public function replaceTokens(array | string $files, string $beginToken, string $endToken, array $tokens): void
   {
-    if (!is_array($files))
-    {
-      $files = array($files);
-    }
-
-    foreach ($files as $file)
-    {
+    foreach ((array)$files as $file) {
       $content = file_get_contents($file);
-      foreach ($tokens as $key => $value)
-      {
-        $content = str_replace($beginToken.$key.$endToken, $value, $content, $count);
+      foreach ($tokens as $key => $value) {
+        $content = str_replace($beginToken . $key . $endToken, $value, $content, $count);
       }
 
       $this->logSection('tokens', $file);
@@ -390,20 +331,19 @@ class sfFilesystem
   /**
    * Logs a message in a section.
    *
-   * @param string $section  The section name
-   * @param string $message  The message
-   * @param int    $size     The maximum size of a line
+   * @param string   $section  The section name
+   * @param string   $message  The message
+   * @param int|null $size     The maximum size of a line
    */
-  protected function logSection($section, $message, $size = null)
+  protected function logSection(string $section, string $message, int | null $size = null): void
   {
-    if (!$this->dispatcher)
-    {
+    if ( ! $this->dispatcher) {
       return;
     }
 
-    $message = $this->formatter ? $this->formatter->formatSection($section, $message, $size) : $section.' '.$message."\n";
+    $message = $this->formatter ? $this->formatter->formatSection($section, $message, $size) : $section . ' ' . $message . "\n";
 
-    $this->dispatcher->notify(new sfEvent($this, 'command.log', array($message)));
+    $this->dispatcher->notify(new sfEvent($this, 'command.log', [$message]));
   }
 
   /**
@@ -411,46 +351,39 @@ class sfFilesystem
    *
    * If the paths share no common path the absolute target dir is returned.
    *
-   * @param string $from The directory from which to calculate the relative path
-   * @param string $to   The target directory
+   * @param string $from  The directory from which to calculate the relative path
+   * @param string $to    The target directory
    *
    * @return string
    */
-  protected function calculateRelativeDir($from, $to)
+  protected function calculateRelativeDir(string $from, string $to): string
   {
     $from = $this->canonicalizePath($from);
-    $to = $this->canonicalizePath($to);
+    $to   = $this->canonicalizePath($to);
 
-    $commonLength = 0;
+    $commonLength  = 0;
     $minPathLength = min(strlen($from), strlen($to));
 
     // count how many chars the strings have in common
-    for ($i = 0; $i < $minPathLength; $i++)
-    {
-      if ($from[$i] != $to[$i])
-      {
+    for ($i = 0; $i < $minPathLength; $i++) {
+      if ($from[$i] != $to[$i]) {
         break;
       }
 
-      if (DIRECTORY_SEPARATOR == $from[$i])
-      {
+      if (DIRECTORY_SEPARATOR == $from[$i]) {
         $commonLength = $i + 1;
       }
     }
 
-    if ($commonLength)
-    {
-      if (extension_loaded('mbstring'))
-      {
+    if ($commonLength) {
+      if (extension_loaded('mbstring')) {
         $levelUp = mb_substr_count(mb_strcut($from, $commonLength), DIRECTORY_SEPARATOR);
-      }
-      else
-      {
+      } else {
         $levelUp = substr_count($from, DIRECTORY_SEPARATOR, $commonLength);
       }
 
       // up that many level
-      $relativeDir = str_repeat('..'.DIRECTORY_SEPARATOR, $levelUp);
+      $relativeDir = str_repeat('..' . DIRECTORY_SEPARATOR, $levelUp);
 
       // down the remaining $to path
       $relativeDir .= substr($to, $commonLength);
@@ -462,36 +395,30 @@ class sfFilesystem
   }
 
   /**
-   * @param string $path A filesystem path
+   * @param string $path  A filesystem path
    *
    * @return string
    */
-  protected function canonicalizePath($path)
+  protected function canonicalizePath(string $path): string
   {
-    if (empty($path))
-    {
+    if (empty($path)) {
       return '';
     }
 
-    $out = array();
-    foreach (explode(DIRECTORY_SEPARATOR, $path) as $i => $fold)
-    {
-      if ('' == $fold || '.' == $fold)
-      {
+    $out = [];
+    foreach (explode(DIRECTORY_SEPARATOR, $path) as $i => $fold) {
+      if ('' == $fold || '.' == $fold) {
         continue;
       }
 
-      if ('..' == $fold && $i > 0 && '..' != end($out))
-      {
+      if ('..' == $fold && $i > 0 && '..' != end($out)) {
         array_pop($out);
-      }
-      else
-      {
+      } else {
         $out[] = $fold;
       }
     }
 
-    $result  = DIRECTORY_SEPARATOR == $path[0] ? DIRECTORY_SEPARATOR : '';
+    $result = DIRECTORY_SEPARATOR == $path[0] ? DIRECTORY_SEPARATOR : '';
     $result .= implode(DIRECTORY_SEPARATOR, $out);
     $result .= DIRECTORY_SEPARATOR == $path[strlen($path) - 1] ? DIRECTORY_SEPARATOR : '';
 

--- a/lib/task/test/sfTestAllTask.class.php
+++ b/lib/task/test/sfTestAllTask.class.php
@@ -21,90 +21,84 @@ class sfTestAllTask extends sfTestBaseTask
   /**
    * @see sfTask
    */
-  protected function configure()
+  protected function configure(): void
   {
-    $this->addOptions(array(
+    $this->addOptions([
       new sfCommandOption('only-failed', 'f', sfCommandOption::PARAMETER_NONE, 'Only run tests that failed last time'),
       new sfCommandOption('full-output', 'o', sfCommandOption::PARAMETER_NONE, 'Display full path for the test'),
       new sfCommandOption('xml', null, sfCommandOption::PARAMETER_REQUIRED, 'The file name for the JUnit compatible XML log file'),
-    ));
+    ]);
 
-    $this->namespace = 'test';
-    $this->name = 'all';
+    $this->namespace        = 'test';
+    $this->name             = 'all';
     $this->briefDescription = 'Launches all tests';
 
     $this->detailedDescription = <<<EOF
-The [test:all|INFO] task launches all unit and functional tests:
+      The [test:all|INFO] task launches all unit and functional tests:
 
-  [./symfony test:all|INFO]
+        [./symfony test:all|INFO]
 
-The task launches all tests found in [test/|COMMENT].
+      The task launches all tests found in [test/|COMMENT].
 
-If some tests fail, you can use the [--trace|COMMENT] option to have more
-information about the failures:
+      If some tests fail, you can use the [--trace|COMMENT] option to have more
+      information about the failures:
 
-  [./symfony test:all -t|INFO]
+        [./symfony test:all -t|INFO]
 
-Or you can also try to fix the problem by launching them by hand or with the
-[test:unit|COMMENT] and [test:functional|COMMENT] task.
+      Or you can also try to fix the problem by launching them by hand or with the
+      [test:unit|COMMENT] and [test:functional|COMMENT] task.
 
-Use the [--only-failed|COMMENT] option to force the task to only execute tests
-that failed during the previous run:
+      Use the [--only-failed|COMMENT] option to force the task to only execute tests
+      that failed during the previous run:
 
-  [./symfony test:all --only-failed|INFO]
+        [./symfony test:all --only-failed|INFO]
 
-Here is how it works: the first time, all tests are run as usual. But for
-subsequent test runs, only tests that failed last time are executed. As you
-fix your code, some tests will pass, and will be removed from subsequent runs.
-When all tests pass again, the full test suite is run... you can then rinse
-and repeat.
+      Here is how it works: the first time, all tests are run as usual. But for
+      subsequent test runs, only tests that failed last time are executed. As you
+      fix your code, some tests will pass, and will be removed from subsequent runs.
+      When all tests pass again, the full test suite is run... you can then rinse
+      and repeat.
 
-The task can output a JUnit compatible XML log file with the [--xml|COMMENT]
-options:
+      The task can output a JUnit compatible XML log file with the [--xml|COMMENT]
+      options:
 
-  [./symfony test:all --xml=log.xml|INFO]
+        [./symfony test:all --xml=log.xml|INFO]
 
-If you want to display full path for each test in output, add the option
-[--full-output|COMMENT] or [-o|COMMENT] :
+      If you want to display full path for each test in output, add the option
+      [--full-output|COMMENT] or [-o|COMMENT] :
 
-  [./symfony test:all --full-output|INFO]
-EOF;
+        [./symfony test:all --full-output|INFO]
+      EOF;
   }
 
   /**
    * @see sfTask
    */
-  protected function execute($arguments = array(), $options = array())
+  protected function execute(array $arguments = [], array $options = []): int
   {
-    require_once __DIR__.'/sfLimeHarness.class.php';
+    require_once __DIR__ . '/sfLimeHarness.class.php';
 
-    $h = new sfLimeHarness(array(
+    $h              = new sfLimeHarness([
       'force_colors' => isset($options['color']) && $options['color'],
       'verbose'      => isset($options['trace']) && $options['trace'],
-    ));
+    ]);
     $h->full_output = $options['full-output'] ? true : false;
-    $h->addPlugins(array_map(array($this->configuration, 'getPluginConfiguration'), $this->configuration->getPlugins()));
+    $h->addPlugins(array_map([$this->configuration, 'getPluginConfiguration'], $this->configuration->getPlugins()));
     $h->base_dir = sfConfig::get('sf_test_dir');
 
-    $status = false;
-    $statusFile = sfConfig::get('sf_cache_dir').'/.test_all_status';
-    if ($options['only-failed'])
-    {
-      if (file_exists($statusFile))
-      {
+    $status     = false;
+    $statusFile = sfConfig::get('sf_cache_dir') . '/.test_all_status';
+    if ($options['only-failed']) {
+      if (file_exists($statusFile)) {
         $status = unserialize(file_get_contents($statusFile));
       }
     }
 
-    if ($status)
-    {
-      foreach ($status as $file)
-      {
+    if ($status) {
+      foreach ($status as $file) {
         $h->register($file);
       }
-    }
-    else
-    {
+    } else {
       // filter and register all tests
       $finder = sfFinder::type('file')->follow_link()->name('*Test.php');
       $h->register($finder->in($h->base_dir));
@@ -114,8 +108,7 @@ EOF;
 
     file_put_contents($statusFile, serialize($h->get_failed_files()));
 
-    if ($options['xml'])
-    {
+    if ($options['xml']) {
       file_put_contents($options['xml'], $h->to_xml());
     }
 

--- a/lib/task/test/sfTestBaseTask.class.php
+++ b/lib/task/test/sfTestBaseTask.class.php
@@ -24,20 +24,17 @@ abstract class sfTestBaseTask extends sfBaseTask
    * The plugin directory must exist and have at least one file or folder
    * inside for that plugin to exist.
    *
-   * @param   string  $plugin
+   * @param string $plugin
    *
    * @return  boolean True if the plugin exist, false otherwise
    */
-  protected function checkPluginExists($plugin)
+  protected function checkPluginExists(string $plugin): bool
   {
-    try
-    {
+    try {
       sfApplicationConfiguration::getActive()->getPluginConfiguration($plugin);
 
       return true;
-    }
-    catch (Exception $e)
-    {
+    } catch (Exception $e) {
       return false;
     }
   }

--- a/lib/task/test/sfTestFunctionalTask.class.php
+++ b/lib/task/test/sfTestFunctionalTask.class.php
@@ -21,89 +21,81 @@ class sfTestFunctionalTask extends sfTestBaseTask
   /**
    * @see sfTask
    */
-  protected function configure()
+  protected function configure(): void
   {
-    $this->addArguments(array(
+    $this->addArguments([
       new sfCommandArgument('application', sfCommandArgument::REQUIRED, 'The application name'),
       new sfCommandArgument('controller', sfCommandArgument::OPTIONAL | sfCommandArgument::IS_ARRAY, 'The controller name'),
-    ));
+    ]);
 
-    $this->addOptions(array(
+    $this->addOptions([
       new sfCommandOption('xml', null, sfCommandOption::PARAMETER_REQUIRED, 'The file name for the JUnit compatible XML log file'),
-    ));
+    ]);
 
-    $this->namespace = 'test';
-    $this->name = 'functional';
+    $this->namespace        = 'test';
+    $this->name             = 'functional';
     $this->briefDescription = 'Launches functional tests';
 
     $this->detailedDescription = <<<EOF
-The [test:functional|INFO] task launches functional tests for a
-given application:
+      The [test:functional|INFO] task launches functional tests for a
+      given application:
 
-  [./symfony test:functional frontend|INFO]
+        [./symfony test:functional frontend|INFO]
 
-The task launches all tests found in [test/functional/%application%|COMMENT].
+      The task launches all tests found in [test/functional/%application%|COMMENT].
 
-If some tests fail, you can use the [--trace|COMMENT] option to have more
-information about the failures:
+      If some tests fail, you can use the [--trace|COMMENT] option to have more
+      information about the failures:
 
-  [./symfony test:functional frontend -t|INFO]
+        [./symfony test:functional frontend -t|INFO]
 
-You can launch all functional tests for a specific controller by
-giving a controller name:
+      You can launch all functional tests for a specific controller by
+      giving a controller name:
 
-  [./symfony test:functional frontend article|INFO]
+        [./symfony test:functional frontend article|INFO]
 
-You can also launch all functional tests for several controllers:
+      You can also launch all functional tests for several controllers:
 
-  [./symfony test:functional frontend article comment|INFO]
+        [./symfony test:functional frontend article comment|INFO]
 
-The task can output a JUnit compatible XML log file with the [--xml|COMMENT]
-options:
+      The task can output a JUnit compatible XML log file with the [--xml|COMMENT]
+      options:
 
-  [./symfony test:functional --xml=log.xml|INFO]
-EOF;
+        [./symfony test:functional --xml=log.xml|INFO]
+      EOF;
   }
 
   /**
    * @see sfTask
    */
-  protected function execute($arguments = array(), $options = array())
+  protected function execute(array $arguments = [], array $options = []): int
   {
     $app = $arguments['application'];
 
-    if (count($arguments['controller']))
-    {
-      $files = array();
+    if (count($arguments['controller'])) {
+      $files = [];
 
-      foreach ($arguments['controller'] as $controller)
-      {
-        $finder = sfFinder::type('file')->follow_link()->name(basename($controller).'Test.php');
-        $files = array_merge($files, $finder->in(sfConfig::get('sf_test_dir').'/functional/'.$app.'/'.dirname($controller)));
+      foreach ($arguments['controller'] as $controller) {
+        $finder = sfFinder::type('file')->follow_link()->name(basename($controller) . 'Test.php');
+        $files  = array_merge($files, $finder->in(sfConfig::get('sf_test_dir') . '/functional/' . $app . '/' . dirname($controller)));
       }
 
-      if(count($files) > 0)
-      {
-        foreach ($files as $file)
-        {
+      if (count($files) > 0) {
+        foreach ($files as $file) {
           include($file);
         }
-      }
-      else
-      {
+      } else {
         $this->logSection('functional', 'no controller found', null, 'ERROR');
       }
-    }
-    else
-    {
-      require_once __DIR__.'/sfLimeHarness.class.php';
+    } else {
+      require_once __DIR__ . '/sfLimeHarness.class.php';
 
-      $h = new sfLimeHarness(array(
+      $h = new sfLimeHarness([
         'force_colors' => isset($options['color']) && $options['color'],
         'verbose'      => isset($options['trace']) && $options['trace'],
-      ));
-      $h->addPlugins(array_map(array($this->configuration, 'getPluginConfiguration'), $this->configuration->getPlugins()));
-      $h->base_dir = sfConfig::get('sf_test_dir').'/functional/'.$app;
+      ]);
+      $h->addPlugins(array_map([$this->configuration, 'getPluginConfiguration'], $this->configuration->getPlugins()));
+      $h->base_dir = sfConfig::get('sf_test_dir') . '/functional/' . $app;
 
       // filter and register functional tests
       $finder = sfFinder::type('file')->follow_link()->name('*Test.php');
@@ -111,8 +103,7 @@ EOF;
 
       $ret = $h->run() ? 0 : 1;
 
-      if ($options['xml'])
-      {
+      if ($options['xml']) {
         file_put_contents($options['xml'], $h->to_xml());
       }
 

--- a/lib/task/test/sfTestPluginTask.class.php
+++ b/lib/task/test/sfTestPluginTask.class.php
@@ -21,55 +21,54 @@ class sfTestPluginTask extends sfTestBaseTask
   /**
    * @see sfTask
    */
-  protected function configure()
+  protected function configure(): void
   {
-    $this->addArguments(array(
+    $this->addArguments([
       new sfCommandArgument('plugin', sfCommandArgument::REQUIRED, 'The plugin name'),
-    ));
+    ]);
 
-    $this->addOptions(array(
+    $this->addOptions([
       new sfCommandOption('only', null, sfCommandOption::PARAMETER_REQUIRED, 'Only run "unit" or "functional" tests'),
-    ));
+    ]);
 
     $this->namespace = 'test';
-    $this->name = 'plugin';
+    $this->name      = 'plugin';
 
     $this->briefDescription = 'Launches a plugin test suite';
 
     $this->detailedDescription = <<<EOF
-The [test:plugin|INFO] task launches a plugin's test suite:
+      The [test:plugin|INFO] task launches a plugin's test suite:
 
-  [./symfony test:plugin sfExamplePlugin|INFO]
+        [./symfony test:plugin sfExamplePlugin|INFO]
 
-You can specify only unit or functional tests with the [--only|COMMENT] option:
+      You can specify only unit or functional tests with the [--only|COMMENT] option:
 
-  [./symfony test:plugin sfExamplePlugin --only=unit|INFO]
-EOF;
+        [./symfony test:plugin sfExamplePlugin --only=unit|INFO]
+      EOF;
   }
 
   /**
    * @see sfTask
    */
-  protected function execute($arguments = array(), $options = array())
+  protected function execute(array $arguments = [], array $options = []): int
   {
-    if (false === $this->checkPluginExists($arguments['plugin']))
-    {
+    if (false === $this->checkPluginExists($arguments['plugin'])) {
       throw new sfCommandException(sprintf('The plugin "%s" does not exists', $arguments['plugin']));
     }
 
-    if ($options['only'] && !in_array($options['only'], array('unit', 'functional')))
-    {
+    if ($options['only'] && ! in_array($options['only'], ['unit', 'functional'])) {
       throw new sfCommandException(sprintf('The --only option must be either "unit" or "functional" ("%s" given)', $options['only']));
     }
 
-    require_once sfConfig::get('sf_symfony_lib_dir').'/vendor/lime/lime.php';
+    require_once sfConfig::get('sf_symfony_lib_dir') . '/vendor/lime/lime.php';
 
     $h = new lime_harness(new lime_output_color());
-    $h->base_dir = sfConfig::get('sf_plugins_dir').'/'.$arguments['plugin'].'/test/'.$options['only'];
+
+    $h->base_dir = sfConfig::get('sf_plugins_dir') . '/' . $arguments['plugin'] . '/test/' . $options['only'];
 
     $finder = sfFinder::type('file')->follow_link()->name('*Test.php');
     $h->register($finder->in($h->base_dir));
 
-    $h->run();
+    return $h->run() ? 0 : 1;
   }
 }

--- a/lib/task/test/sfTestUnitTask.class.php
+++ b/lib/task/test/sfTestUnitTask.class.php
@@ -21,85 +21,77 @@ class sfTestUnitTask extends sfTestBaseTask
   /**
    * @see sfTask
    */
-  protected function configure()
+  protected function configure(): void
   {
-    $this->addArguments(array(
+    $this->addArguments([
       new sfCommandArgument('name', sfCommandArgument::OPTIONAL | sfCommandArgument::IS_ARRAY, 'The test name'),
-    ));
+    ]);
 
-    $this->addOptions(array(
+    $this->addOptions([
       new sfCommandOption('xml', null, sfCommandOption::PARAMETER_REQUIRED, 'The file name for the JUnit compatible XML log file'),
-    ));
+    ]);
 
-    $this->namespace = 'test';
-    $this->name = 'unit';
+    $this->namespace        = 'test';
+    $this->name             = 'unit';
     $this->briefDescription = 'Launches unit tests';
 
     $this->detailedDescription = <<<EOF
-The [test:unit|INFO] task launches unit tests:
+      The [test:unit|INFO] task launches unit tests:
 
-  [./symfony test:unit|INFO]
+        [./symfony test:unit|INFO]
 
-The task launches all tests found in [test/unit|COMMENT].
+      The task launches all tests found in [test/unit|COMMENT].
 
-If some tests fail, you can use the [--trace|COMMENT] option to have more
-information about the failures:
+      If some tests fail, you can use the [--trace|COMMENT] option to have more
+      information about the failures:
 
-  [./symfony test:unit -t|INFO]
+        [./symfony test:unit -t|INFO]
 
-You can launch unit tests for a specific name:
+      You can launch unit tests for a specific name:
 
-  [./symfony test:unit strtolower|INFO]
+        [./symfony test:unit strtolower|INFO]
 
-You can also launch unit tests for several names:
+      You can also launch unit tests for several names:
 
-  [./symfony test:unit strtolower strtoupper|INFO]
+        [./symfony test:unit strtolower strtoupper|INFO]
 
-The task can output a JUnit compatible XML log file with the [--xml|COMMENT]
-options:
+      The task can output a JUnit compatible XML log file with the [--xml|COMMENT]
+      options:
 
-  [./symfony test:unit --xml=log.xml|INFO]
-EOF;
+        [./symfony test:unit --xml=log.xml|INFO]
+      EOF;
   }
 
   /**
    * @see sfTask
    */
-  protected function execute($arguments = array(), $options = array())
+  protected function execute(array $arguments = [], array $options = []): int
   {
-    if (count($arguments['name']))
-    {
-      $files = array();
+    if (count($arguments['name'])) {
+      $files = [];
 
-      foreach ($arguments['name'] as $name)
-      {
-        $finder = sfFinder::type('file')->follow_link()->name(basename($name).'Test.php');
-        $files = array_merge($files, $finder->in(sfConfig::get('sf_test_dir').'/unit/'.dirname($name)));
+      foreach ($arguments['name'] as $name) {
+        $finder = sfFinder::type('file')->follow_link()->name(basename($name) . 'Test.php');
+        $files  = array_merge($files, $finder->in(sfConfig::get('sf_test_dir') . '/unit/' . dirname($name)));
       }
 
-      if(count($files) > 0)
-      {
-        foreach ($files as $file)
-        {
+      if (count($files) > 0) {
+        foreach ($files as $file) {
           include($file);
         }
-      }
-      else
-      {
+      } else {
         $this->logSection('test', 'no tests found', null, 'ERROR');
       }
-    }
-    else
-    {
-      require_once __DIR__.'/sfLimeHarness.class.php';
+    } else {
+      require_once __DIR__ . '/sfLimeHarness.class.php';
 
-      $h = new sfLimeHarness(array(
+      $h = new sfLimeHarness([
         'force_colors' => isset($options['color']) && $options['color'],
         'verbose'      => isset($options['trace']) && $options['trace'],
-        'test_path'    => sfConfig::get('sf_cache_dir') . '/lime'
-      ));
-      $h->addPlugins(array_map(array($this->configuration, 'getPluginConfiguration'), $this->configuration->getPlugins()));
-      $h->base_dir = sfConfig::get('sf_test_dir').'/unit';
+        'test_path'    => sfConfig::get('sf_cache_dir') . '/lime',
+      ]);
+      $h->addPlugins(array_map([$this->configuration, 'getPluginConfiguration'], $this->configuration->getPlugins()));
+      $h->base_dir = sfConfig::get('sf_test_dir') . '/unit';
 
       // filter and register unit tests
       $finder = sfFinder::type('file')->follow_link()->name('*Test.php');
@@ -107,12 +99,13 @@ EOF;
 
       $ret = $h->run() ? 0 : 1;
 
-      if ($options['xml'])
-      {
+      if ($options['xml']) {
         file_put_contents($options['xml'], $h->to_xml());
       }
 
       return $ret;
     }
+
+    return 0;
   }
 }

--- a/lib/user/sfUser.class.php
+++ b/lib/user/sfUser.class.php
@@ -206,17 +206,17 @@ class sfUser
     return $this->attributeHolder;
   }
 
-  public function getAttribute(string $name, $default = null, string $ns = null)
+  public function getAttribute(string $name, mixed $default = null, string | null  $ns = null)
   {
     return $this->attributeHolder->get($name, $default, $ns);
   }
 
-  public function hasAttribute(string $name, string $ns = null)
+  public function hasAttribute(string $name, string | null $ns = null)
   {
     return $this->attributeHolder->has($name, $ns);
   }
 
-  public function setAttribute(string $name, $value, string $ns = null)
+  public function setAttribute(string $name, mixed $value, string | null $ns = null)
   {
     $this->attributeHolder->set($name, $value, $ns);
   }

--- a/lib/util/sfNamespacedParameterHolder.class.php
+++ b/lib/util/sfNamespacedParameterHolder.class.php
@@ -88,19 +88,13 @@ class sfNamespacedParameterHolder extends sfParameterHolder
    *
    * @return mixed A parameter value, if the parameter exists, otherwise null
    */
-  public function & get(string $name, $default = null, string $ns = null)
+  public function & get(string $name, mixed $default = null, string | null $ns = null)
   {
-    if (!$ns)
-    {
-      $ns = $this->default_namespace;
-    }
+    $ns = $ns ?: $this->default_namespace;
 
-    if (isset($this->parameters[$ns][$name]))
-    {
-      $value = & $this->parameters[$ns][$name];
-    }
-    else
-    {
+    if (isset($this->parameters[$ns][$name])) {
+      $value = &$this->parameters[$ns][$name];
+    } else {
       $value = $default;
     }
 
@@ -114,19 +108,15 @@ class sfNamespacedParameterHolder extends sfParameterHolder
    *
    * @return array An indexed array of parameter names, if the namespace exists, otherwise null
    */
-  public function getNames(string $ns = null): array
+  public function getNames(string | null $ns = null): array
   {
-    if (!$ns)
-    {
-      $ns = $this->default_namespace;
-    }
+    $ns = $ns ?: $this->default_namespace;
 
-    if (isset($this->parameters[$ns]))
-    {
+    if (isset($this->parameters[$ns])) {
       return array_keys($this->parameters[$ns]);
     }
 
-    return array();
+    return [];
   }
 
   /**
@@ -151,17 +141,13 @@ class sfNamespacedParameterHolder extends sfParameterHolder
    *
    * @return array An associative array of parameters
    */
-  public function & getAll(string $ns = null): array
+  public function & getAll(string | null $ns = null): array
   {
-    if (!$ns)
-    {
-      $ns = $this->default_namespace;
-    }
+    $ns = $ns ?: $this->default_namespace;
 
     $parameters = [];
 
-    if (isset($this->parameters[$ns]))
-    {
+    if (isset($this->parameters[$ns])) {
       $parameters = $this->parameters[$ns];
     }
 
@@ -176,12 +162,9 @@ class sfNamespacedParameterHolder extends sfParameterHolder
    *
    * @return bool true, if the parameter exists, otherwise false
    */
-  public function has(string $name, string $ns = null): bool
+  public function has(string $name, string | null $ns = null): bool
   {
-    if (!$ns)
-    {
-      $ns = $this->default_namespace;
-    }
+    $ns = $ns ?: $this->default_namespace;
 
     return isset($this->parameters[$ns][$name]);
   }
@@ -207,17 +190,13 @@ class sfNamespacedParameterHolder extends sfParameterHolder
    *
    * @return mixed A parameter value, if the parameter was removed, otherwise default
    */
-  public function remove(string $name, $default = null, string $ns = null)
+  public function remove(string $name, mixed $default = null, string | null $ns = null)
   {
-    if (!$ns)
-    {
-      $ns = $this->default_namespace;
-    }
+    $ns = $ns ?: $this->default_namespace;
 
     $retval = $default;
 
-    if (isset($this->parameters[$ns]) && array_key_exists($name, $this->parameters[$ns]))
-    {
+    if (isset($this->parameters[$ns]) && array_key_exists($name, $this->parameters[$ns])) {
       $retval = $this->parameters[$ns][$name];
       unset($this->parameters[$ns][$name]);
     }
@@ -232,17 +211,13 @@ class sfNamespacedParameterHolder extends sfParameterHolder
    *
    * @return array|null
    */
-  public function & removeNamespace(string $ns = null): ?array
+  public function & removeNamespace(string | null $ns = null): ?array
   {
-    if (!$ns)
-    {
-      $ns = $this->default_namespace;
-    }
+    $ns = $ns ?: $this->default_namespace;
 
     $retval = null;
 
-    if (isset($this->parameters[$ns]))
-    {
+    if (isset($this->parameters[$ns])) {
       $retval =& $this->parameters[$ns];
       unset($this->parameters[$ns]);
     }
@@ -259,16 +234,12 @@ class sfNamespacedParameterHolder extends sfParameterHolder
    * @param mixed        $value A parameter value
    * @param string|null  $ns    A parameter namespace
    */
-  public function set(string $name, $value, string $ns = null): void
+  public function set(string $name, mixed $value, string | null $ns = null): void
   {
-    if (!$ns)
-    {
-      $ns = $this->default_namespace;
-    }
+    $ns = $ns ?: $this->default_namespace;
 
-    if (!isset($this->parameters[$ns]))
-    {
-      $this->parameters[$ns] = array();
+    if ( ! isset($this->parameters[$ns])) {
+      $this->parameters[$ns] = [];
     }
 
     $this->parameters[$ns][$name] = $value;
@@ -283,16 +254,12 @@ class sfNamespacedParameterHolder extends sfParameterHolder
    * @param mixed        $value A reference to a parameter value
    * @param string|null  $ns    A parameter namespace
    */
-  public function setByRef(string $name, & $value, string $ns = null): void
+  public function setByRef(string $name, mixed & $value, string | null $ns = null): void
   {
-    if (!$ns)
-    {
-      $ns = $this->default_namespace;
-    }
+    $ns = $ns ?: $this->default_namespace;
 
-    if (!isset($this->parameters[$ns]))
-    {
-      $this->parameters[$ns] = array();
+    if ( ! isset($this->parameters[$ns])) {
+      $this->parameters[$ns] = [];
     }
 
     $this->parameters[$ns][$name] =& $value;
@@ -307,20 +274,15 @@ class sfNamespacedParameterHolder extends sfParameterHolder
    * @param array        $parameters An associative array of parameters and their associated values
    * @param string|null  $ns         A parameter namespace
    */
-  public function add(array $parameters, string $ns = null): void
+  public function add(array $parameters, string | null $ns = null): void
   {
-    if (!$ns)
-    {
-      $ns = $this->default_namespace;
-    }
+    $ns = $ns ?: $this->default_namespace;
 
-    if (!isset($this->parameters[$ns]))
-    {
+    if ( ! isset($this->parameters[$ns])) {
       $this->parameters[$ns] = [];
     }
 
-    foreach ($parameters as $key => $value)
-    {
+    foreach ($parameters as $key => $value) {
       $this->parameters[$ns][$key] = $value;
     }
   }
@@ -334,20 +296,15 @@ class sfNamespacedParameterHolder extends sfParameterHolder
    * @param array        $parameters An associative array of parameters and references to their associated values
    * @param string|null  $ns         A parameter namespace
    */
-  public function addByRef(array & $parameters, string $ns = null): void
+  public function addByRef(array & $parameters, string | null $ns = null): void
   {
-    if (!$ns)
-    {
-      $ns = $this->default_namespace;
+    $ns = $ns ?: $this->default_namespace;
+
+    if ( ! isset($this->parameters[$ns])) {
+      $this->parameters[$ns] = [];
     }
 
-    if (!isset($this->parameters[$ns]))
-    {
-      $this->parameters[$ns] = array();
-    }
-
-    foreach ($parameters as $key => &$value)
-    {
+    foreach ($parameters as $key => &$value) {
       $this->parameters[$ns][$key] =& $value;
     }
   }

--- a/test/other/fixtures/task/myPluginTask.class.php
+++ b/test/other/fixtures/task/myPluginTask.class.php
@@ -1,12 +1,15 @@
 <?php
-class myPluginTask extends sfBaseTask 
+
+class myPluginTask extends sfBaseTask
 {
-  public function configure()
+  public function configure(): void
   {
     $this->namespace = 'p';
-    $this->name = 'run';
+    $this->name      = 'run';
   }
-  public function execute($arguments = array(), $options = array())
+
+  public function execute(array $arguments = [], array $options = []): int
   {
+    return 0;
   }
 }

--- a/test/unit/action/sfComponentTest.php
+++ b/test/unit/action/sfComponentTest.php
@@ -16,7 +16,9 @@ $t = new lime_test(4);
 
 class myComponent extends sfComponent
 {
-  function execute(sfRequest $request) {}
+  function execute(sfRequest $request): mixed {
+    return null;
+  }
 }
 
 $context = sfContextMock::mockInstance([

--- a/test/unit/command/sfCommandArgumentTest.php
+++ b/test/unit/command/sfCommandArgumentTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -35,7 +35,7 @@ try
   $argument = new sfCommandArgument('foo', 'ANOTHER_ONE');
   $t->fail('__construct() throws an sfCommandException if the mode is not valid');
 }
-catch (sfCommandException $e)
+catch (TypeError $e)
 {
   $t->pass('__construct() throws an sfCommandException if the mode is not valid');
 }

--- a/test/unit/command/sfCommandOptionTest.php
+++ b/test/unit/command/sfCommandOptionTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -56,7 +56,7 @@ try
   $option = new sfCommandOption('foo', 'f', 'ANOTHER_ONE');
   $t->fail('__construct() throws an sfCommandException if the mode is not valid');
 }
-catch (sfCommandException $e)
+catch (TypeError $e)
 {
   $t->pass('__construct() throws an sfCommandException if the mode is not valid');
 }

--- a/test/unit/helper/AssetHelperTest.php
+++ b/test/unit/helper/AssetHelperTest.php
@@ -18,19 +18,19 @@ $t = new lime_test(68);
 
 class myRequest extends sfRequest
 {
-  public $relativeUrlRoot = '';
+  public string $relativeUrlRoot = '';
 
-  public function getRelativeUrlRoot()
+  public function getRelativeUrlRoot(): string
   {
     return $this->relativeUrlRoot;
   }
 
-  public function isSecure()
+  public function isSecure(): bool
   {
     return false;
   }
 
-  public function getHost()
+  public function getHost(): string
   {
     return 'localhost';
   }
@@ -40,8 +40,8 @@ class myResponse extends sfWebResponse
 {
   public function resetAssets(): void
   {
-    $this->javascripts = array_combine($this->positions, array_fill(0, count($this->positions), array()));
-    $this->stylesheets = array_combine($this->positions, array_fill(0, count($this->positions), array()));
+    $this->javascripts = array_combine(self::POSITIONS, array_fill(0, count(self::POSITIONS), []));
+    $this->stylesheets = array_combine(self::POSITIONS, array_fill(0, count(self::POSITIONS), []));
   }
 }
 

--- a/test/unit/log/sfFileLoggerTest.php
+++ b/test/unit/log/sfFileLoggerTest.php
@@ -45,12 +45,12 @@ $t->like($lines[1], '/bar/', '->log() logs a message to the file');
 
 class TestLogger extends sfFileLogger
 {
-  public function getTimeFormat()
+  public function getTimeFormat(): string
   {
     return $this->timeFormat;
   }
 
-  protected function getPriority($priority)
+  protected function getPriority(int $priority): string
   {
     return '*'.$priority.'*';
   }

--- a/test/unit/sfContextMock.class.php
+++ b/test/unit/sfContextMock.class.php
@@ -11,7 +11,7 @@
 class sfContextMock extends sfContext
 {
   /** @var string */
-  private $sessionPath = '';
+  private string $sessionPath = '';
 
   static public function mockInstance(array $factories = [], bool $force = false): sfContextMock
   {
@@ -36,7 +36,7 @@ class sfContextMock extends sfContext
     sfToolkit::clearDirectory($this->sessionPath);
   }
 
-  static public function hasInstance(string $name = null): bool
+  static public function hasInstance(string | null $name = null): bool
   {
     return true;
   }

--- a/test/unit/storage/sfStorageTest.php
+++ b/test/unit/storage/sfStorageTest.php
@@ -14,10 +14,14 @@ $t = new lime_test(0);
 
 class myStorage extends sfStorage
 {
-  public function read(string $key) {}
-  public function remove(string $key) {}
+  public function read(string $key): mixed {
+    return null;
+  }
+  public function remove(string $key): mixed {
+    return null;
+  }
   public function shutdown(): void {}
-  public function write(string $key, $data): void {}
+  public function write(string $key, mixed $data): void {}
   public function regenerate(bool $destroy = false): void {}
 }
 

--- a/test/unit/task/sfBaseTaskTest.php
+++ b/test/unit/task/sfBaseTaskTest.php
@@ -13,8 +13,9 @@ require_once sfConfig::get('sf_symfony_lib_dir').'/vendor/lime/lime.php';
 
 class TestTask extends sfBaseTask
 {
-  protected function execute($arguments = array(), $options = array())
+  protected function execute(array $arguments = [], array $options = []): int
   {
+    return 0;
   }
 }
 
@@ -33,30 +34,31 @@ $t->diag('->run()');
 
 class ApplicationTask extends sfBaseTask
 {
-  protected function configure()
+  protected function configure(): void
   {
     $this->addOption('application', null, sfCommandOption::PARAMETER_REQUIRED, '', true);
   }
 
-  protected function execute($arguments = array(), $options = array())
+  protected function execute(array $arguments = [], array $options = []): int
   {
-    if (!$this->configuration instanceof sfApplicationConfiguration)
-    {
+    if ( ! $this->configuration instanceof sfApplicationConfiguration) {
       throw new Exception('This task requires an application configuration be loaded.');
     }
+
+    return 0;
   }
 
-  public function getServiceContainer()
+  public function getServiceContainer(): sfServiceContainer
   {
     return parent::getServiceContainer();
   }
 
-  public function getRouting()
+  public function getRouting(): sfRouting
   {
     return parent::getRouting();
   }
 
-  public function getMailer()
+  public function getMailer(): sfMailer
   {
     return parent::getMailer();
   }

--- a/test/unit/task/sfFilesystemTest.php
+++ b/test/unit/task/sfFilesystemTest.php
@@ -14,11 +14,11 @@ define("DS", DIRECTORY_SEPARATOR);
 
 class myFilesystem extends sfFilesystem
 {
-  public function calculateRelativeDir($from, $to)
+  public function calculateRelativeDir(string $from, string $to): string
   {
     return parent::calculateRelativeDir($from, $to);
   }
-  public function canonicalizePath($path)
+  public function canonicalizePath(string $path): string
   {
     return parent::canonicalizePath($path);
   }

--- a/test/unit/task/sfTaskTest.php
+++ b/test/unit/task/sfTaskTest.php
@@ -7,15 +7,14 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-require_once __DIR__.'/../../bootstrap/unit.php';
+require_once __DIR__ . '/../../bootstrap/unit.php';
 
 $t = new lime_test(16);
 
 abstract class BaseTestTask extends sfTask
 {
-  public
-    $lastArguments = array(),
-    $lastOptions   = array();
+  public array $lastArguments = [];
+  public array $lastOptions   = [];
 
   public function __construct()
   {
@@ -23,10 +22,12 @@ abstract class BaseTestTask extends sfTask
     parent::__construct(new sfEventDispatcher(), new sfFormatter());
   }
 
-  protected function execute($arguments = array(), $options = array())
+  protected function execute(array $arguments = [], array $options = []): int
   {
     $this->lastArguments = $arguments;
-    $this->lastOptions = $options;
+    $this->lastOptions   = $options;
+
+    return 0;
   }
 }
 
@@ -35,96 +36,116 @@ $t->diag('->run()');
 
 class ArgumentsTest1Task extends BaseTestTask
 {
-  protected function configure()
+  protected function configure(): void
   {
-    $this->addArguments(array(
+    $this->addArguments([
       new sfCommandArgument('foo', sfCommandArgument::REQUIRED),
       new sfCommandArgument('bar', sfCommandArgument::OPTIONAL),
-    ));
+    ]);
   }
 }
 
 $task = new ArgumentsTest1Task();
-$task->run(array('FOO'));
-$t->is_deeply($task->lastArguments, array('foo' => 'FOO', 'bar' => null), '->run() accepts an indexed array of arguments');
+$task->run(['FOO']);
+$t->is_deeply($task->lastArguments, ['foo' => 'FOO', 'bar' => null], '->run() accepts an indexed array of arguments');
 
-$task->run(array('foo' => 'FOO'));
-$t->is_deeply($task->lastArguments, array('foo' => 'FOO', 'bar' => null), '->run() accepts an associative array of arguments');
+$task->run(['foo' => 'FOO']);
+$t->is_deeply($task->lastArguments, ['foo' => 'FOO', 'bar' => null], '->run() accepts an associative array of arguments');
 
-$task->run(array('bar' => 'BAR', 'foo' => 'FOO'));
-$t->is_deeply($task->lastArguments, array('foo' => 'FOO', 'bar' => 'BAR'), '->run() accepts an unordered associative array of arguments');
+$task->run(['bar' => 'BAR', 'foo' => 'FOO']);
+$t->is_deeply($task->lastArguments, ['foo' => 'FOO', 'bar' => 'BAR'], '->run() accepts an unordered associative array of arguments');
 
 $task->run('FOO BAR');
-$t->is_deeply($task->lastArguments, array('foo' => 'FOO', 'bar' => 'BAR'), '->run() accepts a string of arguments');
+$t->is_deeply($task->lastArguments, ['foo' => 'FOO', 'bar' => 'BAR'], '->run() accepts a string of arguments');
 
-$task->run(array('foo' => 'FOO', 'bar' => null));
-$t->is_deeply($task->lastArguments, array('foo' => 'FOO', 'bar' => null), '->run() accepts an associative array of arguments when optional arguments are passed as null');
+$task->run(['foo' => 'FOO', 'bar' => null]);
+$t->is_deeply($task->lastArguments, ['foo' => 'FOO', 'bar' => null], '->run() accepts an associative array of arguments when optional arguments are passed as null');
 
-$task->run(array('bar' => null, 'foo' => 'FOO'));
-$t->is_deeply($task->lastArguments, array('foo' => 'FOO', 'bar' => null), '->run() accepts an unordered associative array of arguments when optional arguments are passed as null');
+$task->run(['bar' => null, 'foo' => 'FOO']);
+$t->is_deeply($task->lastArguments, ['foo' => 'FOO', 'bar' => null], '->run() accepts an unordered associative array of arguments when optional arguments are passed as null');
 
 class ArgumentsTest2Task extends BaseTestTask
 {
-  protected function configure()
+  protected function configure(): void
   {
-    $this->addArguments(array(
+    $this->addArguments([
       new sfCommandArgument('foo', sfCommandArgument::OPTIONAL | sfCommandArgument::IS_ARRAY),
-    ));
+    ]);
   }
 }
 
 $task = new ArgumentsTest2Task();
-$task->run(array('arg1', 'arg2', 'arg3'));
-$t->is_deeply($task->lastArguments, array('foo' => array('arg1', 'arg2', 'arg3')), '->run() accepts an indexed array of an IS_ARRAY argument');
+$task->run(['arg1', 'arg2', 'arg3']);
+$t->is_deeply($task->lastArguments, ['foo' => ['arg1', 'arg2', 'arg3']], '->run() accepts an indexed array of an IS_ARRAY argument');
 
-$task->run(array('foo' => array('arg1', 'arg2', 'arg3')));
-$t->is_deeply($task->lastArguments, array('foo' => array('arg1', 'arg2', 'arg3')), '->run() accepts an associative array of an IS_ARRAY argument');
+$task->run(['foo' => ['arg1', 'arg2', 'arg3']]);
+$t->is_deeply($task->lastArguments, ['foo' => ['arg1', 'arg2', 'arg3']], '->run() accepts an associative array of an IS_ARRAY argument');
 
 class OptionsTest1Task extends BaseTestTask
 {
-  protected function configure()
+  protected function configure(): void
   {
-    $this->addOptions(array(
+    $this->addOptions([
       new sfCommandOption('none', null, sfCommandOption::PARAMETER_NONE),
       new sfCommandOption('required', null, sfCommandOption::PARAMETER_REQUIRED),
       new sfCommandOption('optional', null, sfCommandOption::PARAMETER_OPTIONAL),
       new sfCommandOption('array', null, sfCommandOption::PARAMETER_REQUIRED | sfCommandOption::IS_ARRAY),
-    ));
+    ]);
   }
 }
 
 $task = new OptionsTest1Task();
 $task->run();
-$t->is_deeply($task->lastOptions, array('none' => false, 'required' => null, 'optional' => null, 'array' => array()), '->run() sets empty option values');
+$t->is_deeply($task->lastOptions, ['none' => false, 'required' => null, 'optional' => null, 'array' => []], '->run() sets empty option values');
 
-$task->run(array(), array('--none', '--required=TEST1', '--array=one', '--array=two', '--array=three'));
-$t->is_deeply($task->lastOptions, array('none' => true, 'required' => 'TEST1', 'optional' => null, 'array' => array('one', 'two', 'three')), '->run() accepts an indexed array of option values');
+$task->run([], ['--none', '--required=TEST1', '--array=one', '--array=two', '--array=three']);
+$t->is_deeply(
+  $task->lastOptions,
+  ['none' => true, 'required' => 'TEST1', 'optional' => null, 'array' => ['one', 'two', 'three']],
+  '->run() accepts an indexed array of option values'
+);
 
-$task->run(array(), array('none', 'required=TEST1', 'array=one', 'array=two', 'array=three'));
-$t->is_deeply($task->lastOptions, array('none' => true, 'required' => 'TEST1', 'optional' => null, 'array' => array('one', 'two', 'three')), '->run() accepts an indexed array of unflagged option values');
+$task->run([], ['none', 'required=TEST1', 'array=one', 'array=two', 'array=three']);
+$t->is_deeply(
+  $task->lastOptions,
+  ['none' => true, 'required' => 'TEST1', 'optional' => null, 'array' => ['one', 'two', 'three']],
+  '->run() accepts an indexed array of unflagged option values'
+);
 
-$task->run(array(), array('none' => false, 'required' => 'TEST1', 'array' => array('one', 'two', 'three')));
-$t->is_deeply($task->lastOptions, array('none' => false, 'required' => 'TEST1', 'optional' => null, 'array' => array('one', 'two', 'three')), '->run() accepts an associative array of option values');
+$task->run([], ['none' => false, 'required' => 'TEST1', 'array' => ['one', 'two', 'three']]);
+$t->is_deeply(
+  $task->lastOptions,
+  ['none' => false, 'required' => 'TEST1', 'optional' => null, 'array' => ['one', 'two', 'three']],
+  '->run() accepts an associative array of option values'
+);
 
-$task->run(array(), array('optional' => null, 'array' => array()));
-$t->is_deeply($task->lastOptions, array('none' => false, 'required' => null, 'optional' => null, 'array' => array()), '->run() accepts an associative array of options when optional values are passed as empty');
+$task->run([], ['optional' => null, 'array' => []]);
+$t->is_deeply(
+  $task->lastOptions,
+  ['none' => false, 'required' => null, 'optional' => null, 'array' => []],
+  '->run() accepts an associative array of options when optional values are passed as empty'
+);
 
 $task->run('--none --required=TEST1 --array=one --array=two --array=three');
-$t->is_deeply($task->lastOptions, array('none' => true, 'required' => 'TEST1', 'optional' => null, 'array' => array('one', 'two', 'three')), '->run() accepts a string of options');
+$t->is_deeply($task->lastOptions, ['none' => true, 'required' => 'TEST1', 'optional' => null, 'array' => ['one', 'two', 'three']], '->run() accepts a string of options');
 
-$task->run(array(), array('array' => 'one'));
-$t->is_deeply($task->lastOptions, array('none' => false, 'required' => null, 'optional' => null, 'array' => array('one')), '->run() accepts an associative array of options with a scalar array option value');
+$task->run([], ['array' => 'one']);
+$t->is_deeply(
+  $task->lastOptions,
+  ['none' => false, 'required' => null, 'optional' => null, 'array' => ['one']],
+  '->run() accepts an associative array of options with a scalar array option value'
+);
 
 // ->getDetailedDescription()
 $t->diag('->getDetailedDescription()');
 
 class DetailedDescriptionTestTask extends BaseTestTask
 {
-  protected function configure()
+  protected function configure(): void
   {
     $this->detailedDescription = <<<EOF
-The [detailedDescription|INFO] formats special string like [...|COMMENT] or [--xml|COMMENT]
-EOF;
+      The [detailedDescription|INFO] formats special string like [...|COMMENT] or [--xml|COMMENT]
+      EOF;
   }
 }
 


### PR DESCRIPTION
Add properties, arguments and return types to multiple classes:

- `sfFormater`, `sfAnsiColorFormatter`
- `sfCommandApplication`, `sfTask` and all its subclasses
- `sfLogger` and all its related classes
- `sfEventDispatcher` and `sfEvent`
- `sfComponent`, `sfAction`, `sfComponents`, `sfActions`
- `sfController`, `sfWebController`, `sfFrontWebController`
- `sfProjectConfiguration`, `sfApplicationConfiguration`
- `sfConfig`, `sfContext`
- `sfRequest`, `sfWebRequest`, `sfResponse`, `sfWebResponse`, `sfCookie`
- `sfStorage` and its subclasses