### PR TITLE
Refactor - Replace `sfFinder` with `symfony/finder`

### DIFF
--- a/test/bin/coverage.php
+++ b/test/bin/coverage.php
@@ -20,7 +20,6 @@ if (isset($argv[1]))
 }
 
 require_once(__DIR__.'/../../lib/vendor/lime/lime.php');
-require_once(__DIR__.'/../../lib/util/sfFinder.class.php');
 
 $h = new lime_harness();
 $h->base_dir = realpath(__DIR__.'/..');

--- a/test/bin/loc.php
+++ b/test/bin/loc.php
@@ -4,7 +4,6 @@ use RockSymphony\Util\Finder;
 
 $root_dir = realpath(__DIR__ . '/../..');
 require_once($root_dir.'/lib/vendor/lime/lime.php');
-require_once($root_dir.'/lib/util/sfFinder.class.php');
 
 require_once($root_dir.'/lib/SYMFONY_VERSION.php');
 $version = SYMFONY_VERSION;


### PR DESCRIPTION
- Drop `sfFinder` class
- Introduce `RockSymphony\Util\Finder` wrapper around the new `Symfony/Finder`  implementation