### PR TITLE
Add PHP 8.4 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ '8.0', '8.1', '8.2' ]
+        php: [ '8.0', '8.1', '8.2', '8.3', '8.4' ]
 
     steps:
       - uses: actions/checkout@master

--- a/lib/action/sfAction.class.php
+++ b/lib/action/sfAction.class.php
@@ -70,7 +70,7 @@ abstract class sfAction extends sfComponent
    * @throws sfError404Exception
    *
    */
-  public function forward404(string $message = null): void
+  public function forward404(?string $message = null): void
   {
     throw new sfError404Exception($this->get404Message($message));
   }
@@ -83,7 +83,7 @@ abstract class sfAction extends sfComponent
    *
    * @throws sfError404Exception
    */
-  public function forward404Unless(bool $condition, string $message = null): void
+  public function forward404Unless(bool $condition, ?string $message = null): void
   {
     if (!$condition)
     {
@@ -99,7 +99,7 @@ abstract class sfAction extends sfComponent
    *
    * @throws sfError404Exception
    */
-  public function forward404If(bool $condition, string $message = null): void
+  public function forward404If(bool $condition, ?string $message = null): void
   {
     if ($condition)
     {
@@ -289,7 +289,7 @@ abstract class sfAction extends sfComponent
    *
    * @return string The partial content
    */
-  public function getPartial(string $templateName, array $vars = null): string
+  public function getPartial(string $templateName, ?array $vars = null): string
   {
     $this->getContext()->getConfiguration()->loadHelpers(['Partial']);
 
@@ -312,7 +312,7 @@ abstract class sfAction extends sfComponent
    *
    * @see    getPartial
    */
-  public function renderPartial(string $templateName, array $vars = null): string
+  public function renderPartial(string $templateName, ?array $vars = null): string
   {
     return $this->renderText($this->getPartial($templateName, $vars));
   }
@@ -332,7 +332,7 @@ abstract class sfAction extends sfComponent
    *
    * @return string  The component rendered content
    */
-  public function getComponent(string $moduleName, string $componentName, array $vars = null): string
+  public function getComponent(string $moduleName, string $componentName, ?array $vars = null): string
   {
     $this->getContext()->getConfiguration()->loadHelpers(['Partial']);
 
@@ -356,7 +356,7 @@ abstract class sfAction extends sfComponent
    *
    * @see    getComponent
    */
-  public function renderComponent(string $moduleName, string $componentName, array $vars = null): string
+  public function renderComponent(string $moduleName, string $componentName, ?array $vars = null): string
   {
     return $this->renderText($this->getComponent($moduleName, $componentName, $vars));
   }
@@ -434,7 +434,7 @@ abstract class sfAction extends sfComponent
    * @param string $name    Template name
    * @param string $module  The module (current if null)
    */
-  public function setTemplate(string $name, string $module = null): void
+  public function setTemplate(string $name, ?string $module = null): void
   {
     if (sfConfig::get('sf_logging_enabled'))
     {
@@ -524,7 +524,7 @@ abstract class sfAction extends sfComponent
    *
    * @return string The error message or a default one if null
    */
-  protected function get404Message(string $message = null): string
+  protected function get404Message(?string $message = null): string
   {
     return null === $message ? sprintf('This request has been forwarded to a 404 error page by the action "%s/%s".', $this->getModuleName(), $this->getActionName()) : $message;
   }

--- a/lib/cache/sfAPCuCache.class.php
+++ b/lib/cache/sfAPCuCache.class.php
@@ -88,7 +88,7 @@ class sfAPCuCache extends sfCache
    * @see sfCache
    * @inheritdoc
    */
-  public function set(string $key, string $data, int $lifetime = null): bool
+  public function set(string $key, string $data, ?int $lifetime = null): bool
   {
     if (!$this->enabled)
     {

--- a/lib/cache/sfCache.class.php
+++ b/lib/cache/sfCache.class.php
@@ -81,7 +81,7 @@ abstract class sfCache
    *
    * @return Boolean true if no problem
    */
-  abstract public function set(string $key, string $data, int $lifetime = null): bool;
+  abstract public function set(string $key, string $data, ?int $lifetime = null): bool;
 
   /**
    * Removes a content from the cache.

--- a/lib/cache/sfFileCache.class.php
+++ b/lib/cache/sfFileCache.class.php
@@ -83,7 +83,7 @@ class sfFileCache extends sfCache
    * @see sfCache
    * @inheritdoc
    */
-  public function set(string $key, string $data, int $lifetime = null): bool
+  public function set(string $key, string $data, ?int $lifetime = null): bool
   {
     if ($this->getOption('automatic_cleaning_factor') > 0 && mt_rand(1, $this->getOption('automatic_cleaning_factor')) == 1)
     {

--- a/lib/cache/sfMemcacheCache.class.php
+++ b/lib/cache/sfMemcacheCache.class.php
@@ -117,7 +117,7 @@ class sfMemcacheCache extends sfCache
    * @see sfCache
    * @inheritdoc
    */
-  public function set(string $key, string $data, int $lifetime = null): bool
+  public function set(string $key, string $data, ?int $lifetime = null): bool
   {
     $lifetime = null === $lifetime ? $this->getOption('lifetime') : $lifetime;
 

--- a/lib/cache/sfNoCache.class.php
+++ b/lib/cache/sfNoCache.class.php
@@ -40,7 +40,7 @@ class sfNoCache extends sfCache
    * @see sfCache
    * @inheritdoc
    */
-  public function set(string $key, string $data, int $lifetime = null): bool
+  public function set(string $key, string $data, ?int $lifetime = null): bool
   {
     return true;
   }

--- a/lib/cache/sfSQLiteCache.class.php
+++ b/lib/cache/sfSQLiteCache.class.php
@@ -100,7 +100,7 @@ class sfSQLiteCache extends sfCache
    * @see sfCache
    * @inheritdoc
    */
-  public function set(string $key, string $data, int $lifetime = null): bool
+  public function set(string $key, string $data, ?int $lifetime = null): bool
   {
     if ($this->getOption('automatic_cleaning_factor') > 0 && mt_rand(1, $this->getOption('automatic_cleaning_factor')) == 1)
     {

--- a/lib/cache/sfXCacheCache.class.php
+++ b/lib/cache/sfXCacheCache.class.php
@@ -71,7 +71,7 @@ class sfXCacheCache extends sfCache
    * @see sfCache
    * @inheritdoc
    */
-  public function set(string $key, string $data, int $lifetime = null): bool
+  public function set(string $key, string $data, ?int $lifetime = null): bool
   {
     $lifetime = $this->getLifetime($lifetime);
 

--- a/lib/command/sfCommandApplication.class.php
+++ b/lib/command/sfCommandApplication.class.php
@@ -51,7 +51,7 @@ abstract class sfCommandApplication
    * @param sfFormatter       $formatter    A sfFormatter instance
    * @param array             $options      An array of options
    */
-  public function __construct(sfEventDispatcher $dispatcher, sfFormatter $formatter = null, $options = array())
+  public function __construct(sfEventDispatcher $dispatcher, ?sfFormatter $formatter = null, $options = array())
   {
     $this->dispatcher = $dispatcher;
     $this->formatter = null === $formatter ? $this->guessBestFormatter(STDOUT) : $formatter;

--- a/lib/command/sfCommandManager.class.php
+++ b/lib/command/sfCommandManager.class.php
@@ -39,7 +39,7 @@ class sfCommandManager
    * @param sfCommandArgumentSet $argumentSet A sfCommandArgumentSet object
    * @param sfCommandOptionSet   $optionSet   A setOptionSet object
    */
-  public function __construct(sfCommandArgumentSet $argumentSet = null, sfCommandOptionSet $optionSet = null)
+  public function __construct(?sfCommandArgumentSet $argumentSet = null, ?sfCommandOptionSet $optionSet = null)
   {
     if (null === $argumentSet)
     {

--- a/lib/config/sfApplicationConfiguration.class.php
+++ b/lib/config/sfApplicationConfiguration.class.php
@@ -44,7 +44,7 @@ abstract class sfApplicationConfiguration extends ProjectConfiguration
    * @param string            $rootDir        The project root directory
    * @param sfEventDispatcher $dispatcher     An event dispatcher
    */
-  public function __construct(string $environment, bool $debug, string $rootDir = null, sfEventDispatcher $dispatcher = null)
+  public function __construct(string $environment, bool $debug, ?string $rootDir = null, ?sfEventDispatcher $dispatcher = null)
   {
     $this->environment = $environment;
     $this->debug       = $debug;
@@ -390,7 +390,7 @@ abstract class sfApplicationConfiguration extends ProjectConfiguration
    *
    * @return string[]  An array of directories
    */
-  public function getHelperDirs(string $moduleName = null): array
+  public function getHelperDirs(?string $moduleName = null): array
   {
     $dirs = array();
 

--- a/lib/config/sfProjectConfiguration.class.php
+++ b/lib/config/sfProjectConfiguration.class.php
@@ -44,7 +44,7 @@ class sfProjectConfiguration
    * @param string              $rootDir    The project root directory
    * @param sfEventDispatcher   $dispatcher The event dispatcher
    */
-  public function __construct(string $rootDir = null, sfEventDispatcher $dispatcher = null)
+  public function __construct(?string $rootDir = null, ?sfEventDispatcher $dispatcher = null)
   {
     if (null === self::$active || $this instanceof sfApplicationConfiguration)
     {
@@ -582,7 +582,7 @@ class sfProjectConfiguration
    *
    * @return sfApplicationConfiguration A sfApplicationConfiguration instance
    */
-  static public function getApplicationConfiguration(string $application, string $environment, bool $debug, string $rootDir = null, sfEventDispatcher $dispatcher = null): sfApplicationConfiguration
+  static public function getApplicationConfiguration(string $application, string $environment, bool $debug, ?string $rootDir = null, ?sfEventDispatcher $dispatcher = null): sfApplicationConfiguration
   {
     $class = $application.'Configuration';
 

--- a/lib/controller/sfController.class.php
+++ b/lib/controller/sfController.class.php
@@ -381,7 +381,7 @@ abstract class sfController
    * @throws Exception
    * @throws sfException
    */
-  public function getPresentationFor(string $module, string $action, string $viewName = null): string
+  public function getPresentationFor(string $module, string $action, ?string $viewName = null): string
   {
     if (sfConfig::get('sf_logging_enabled'))
     {

--- a/lib/debug/sfDebug.class.php
+++ b/lib/debug/sfDebug.class.php
@@ -107,7 +107,7 @@ class sfDebug
    *
    * @return array The request parameter holders
    */
-  public static function requestAsArray(sfRequest $request = null): array
+  public static function requestAsArray(?sfRequest $request = null): array
   {
     if (!$request)
     {
@@ -128,7 +128,7 @@ class sfDebug
    *
    * @return array The response parameters
    */
-  public static function responseAsArray(sfResponse $response = null): array
+  public static function responseAsArray(?sfResponse $response = null): array
   {
     if (!$response)
     {
@@ -165,7 +165,7 @@ class sfDebug
    *
    * @return array The user parameters
    */
-  public static function userAsArray(sfUser $user = null): array
+  public static function userAsArray(?sfUser $user = null): array
   {
     if (!$user)
     {

--- a/lib/debug/sfWebDebugPanel.class.php
+++ b/lib/debug/sfWebDebugPanel.class.php
@@ -153,7 +153,7 @@ abstract class sfWebDebugPanel
    *
    * @return string
    */
-  public function formatFileLink(string $file, int $line = null, string $text = null): string
+  public function formatFileLink(string $file, ?int $line = null, ?string $text = null): string
   {
     // this method is called a lot so we avoid calling class_exists()
     if ($file && !sfToolkit::isPathAbsolute($file))

--- a/lib/debug/sfWebDebugPanelView.class.php
+++ b/lib/debug/sfWebDebugPanelView.class.php
@@ -292,7 +292,7 @@ class sfWebDebugPanelView extends sfWebDebugPanel
    *
    * @return string
    */
-  protected function getParameterDescription(string $name, $parameter, string $nameFormat = null, string $typeFormat = null)
+  protected function getParameterDescription(string $name, $parameter, ?string $nameFormat = null, ?string $typeFormat = null)
   {
     if (null === $nameFormat)
     {

--- a/lib/form/sfForm.class.php
+++ b/lib/form/sfForm.class.php
@@ -205,7 +205,7 @@ class sfForm implements ArrayAccess, IteratorAggregate, Countable
    * @param array $taintedValues  An array of input values
    * @param array $taintedFiles   An array of uploaded files (in the $_FILES or $_GET format)
    */
-  public function bind(array $taintedValues = null, array $taintedFiles = null)
+  public function bind(?array $taintedValues = null, ?array $taintedFiles = null)
   {
     $this->taintedValues = $taintedValues;
     $this->taintedFiles  = $taintedFiles;
@@ -265,7 +265,7 @@ class sfForm implements ArrayAccess, IteratorAggregate, Countable
    * @param array $taintedValues
    * @param array $taintedFiles
    */
-  public function bindEmbeddedForms(array $taintedValues = null, array $taintedFiles = null)
+  public function bindEmbeddedForms(?array $taintedValues = null, ?array $taintedFiles = null)
   {
     foreach ($this->embeddedForms as $name => $form)
     {
@@ -546,7 +546,7 @@ class sfForm implements ArrayAccess, IteratorAggregate, Countable
    *
    * @param sfValidatorBase $validator A validator to be merged
    */
-  public function mergePreValidator(sfValidatorBase $validator = null)
+  public function mergePreValidator(?sfValidatorBase $validator = null)
   {
     if (null === $validator)
     {
@@ -571,7 +571,7 @@ class sfForm implements ArrayAccess, IteratorAggregate, Countable
    *
    * @param sfValidatorBase $validator A validator to be merged
    */
-  public function mergePostValidator(sfValidatorBase $validator = null)
+  public function mergePostValidator(?sfValidatorBase $validator = null)
   {
     if (null === $validator)
     {

--- a/lib/form/sfFormField.class.php
+++ b/lib/form/sfFormField.class.php
@@ -41,7 +41,7 @@ class sfFormField
    * @param string           $value  The field value
    * @param sfValidatorError $error  A sfValidatorError instance
    */
-  public function __construct(sfWidgetForm $widget, sfFormField $parent = null, $name, $value, sfValidatorError $error = null)
+  public function __construct(sfWidgetForm $widget, ?sfFormField $parent = null, $name, $value, ?sfValidatorError $error = null)
   {
     $this->widget = $widget;
     $this->parent = $parent;

--- a/lib/form/sfFormFieldSchema.class.php
+++ b/lib/form/sfFormFieldSchema.class.php
@@ -32,7 +32,7 @@ class sfFormFieldSchema extends sfFormField implements ArrayAccess, IteratorAggr
    * @param string             $value  The field value
    * @param sfValidatorError   $error  A sfValidatorError instance
    */
-  public function __construct(sfWidgetFormSchema $widget, sfFormField $parent = null, $name, $value, sfValidatorError $error = null)
+  public function __construct(sfWidgetFormSchema $widget, ?sfFormField $parent = null, $name, $value, ?sfValidatorError $error = null)
   {
     parent::__construct($widget, $parent, $name, $value, $error);
 

--- a/lib/i18n/sfI18N.class.php
+++ b/lib/i18n/sfI18N.class.php
@@ -49,7 +49,7 @@ class sfI18N
    * @param sfCache                    $cache           A sfCache instance
    * @param array                      $options         An array of options
    */
-  public function __construct(sfApplicationConfiguration $configuration, sfCache $cache = null, array $options = [])
+  public function __construct(sfApplicationConfiguration $configuration, ?sfCache $cache = null, array $options = [])
   {
     $this->configuration = $configuration;
     $this->dispatcher = $configuration->getEventDispatcher();
@@ -103,7 +103,7 @@ class sfI18N
    * @param null  $dirs    An array of i18n directories if message source is a sfMessageSource_File subclass, null otherwise
    * @param string $culture The culture
    */
-  public function setMessageSource($dirs, string $culture = null): void
+  public function setMessageSource($dirs, ?string $culture = null): void
   {
     if (null === $dirs)
     {
@@ -234,7 +234,7 @@ class sfI18N
    *
    * @return string The country name
    */
-  public function getCountry(string $iso, string $culture = null): string
+  public function getCountry(string $iso, ?string $culture = null): string
   {
     $c = sfCultureInfo::getInstance(null === $culture ? $this->culture : $culture);
     $countries = $c->getCountries();
@@ -262,7 +262,7 @@ class sfI18N
    *
    * @return int|null The timestamp
    */
-  public function getTimestampForCulture(string $dateTime, string $culture = null): ?int
+  public function getTimestampForCulture(string $dateTime, ?string $culture = null): ?int
   {
     [$day, $month, $year] = $this->getDateForCulture($dateTime, null === $culture ? $this->culture : $culture);
     [$hour, $minute] = $this->getTimeForCulture($dateTime, null === $culture ? $this->culture : $culture);
@@ -278,7 +278,7 @@ class sfI18N
    *
    * @return array|null   An array with the day, month and year
    */
-  public function getDateForCulture(?string $date, string $culture = null): ?array
+  public function getDateForCulture(?string $date, ?string $culture = null): ?array
   {
     if (!$date)
     {
@@ -322,7 +322,7 @@ class sfI18N
    *
    * @return array|null   An array with the hour and minute
    */
-  public function getTimeForCulture(?string $time, string $culture = null): ?array
+  public function getTimeForCulture(?string $time, ?string $culture = null): ?array
   {
     if (!$time) return null;
 

--- a/lib/request/sfRequest.class.php
+++ b/lib/request/sfRequest.class.php
@@ -175,7 +175,7 @@ abstract class sfRequest
    *
    * @return mixed An attribute value
    */
-  public function getAttribute(string $name, string $default = null)
+  public function getAttribute(string $name, ?string $default = null)
   {
     return $this->attributeHolder->get($name, $default);
   }

--- a/lib/request/sfWebRequest.class.php
+++ b/lib/request/sfWebRequest.class.php
@@ -450,7 +450,7 @@ class sfWebRequest extends sfRequest
    *
    * @return string|null The preferred culture
    */
-  public function getPreferredCulture(array $cultures = null): ?string
+  public function getPreferredCulture(?array $cultures = null): ?string
   {
     $preferredCultures = $this->getLanguages();
 
@@ -828,7 +828,7 @@ class sfWebRequest extends sfRequest
    *
    * @return array  An associative array of files
    */
-  public function getFiles(string $key = null): array
+  public function getFiles(?string $key = null): array
   {
     if (null === $this->fixedFileArray)
     {

--- a/lib/response/sfWebResponse.class.php
+++ b/lib/response/sfWebResponse.class.php
@@ -199,7 +199,7 @@ class sfWebResponse extends sfResponse
    * @param string $name  HTTP status text
    *
    */
-  public function setStatusCode(string $code, string $name = null): void
+  public function setStatusCode(string $code, ?string $name = null): void
   {
     $this->statusCode = $code;
     $this->statusText = null !== $name ? $name : self::$statusTexts[$code];
@@ -271,7 +271,7 @@ class sfWebResponse extends sfResponse
    *
    * @return string|null
    */
-  public function getHttpHeader(string $name, string $default = null): ?string
+  public function getHttpHeader(string $name, ?string $default = null): ?string
   {
     $name = $this->normalizeHeaderName($name);
 
@@ -477,7 +477,7 @@ class sfWebResponse extends sfResponse
    * @param string $name   HTTP header
    * @param string $value  Value for the http header
    */
-  public function addCacheControlHttpHeader(string $name, string $value = null): void
+  public function addCacheControlHttpHeader(string $name, ?string $value = null): void
   {
     $cacheControl = $this->getHttpHeader('Cache-Control');
     $currentHeaders = array();

--- a/lib/routing/sfPatternRouting.class.php
+++ b/lib/routing/sfPatternRouting.class.php
@@ -46,7 +46,7 @@ class sfPatternRouting extends sfRouting
    * @see sfRouting
    * @inheritdoc
    */
-  public function __construct(sfEventDispatcher $dispatcher, sfCache $cache = null, array $options = [])
+  public function __construct(sfEventDispatcher $dispatcher, ?sfCache $cache = null, array $options = [])
   {
     $options = array_merge(array(
       'variable_prefixes'                => array(':'),

--- a/lib/routing/sfRouting.class.php
+++ b/lib/routing/sfRouting.class.php
@@ -40,7 +40,7 @@ abstract class sfRouting
    * @param sfCache           $cache       An sfCache instance
    * @param array             $options     An associative array of initialization options.
    */
-  public function __construct(sfEventDispatcher $dispatcher, sfCache $cache = null, array $options = [])
+  public function __construct(sfEventDispatcher $dispatcher, ?sfCache $cache = null, array $options = [])
   {
     $this->dispatcher = $dispatcher;
 

--- a/lib/service/sfServiceContainerLoader.class.php
+++ b/lib/service/sfServiceContainerLoader.class.php
@@ -25,7 +25,7 @@ abstract class sfServiceContainerLoader implements sfServiceContainerLoaderInter
    *
    * @param sfServiceContainerBuilder $container A sfServiceContainerBuilder instance
    */
-  public function __construct(sfServiceContainerBuilder $container = null)
+  public function __construct(?sfServiceContainerBuilder $container = null)
   {
     $this->container = $container;
   }

--- a/lib/storage/sfDatabaseSessionStorage.class.php
+++ b/lib/storage/sfDatabaseSessionStorage.class.php
@@ -99,7 +99,7 @@ abstract class sfDatabaseSessionStorage extends sfSessionStorage
    *
    * @throws <b>DatabaseException</b> If a connection with the database does not exist or cannot be created
    */
-  public function sessionOpen(string $path = null, string $name = null): bool
+  public function sessionOpen(?string $path = null, ?string $name = null): bool
   {
     // what database are we using?
     /** @var sfDatabase $database */

--- a/lib/task/generator/skeleton/project/composer.json
+++ b/lib/task/generator/skeleton/project/composer.json
@@ -3,7 +3,7 @@
   "description": "Project based on Rock-Symfony framework (symfony1 fork)",
   "license": "MIT",
   "require": {
-    "php": ">=7.4,<7.5",
+    "php": "^8.0",
     "rock-symphony/rock-symphony": "dev-3.x"
   },
   "type": "project"

--- a/lib/task/sfBaseTask.class.php
+++ b/lib/task/sfBaseTask.class.php
@@ -81,7 +81,7 @@ abstract class sfBaseTask extends sfCommandApplicationTask
    *
    * @param sfProjectConfiguration $configuration
    */
-  public function setConfiguration(sfProjectConfiguration $configuration = null)
+  public function setConfiguration(?sfProjectConfiguration $configuration = null)
   {
     $this->configuration = $configuration;
   }

--- a/lib/task/sfCommandApplicationTask.class.php
+++ b/lib/task/sfCommandApplicationTask.class.php
@@ -37,7 +37,7 @@ abstract class sfCommandApplicationTask extends sfTask
    *
    * @param sfCommandApplication $commandApplication A sfCommandApplication instance
    */
-  public function setCommandApplication(sfCommandApplication $commandApplication = null)
+  public function setCommandApplication(?sfCommandApplication $commandApplication = null)
   {
     $this->commandApplication = $commandApplication;
   }

--- a/lib/task/sfFilesystem.class.php
+++ b/lib/task/sfFilesystem.class.php
@@ -29,7 +29,7 @@ class sfFilesystem
    * @param sfEventDispatcher $dispatcher  An sfEventDispatcher instance
    * @param sfFormatter       $formatter   An sfFormatter instance
    */
-  public function __construct(sfEventDispatcher $dispatcher = null, sfFormatter $formatter = null)
+  public function __construct(?sfEventDispatcher $dispatcher = null, ?sfFormatter $formatter = null)
   {
     $this->dispatcher = $dispatcher;
     $this->formatter = $formatter;

--- a/lib/test/sfTestBrowser.class.php
+++ b/lib/test/sfTestBrowser.class.php
@@ -30,7 +30,7 @@ class sfTestBrowser extends sfTestFunctional
    * @param  string|null  $remote    Remote address to spook
    * @param  array        $options   Options for sfBrowser
    */
-  public function __construct(string $hostname = null, string $remote = null, array $options = [])
+  public function __construct(?string $hostname = null, ?string $remote = null, array $options = [])
   {
     $browser = new sfBrowser($hostname, $remote, $options);
 

--- a/lib/test/sfTestFunctional.class.php
+++ b/lib/test/sfTestFunctional.class.php
@@ -25,7 +25,7 @@ class sfTestFunctional extends sfTestFunctionalBase
    * @param  \lime_test|null                $lime     A lime instance
    * @param  array<string,string|sfTester>  $testers  Testers to use
    */
-  public function __construct(sfBrowser $browser, lime_test $lime = null, array $testers = [])
+  public function __construct(sfBrowser $browser, ?lime_test $lime = null, array $testers = [])
   {
     $testers = array_merge([
       'form' => sfTesterForm::class,

--- a/lib/test/sfTestFunctionalBase.class.php
+++ b/lib/test/sfTestFunctionalBase.class.php
@@ -35,7 +35,7 @@ abstract class sfTestFunctionalBase
    * @param  lime_test|null                 $lime     A lime instance
    * @param  array<string,string|sfTester>  $testers  Testers to use
    */
-  public function __construct(sfBrowser $browser, lime_test $lime = null, array $testers = [])
+  public function __construct(sfBrowser $browser, ?lime_test $lime = null, array $testers = [])
   {
     $this->browser = $browser;
 
@@ -328,7 +328,7 @@ abstract class sfTestFunctionalBase
    *
    * @return $this The current sfTestFunctionalBase instance
    */
-  public function throwsException(string $class = null, string $message = null): self
+  public function throwsException(?string $class = null, ?string $message = null): self
   {
     $e = $this->browser->getCurrentException();
 

--- a/lib/test/sfTesterMailer.class.php
+++ b/lib/test/sfTesterMailer.class.php
@@ -44,7 +44,7 @@ class sfTesterMailer extends sfTester
    *
    * @return $this
    */
-  public function hasSent(int $nb = null): self
+  public function hasSent(?int $nb = null): self
   {
     if (null === $nb)
     {

--- a/lib/test/sfTesterResponse.class.php
+++ b/lib/test/sfTesterResponse.class.php
@@ -335,7 +335,7 @@ class sfTesterResponse extends sfTester
    *
    * @return $this
    */
-  public function setsCookie(string $name, string $value = null, array $attributes = []): self
+  public function setsCookie(string $name, ?string $value = null, array $attributes = []): self
   {
     foreach ($this->response->getCookies() as $cookie)
     {

--- a/lib/test/sfTesterUser.class.php
+++ b/lib/test/sfTesterUser.class.php
@@ -37,7 +37,7 @@ class sfTesterUser extends sfTester
    *
    * @return $this
    */
-  public function isAttribute(string $key, string $value, string $ns = null): self
+  public function isAttribute(string $key, string $value, ?string $ns = null): self
   {
     $this->tester->is($this->user->getAttribute($key, null, $ns), $value, sprintf('user attribute "%s" is "%s"', $key, $value));
 

--- a/lib/user/sfUser.class.php
+++ b/lib/user/sfUser.class.php
@@ -206,17 +206,17 @@ class sfUser
     return $this->attributeHolder;
   }
 
-  public function getAttribute(string $name, $default = null, string $ns = null)
+  public function getAttribute(string $name, $default = null, ?string $ns = null)
   {
     return $this->attributeHolder->get($name, $default, $ns);
   }
 
-  public function hasAttribute(string $name, string $ns = null)
+  public function hasAttribute(string $name, ?string $ns = null)
   {
     return $this->attributeHolder->has($name, $ns);
   }
 
-  public function setAttribute(string $name, $value, string $ns = null)
+  public function setAttribute(string $name, $value, ?string $ns = null)
   {
     $this->attributeHolder->set($name, $value, $ns);
   }

--- a/lib/util/sfContext.class.php
+++ b/lib/util/sfContext.class.php
@@ -45,7 +45,7 @@ class sfContext
    *
    * @throws sfFactoryException
    */
-  static public function createInstance(sfApplicationConfiguration $configuration, string $name = null, string $class = self::class): sfContext
+  static public function createInstance(sfApplicationConfiguration $configuration, ?string $name = null, string $class = self::class): sfContext
   {
     if (null === $name)
     {
@@ -104,7 +104,7 @@ class sfContext
    *
    * @throws sfException
    */
-  static public function getInstance(string $name = null): sfContext
+  static public function getInstance(?string $name = null): sfContext
   {
     if (null === $name)
     {
@@ -127,7 +127,7 @@ class sfContext
    * @return bool true is instanced, otherwise false
    */
 
-  public static function hasInstance(string $name = null): bool
+  public static function hasInstance(?string $name = null): bool
   {
     if (null === $name)
     {

--- a/lib/util/sfNamespacedParameterHolder.class.php
+++ b/lib/util/sfNamespacedParameterHolder.class.php
@@ -114,7 +114,7 @@ class sfNamespacedParameterHolder extends sfParameterHolder
    *
    * @return array An indexed array of parameter names, if the namespace exists, otherwise null
    */
-  public function getNames(string $ns = null): array
+  public function getNames(?string $ns = null): array
   {
     if (!$ns)
     {
@@ -176,7 +176,7 @@ class sfNamespacedParameterHolder extends sfParameterHolder
    *
    * @return bool true, if the parameter exists, otherwise false
    */
-  public function has(string $name, string $ns = null): bool
+  public function has(string $name, ?string $ns = null): bool
   {
     if (!$ns)
     {
@@ -207,7 +207,7 @@ class sfNamespacedParameterHolder extends sfParameterHolder
    *
    * @return mixed A parameter value, if the parameter was removed, otherwise default
    */
-  public function remove(string $name, $default = null, string $ns = null)
+  public function remove(string $name, $default = null, ?string $ns = null)
   {
     if (!$ns)
     {
@@ -259,7 +259,7 @@ class sfNamespacedParameterHolder extends sfParameterHolder
    * @param mixed        $value A parameter value
    * @param string|null  $ns    A parameter namespace
    */
-  public function set(string $name, $value, string $ns = null): void
+  public function set(string $name, $value, ?string $ns = null): void
   {
     if (!$ns)
     {
@@ -283,7 +283,7 @@ class sfNamespacedParameterHolder extends sfParameterHolder
    * @param mixed        $value A reference to a parameter value
    * @param string|null  $ns    A parameter namespace
    */
-  public function setByRef(string $name, & $value, string $ns = null): void
+  public function setByRef(string $name, & $value, ?string $ns = null): void
   {
     if (!$ns)
     {
@@ -307,7 +307,7 @@ class sfNamespacedParameterHolder extends sfParameterHolder
    * @param array        $parameters An associative array of parameters and their associated values
    * @param string|null  $ns         A parameter namespace
    */
-  public function add(array $parameters, string $ns = null): void
+  public function add(array $parameters, ?string $ns = null): void
   {
     if (!$ns)
     {
@@ -334,7 +334,7 @@ class sfNamespacedParameterHolder extends sfParameterHolder
    * @param array        $parameters An associative array of parameters and references to their associated values
    * @param string|null  $ns         A parameter namespace
    */
-  public function addByRef(array & $parameters, string $ns = null): void
+  public function addByRef(array & $parameters, ?string $ns = null): void
   {
     if (!$ns)
     {

--- a/lib/validator/sfValidatorErrorSchema.class.php
+++ b/lib/validator/sfValidatorErrorSchema.class.php
@@ -61,7 +61,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
    *
    * @return $this The current error schema instance
    */
-  public function addError(sfValidatorError $error, string $name = null)
+  public function addError(sfValidatorError $error, ?string $name = null)
   {
     if (null === $name)
     {

--- a/lib/widget/sfWidgetForm.class.php
+++ b/lib/widget/sfWidgetForm.class.php
@@ -282,7 +282,7 @@ abstract class sfWidgetForm extends sfWidget
    *
    * @return sfWidgetForm The current widget instance
    */
-  public function setParent(sfWidgetFormSchema $widgetSchema = null)
+  public function setParent(?sfWidgetFormSchema $widgetSchema = null)
   {
     $this->parent = $widgetSchema;
 

--- a/lib/widget/sfWidgetFormSchemaDecorator.class.php
+++ b/lib/widget/sfWidgetFormSchemaDecorator.class.php
@@ -297,7 +297,7 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
    * @see sfWidgetFormSchema
    * @inheritdoc
    */
-  public function setParent(sfWidgetFormSchema $parent = null)
+  public function setParent(?sfWidgetFormSchema $parent = null)
   {
     $this->widget->setParent($parent);
 

--- a/test/unit/routing/sfPatternRoutingTest.php
+++ b/test/unit/routing/sfPatternRoutingTest.php
@@ -14,7 +14,7 @@ $t = new lime_test(149);
 
 class sfPatternRoutingTest extends sfPatternRouting
 {
-  public function __construct(sfEventDispatcher $dispatcher, sfCache $cache = null, array $options = [])
+  public function __construct(sfEventDispatcher $dispatcher, ?sfCache $cache = null, array $options = [])
   {
     parent::__construct($dispatcher, $cache, $options);
 

--- a/test/unit/sfContextMock.class.php
+++ b/test/unit/sfContextMock.class.php
@@ -36,7 +36,7 @@ class sfContextMock extends sfContext
     sfToolkit::clearDirectory($this->sessionPath);
   }
 
-  static public function hasInstance(string $name = null): bool
+  static public function hasInstance(?string $name = null): bool
   {
     return true;
   }


### PR DESCRIPTION
## Summary
- add PHP 8.3 and 8.4 to the GitHub Actions test matrix
- update project skeleton `composer.json` to require PHP `^8.0`
- replace implicit nullable parameter declarations (e.g. `string $x = null`) with explicit nullable types (`?string $x = null`) to satisfy PHP 8.4 deprecation rules
- keep behavior unchanged across framework, task, and test helper APIs

## Validation
- `php data/bin/check_configuration.php`
- `php data/bin/symfony symfony:test --trace`