### PR TITLE
Cleanup - Drop mentions of `magic_quotes_runtime` ini setting

### DIFF
--- a/lib/command/sfCommandApplication.class.php
+++ b/lib/command/sfCommandApplication.class.php
@@ -572,7 +572,6 @@ abstract class sfCommandApplication
     set_time_limit(0);
     ini_set('track_errors', true);
     ini_set('html_errors', false);
-    ini_set('magic_quotes_runtime', false);
 
     if (false === strpos(PHP_SAPI, 'cgi')) {
       return;

--- a/lib/config/sfProjectConfiguration.class.php
+++ b/lib/config/sfProjectConfiguration.class.php
@@ -60,8 +60,6 @@ class sfProjectConfiguration
     $this->symfonyLibDir = realpath(__DIR__ . '/..');
     $this->dispatcher    = $dispatcher ?: new sfEventDispatcher();
 
-    ini_set('magic_quotes_runtime', 'off');
-
     sfConfig::set('sf_symfony_lib_dir', $this->symfonyLibDir);
 
     $this->setRootDir($this->rootDir);

--- a/test/bootstrap/functional.php
+++ b/test/bootstrap/functional.php
@@ -9,7 +9,6 @@
  */
 
 // setup expected test environment (per check_configuration.php)
-ini_set('magic_quotes_runtime', 'off');
 ini_set('session.auto_start', 'off');
 ini_set('arg_separator.output', '&amp;');
 ini_set('allow_url_fopen', 'on');

--- a/test/bootstrap/unit.php
+++ b/test/bootstrap/unit.php
@@ -9,7 +9,6 @@
  */
 
 // setup expected test environment (per check_configuration.php)
-ini_set('magic_quotes_runtime', 'off');
 ini_set('session.auto_start', 'off');
 ini_set('arg_separator.output', '&amp;');
 ini_set('allow_url_fopen', 'on');


### PR DESCRIPTION
It has been deprecated in PHP 7.4 & dropped as of PHP 8.0